### PR TITLE
feat: Discord-Claude Bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Discord bot token from https://discord.com/developers/applications
+DISCORD_BOT_TOKEN=your-bot-token-here
+
+# Claude model (sonnet, opus, haiku, or full model id). Optional, defaults to sonnet.
+CLAUDE_MODEL=sonnet
+
+# Claude permission mode (default, acceptEdits, plan, bypassPermissions). Defaults to bypassPermissions.
+CLAUDE_PERMISSION_MODE=bypassPermissions

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,29 @@
 .crew/
+
+# Environment
+.env
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+*.egg
+build/
+dist/
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Persistent data
+data/
+
+# IDE
+.idea/
+.vscode/
+
+# OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -2,25 +2,55 @@
 
 Expose [Claude Code](https://docs.anthropic.com/claude/docs/claude-code) through
 a Discord bot. A Discord channel becomes a project (bound to a local directory),
-and each thread becomes a Claude session.
+and each thread inside it becomes its own Claude Code session — message Claude
+in Discord, watch it stream code, tool calls, and answers back into the thread.
 
-## Requirements
+## How it works
 
-- Python 3.13+
-- A Discord bot token ([create one here](https://discord.com/developers/applications))
-- The `claude` CLI installed and authenticated locally (used by `claude-code-sdk`)
+```
++------------------+      +----------------+      +------------------+
+| Discord channel  | ---> | claudeD bot    | ---> | Claude Code SDK  |
+| (bound to dir)   |      | (this project) |      | (per-thread     )|
++------------------+      +----------------+      +------------------+
+        |                       |                          |
+        | new message creates   | persists channel→path    | streams assistant
+        | a thread + session    | bindings to JSON         | messages + tool
+        v                       v                          | results
++------------------+      +----------------+               v
+| Discord thread   | <----+ DiscordRenderer + <----- AssistantMessage,
+| (typewriter UX)  |      |                |          ToolUseBlock, etc.
++------------------+      +----------------+
+```
 
-## Install
+Each Discord channel can be **bound** to a local project directory with
+`/project bind`. Once bound, any top-level message in the channel opens a new
+thread, and the thread becomes a Claude session whose `cwd` is the bound
+directory. Subsequent messages in the thread continue that conversation. All
+of Claude's text and tool activity is streamed back into the thread.
+
+## Prerequisites
+
+- **Python 3.13+**
+- The **Claude Code CLI** installed and authenticated locally — the
+  `claude-code-sdk` package shells out to it.
+  See <https://docs.anthropic.com/claude/docs/claude-code> for install
+  instructions, then run `claude` once to authenticate.
+- A **Discord application + bot user** — create one at
+  <https://discord.com/developers/applications> and copy the bot token.
+
+## Installation
 
 ```bash
-git clone <this-repo>
+git clone <this-repo> discord-claude-bridge
 cd discord-claude-bridge
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -e .
 ```
 
-## Configure
+This installs the `clauded` console script.
+
+## Configuration
 
 Copy the example env file and fill in your values:
 
@@ -29,15 +59,39 @@ cp .env.example .env
 # edit .env, set DISCORD_BOT_TOKEN
 ```
 
-Available variables:
+Available environment variables:
 
-| Variable                  | Default              | Notes                                          |
-|---------------------------|----------------------|------------------------------------------------|
-| `DISCORD_BOT_TOKEN`       | (required)           | Bot token from the Discord developer portal.   |
-| `CLAUDE_MODEL`            | `sonnet`             | Default Claude model.                          |
-| `CLAUDE_PERMISSION_MODE`  | `bypassPermissions`  | Claude Code permission mode.                   |
+| Variable                  | Default              | Notes                                                        |
+|---------------------------|----------------------|--------------------------------------------------------------|
+| `DISCORD_BOT_TOKEN`       | (required)           | Bot token from the Discord developer portal.                 |
+| `CLAUDE_MODEL`            | `sonnet`             | Default Claude model (`sonnet`, `opus`, `haiku`, or full id).|
+| `CLAUDE_PERMISSION_MODE`  | `bypassPermissions`  | Claude Code permission mode (`default`, `acceptEdits`, `plan`, `bypassPermissions`). |
 
-## Run
+### Discord bot setup
+
+In the Discord developer portal:
+
+1. **Bot tab** — enable the **Message Content Intent** (privileged). Without
+   it, the bot cannot read user messages and bridging will silently no-op.
+2. **OAuth2 → URL Generator** — pick the `bot` and `applications.commands`
+   scopes.
+3. **Bot permissions** — at minimum:
+   - View Channels
+   - Send Messages
+   - Send Messages in Threads
+   - Create Public Threads
+   - Read Message History
+   - Embed Links
+   - Use Application Commands
+4. Open the generated URL and invite the bot to your server.
+
+The bot itself requests these intents (see `bot.py`):
+
+- `message_content` — to read message text
+- `messages`        — to receive `MESSAGE_CREATE`
+- `guilds`          — for slash command sync
+
+## Running
 
 ```bash
 clauded
@@ -52,17 +106,121 @@ INFO clauded.bot: Synced N application command(s)
 INFO clauded.bot: Bot online as <name> (id=...)
 ```
 
-## Slash commands
+State (channel→path bindings) is persisted to `./data/projects.json` in the
+working directory the bot is launched from.
 
-Currently registered (handlers are placeholders — wired in later subtasks):
+## Usage
 
-- `/project bind <path>` — bind this channel to a local directory
-- `/project info` — show the current binding
-- `/project unbind` — remove the binding
-- `/session stop` — stop the Claude session in this thread
-- `/session info` — show the session's status
+1. **Bind a channel** to a local directory (one-time):
 
-## Status
+   ```
+   /project bind path:/Users/me/code/my-project
+   ```
 
-Skeleton only — issue #2. See `docs/prd/discord-claude-bridge.md` for the full
-design.
+   The path must already exist on the host running the bot.
+
+2. **Start a Claude session** by sending a normal message in that channel.
+   The bot opens a thread named after your message and connects a Claude
+   session whose working directory is the bound path.
+
+3. **Continue the conversation** by replying inside the thread. Each thread
+   keeps its own independent Claude session.
+
+4. **Inspect or stop** the session with `/session info` and `/session stop`
+   inside the thread.
+
+### Streaming UX
+
+- Short replies (≲ 3 s) are sent as a single message.
+- Longer replies are written into a "typewriter" message that's edited in
+  place (~once per second) until it would exceed Discord's 2 000-character
+  limit, at which point the current message is finalized and a new one is
+  started. Code fences are auto-closed and reopened across splits.
+- Tool calls render as `⚙️ Running: <name>…` status messages that update to
+  `✅ <name>` or `❌ <name> failed` when the tool finishes.
+- If Claude calls the **AskUserQuestion** tool, the bot renders the
+  question(s) as Discord buttons (≤ 4 single-select options) or a select
+  menu (multi-select / > 4 options) and waits up to 5 minutes for a click
+  before timing out and denying the tool call.
+
+## Commands reference
+
+| Command            | Where     | What it does                                                  |
+|--------------------|-----------|---------------------------------------------------------------|
+| `/project bind`    | Channel   | Bind this channel to an absolute filesystem path. Validates that the directory exists. |
+| `/project info`    | Channel   | Show the directory currently bound to this channel.           |
+| `/project unbind`  | Channel   | Remove this channel's binding. Existing thread sessions stay running until stopped. |
+| `/session info`    | Thread    | Show whether a Claude session is active in this thread, and its `cwd`. |
+| `/session stop`    | Thread    | Disconnect the Claude session for this thread. The next message in the thread starts a fresh one. |
+
+All command responses are ephemeral (only the invoker sees them).
+
+## Architecture overview
+
+Source layout (`src/clauded/`):
+
+| Module                  | Responsibility                                                        |
+|-------------------------|------------------------------------------------------------------------|
+| `bot.py`                | Discord client; wires events and slash commands; owns the managers.    |
+| `config.py`             | `.env` / environment loading into a frozen `Config` dataclass.         |
+| `project_manager.py`    | Persisted channel-id → directory bindings (`data/projects.json`).      |
+| `session_manager.py`    | In-memory map of thread-id → live `ClaudeBridge`.                      |
+| `claude_bridge.py`      | Wraps a single `ClaudeSDKClient` connection (one per thread).          |
+| `discord_renderer.py`   | Streams Claude's messages into Discord with smart-split + typewriter.  |
+| `interaction_handler.py`| Renders `AskUserQuestion` tool calls as Discord buttons / selects.     |
+
+Message flow on a top-level channel message:
+
+1. `bot.on_message` checks the channel binding via `ProjectManager`.
+2. A new thread is created with `message.create_thread(...)`.
+3. `SessionManager.create_session(...)` constructs and starts a
+   `ClaudeBridge` (one `ClaudeSDKClient`) for that thread, with an
+   `InteractionHandler` wired in as the `on_ask_user` callback.
+4. `DiscordRenderer.render_response(...)` consumes the SDK message stream
+   and writes it to the thread.
+
+Thread messages reuse the existing `ClaudeBridge` for that thread; if the
+bridge has gone inactive (e.g. the SDK errored on a previous turn), a fresh
+session is started transparently.
+
+## Troubleshooting
+
+**The bot ignores my messages in a channel.**
+The channel isn't bound. Run `/project bind path:/abs/path` first. Bindings
+are per-channel and survive bot restarts (`data/projects.json`).
+
+**`/project bind` returns "Not a directory".**
+The path must exist on the machine running the bot, not on your client.
+Use an absolute path; `~` is expanded automatically.
+
+**The bot replies but no message content appears.**
+You probably haven't enabled the **Message Content Intent** in the Discord
+developer portal. Enable it on the Bot tab and restart the bot.
+
+**Claude session fails to start.**
+Check the bot logs — usually means `claude` isn't on `PATH`, isn't
+authenticated, or the bound directory isn't readable. Run `claude`
+manually in that directory to verify. The thread will receive an
+`❌ Failed to start Claude session: ...` message.
+
+**Slash commands don't appear in Discord.**
+Wait a minute — global command sync can take up to an hour the first time.
+Re-invite the bot with the `applications.commands` scope if needed.
+
+**Replies stop midway / "typewriter" message stops updating.**
+Discord rate-limited us. The renderer backs off and retries automatically;
+in the worst case a single edit is dropped but the stream continues. Check
+the logs for `Discord edit rate-limited` warnings.
+
+**Claude's process crashed mid-reply.**
+The renderer surfaces `Error talking to Claude: …` in the thread, the
+bridge is dropped, and the next message in the thread starts a fresh
+session.
+
+## Development
+
+The full design lives in [`docs/prd/discord-claude-bridge.md`](docs/prd/discord-claude-bridge.md).
+
+## License
+
+MIT.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# claudeD — Discord-Claude Bridge
+
+Expose [Claude Code](https://docs.anthropic.com/claude/docs/claude-code) through
+a Discord bot. A Discord channel becomes a project (bound to a local directory),
+and each thread becomes a Claude session.
+
+## Requirements
+
+- Python 3.13+
+- A Discord bot token ([create one here](https://discord.com/developers/applications))
+- The `claude` CLI installed and authenticated locally (used by `claude-code-sdk`)
+
+## Install
+
+```bash
+git clone <this-repo>
+cd discord-claude-bridge
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Configure
+
+Copy the example env file and fill in your values:
+
+```bash
+cp .env.example .env
+# edit .env, set DISCORD_BOT_TOKEN
+```
+
+Available variables:
+
+| Variable                  | Default              | Notes                                          |
+|---------------------------|----------------------|------------------------------------------------|
+| `DISCORD_BOT_TOKEN`       | (required)           | Bot token from the Discord developer portal.   |
+| `CLAUDE_MODEL`            | `sonnet`             | Default Claude model.                          |
+| `CLAUDE_PERMISSION_MODE`  | `bypassPermissions`  | Claude Code permission mode.                   |
+
+## Run
+
+```bash
+clauded
+# or, equivalently:
+python -m clauded.bot
+```
+
+You should see something like:
+
+```
+INFO clauded.bot: Synced N application command(s)
+INFO clauded.bot: Bot online as <name> (id=...)
+```
+
+## Slash commands
+
+Currently registered (handlers are placeholders — wired in later subtasks):
+
+- `/project bind <path>` — bind this channel to a local directory
+- `/project info` — show the current binding
+- `/project unbind` — remove the binding
+- `/session stop` — stop the Claude session in this thread
+- `/session info` — show the session's status
+
+## Status
+
+Skeleton only — issue #2. See `docs/prd/discord-claude-bridge.md` for the full
+design.

--- a/docs/prd/discord-claude-bridge.md
+++ b/docs/prd/discord-claude-bridge.md
@@ -1,7 +1,7 @@
 # Discord-Claude Bridge (claudeD)
 
 ## Status
-Draft
+Approved
 
 ## Overview
 

--- a/docs/prd/discord-claude-bridge.md
+++ b/docs/prd/discord-claude-bridge.md
@@ -1,0 +1,207 @@
+# Discord-Claude Bridge (claudeD)
+
+## Status
+Draft
+
+## Overview
+
+一个 Python 框架，将 Claude Code 的完整功能通过 Discord Bot 暴露给用户。用户在 Discord 中与 Claude Code 交互，体验等同甚至优于本地 CLI。
+
+## Motivation
+
+Claude Code CLI 功能强大但局限于终端。通过 Discord 桥接可以实现：
+- 随时随地通过手机/桌面 Discord 使用 Claude Code
+- 天然的会话管理（thread = session）
+- 天然的项目隔离（channel = project）
+- 丰富的 UI 组件（buttons、select menu）替代纯文本交互
+- 会话历史自动持久化在 Discord 中
+
+## Requirements
+
+### R1 — 项目绑定
+1. 一个 Discord channel 代表一个项目
+2. 用 slash command `/project bind <path>` 将 channel 绑定到本地目录
+3. 绑定信息持久化存储（重启不丢失）
+4. 支持 `/project info` 查看当前绑定
+5. 支持 `/project unbind` 解除绑定
+
+### R2 — Session 管理
+1. 用户在已绑定的 channel 中发送消息 → bot 自动创建 thread → 在 thread 中启动新 Claude session
+2. thread 名称为消息内容的前 100 字符
+3. 同一 thread 内的后续消息发送给同一 Claude session（多轮对话）
+4. Claude session 的 `cwd` 设为 channel 绑定的项目目录
+5. 使用 `claude-code-sdk` 的 `ClaudeSDKClient` 管理每个 session
+
+### R3 — 消息桥接（Discord → Claude）
+1. 用户在 thread 中发送文本消息 → 转发给对应的 Claude session
+2. 用户上传的文件 → 下载到临时目录 → 作为上下文传递给 Claude
+3. 支持在 Claude 处理中发送新消息（追加到 session）
+
+### R4 — 消息桥接（Claude → Discord）
+1. Claude 的文本回复 → 发送到对应 thread
+2. 流式输出策略（混合模式）：
+   - 回复在 3 秒内完成 → 等完成后一次性发送
+   - 超过 3 秒 → 切换为打字机效果（每 1.2 秒编辑一次，末尾加 `▌` 光标）
+   - 完成后去掉光标
+3. 长消息分片：超过 1900 字符在合理断点（段落、代码块边界）拆分，发多条消息
+4. 代码块保护：分片时不拆散未闭合的 ` ``` ` 块
+
+### R5 — 工具调用展示
+1. Claude 调用工具时，在 thread 中发送状态提示：`⚙️ Running: <tool_name>...`
+2. 工具完成后更新状态：`✅ <tool_name> completed` 或 `❌ <tool_name> failed`
+3. 状态消息简短，不展示完整输入输出（避免刷屏）
+
+### R6 — AskUserQuestion 映射
+1. Claude 使用 `AskUserQuestion` 工具时，拦截并桥接到 Discord
+2. 单选（≤4 选项）→ Discord Buttons
+3. 单选/多选（5-25 选项）→ Discord Select Menu
+4. 用户在 Discord 选择后，将结果回传给 Claude session
+5. 设置超时（5 分钟），超时自动回复超时错误
+
+### R7 — 基础命令
+1. `/project bind <path>` — 绑定 channel 到本地目录
+2. `/project info` — 查看当前绑定信息
+3. `/project unbind` — 解除绑定
+4. `/session stop` — 停止当前 thread 的 Claude session
+5. `/session info` — 查看当前 session 状态（cost、turns、model）
+
+### R8 — 错误处理
+1. Claude 进程崩溃 → 在 thread 中通知用户，提供重试按钮
+2. 未绑定的 channel 发消息 → 提示用户先绑定
+3. Discord rate limit → 自动退避重试
+4. 网络断开 → 优雅降级，恢复后通知用户
+
+### R9 — 配置
+1. 通过 `.env` 文件配置：
+   - `DISCORD_BOT_TOKEN` — Discord Bot Token
+   - `CLAUDE_MODEL` — 默认模型（可选，默认 sonnet）
+   - `CLAUDE_PERMISSION_MODE` — 权限模式（默认 bypassPermissions）
+2. 项目绑定数据持久化到本地 JSON 文件
+
+## Acceptance Criteria
+
+- [ ] AC1: `/project bind ~/myproject` 后，在 channel 发消息能自动创建 thread 并得到 Claude 回复
+- [ ] AC2: 同一 thread 中多轮对话保持上下文
+- [ ] AC3: Claude 输出超过 2000 字符时正确分片
+- [ ] AC4: Claude 执行 Bash/Edit 等工具时显示状态提示
+- [ ] AC5: Claude 使用 AskUserQuestion 时，Discord 中出现 buttons/select menu，选择后 Claude 继续
+- [ ] AC6: 短回复（<3s）一次性发送，长回复有打字机效果
+- [ ] AC7: Bot 重启后绑定信息不丢失
+- [ ] AC8: Claude 进程崩溃后用户收到通知
+
+## Technical Approach
+
+### 架构
+
+```
+Discord ←→ discord.py Bot
+                ├── ProjectManager (channel ↔ 目录绑定)
+                ├── SessionManager (thread ↔ ClaudeSDKClient 映射)
+                │     ├── Session 1 (thread A → ClaudeSDKClient → ~/project1)
+                │     ├── Session 2 (thread B → ClaudeSDKClient → ~/project1)
+                │     └── Session 3 (thread C → ClaudeSDKClient → ~/project2)
+                └── MessageBridge
+                      ├── Discord → Claude (消息转发)
+                      └── Claude → Discord (流式输出、分片、工具状态)
+```
+
+### 核心组件
+
+1. **`bot.py`** — Discord Bot 入口，事件监听，slash command 注册
+2. **`project_manager.py`** — Channel ↔ 目录绑定管理，JSON 持久化
+3. **`session_manager.py`** — Thread ↔ ClaudeSDKClient 生命周期管理
+4. **`claude_bridge.py`** — Claude SDK 封装，消息收发，工具拦截
+5. **`discord_renderer.py`** — Claude 输出 → Discord 消息渲染（分片、流式、embed）
+6. **`interaction_handler.py`** — AskUserQuestion ↔ Discord Buttons/Select Menu
+
+### Claude SDK 使用方式
+
+```python
+from claude_code_sdk import ClaudeSDKClient, ClaudeCodeOptions
+
+options = ClaudeCodeOptions(
+    cwd="/path/to/project",
+    permission_mode="bypassPermissions",
+    model="sonnet",
+)
+
+async with ClaudeSDKClient(options) as client:
+    await client.query("用户的消息")
+    async for msg in client.receive_response():
+        # 桥接到 Discord
+        ...
+```
+
+### 流式输出策略
+
+```python
+async def stream_to_discord(response_iter, thread):
+    buffer = ""
+    first_token_time = None
+    msg = None
+
+    async for chunk in response_iter:
+        buffer += chunk.text
+        if first_token_time is None:
+            first_token_time = time.time()
+
+        elapsed = time.time() - first_token_time
+        if elapsed < 3.0:
+            continue  # 等一下，看能不能一次性发
+
+        # 超过 3 秒，切换打字机模式
+        if msg is None:
+            msg = await thread.send(buffer[:1900] + "▌")
+        elif time.time() - last_edit > 1.2:
+            await msg.edit(content=buffer[:1900] + "▌")
+
+    # 最终发送
+    if msg:
+        await msg.edit(content=buffer[:1900])  # 去掉光标
+    else:
+        await thread.send(buffer)  # 短回复，一次性发
+```
+
+### 工具拦截（AskUserQuestion）
+
+通过 `can_use_tool` 回调拦截：
+
+```python
+async def handle_tool_permission(tool_name, tool_input, context):
+    if tool_name == "AskUserQuestion":
+        # 在 Discord 发 buttons/select menu
+        # 等待用户选择
+        # 返回 PermissionResultAllow(updated_input=用户选择)
+        ...
+    return PermissionResultAllow()  # 其他工具放行
+```
+
+### 数据持久化
+
+```json
+// data/projects.json
+{
+  "channel_id_1": {
+    "path": "/Users/xuzhang/project1",
+    "bound_at": "2026-04-30T17:00:00Z"
+  }
+}
+```
+
+Session 状态不持久化（重启后用户在 thread 里发新消息会创建新 session）。
+
+## Testing Strategy
+
+1. **单元测试**：消息分片逻辑、代码块检测、流式节流逻辑
+2. **集成测试**：mock ClaudeSDKClient，验证消息桥接完整流程
+3. **手动测试**：真实 Discord bot + Claude Code 端到端验证
+
+## Out of Scope
+
+- 多用户/权限管理（单用户场景）
+- 沙箱隔离
+- Web UI
+- Claude 以外的 AI 模型支持
+- 消息历史搜索
+- 费用追踪/预算限制（v1 不做）
+- Discord slash command 之外的 Claude slash command 映射（后续迭代）

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "clauded"
+version = "0.1.0"
+description = "Discord-Claude Bridge: expose Claude Code via a Discord bot"
+readme = "README.md"
+requires-python = ">=3.13"
+license = { text = "MIT" }
+authors = [
+    { name = "claudeD contributors" },
+]
+dependencies = [
+    "discord.py>=2.4,<3.0",
+    "claude-code-sdk>=0.0.10",
+    "python-dotenv>=1.0",
+]
+
+[project.scripts]
+clauded = "clauded.bot:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-dir]
+"" = "src"

--- a/src/clauded/__init__.py
+++ b/src/clauded/__init__.py
@@ -1,0 +1,3 @@
+"""claudeD — Discord-Claude Bridge."""
+
+__version__ = "0.1.0"

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -1,0 +1,143 @@
+"""Discord bot entrypoint for claudeD.
+
+Wires up event handlers (on_ready, on_message) and registers slash command
+groups (`/project`, `/session`). Handlers are placeholders at this stage —
+real logic arrives in later subtasks.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from .config import Config, load_config
+
+log = logging.getLogger("clauded.bot")
+
+
+def _build_intents() -> discord.Intents:
+    """Intents needed: messages + content for bridging, guilds for commands."""
+    intents = discord.Intents.default()
+    intents.message_content = True
+    intents.messages = True
+    intents.guilds = True
+    return intents
+
+
+class ClaudedBot(commands.Bot):
+    """Discord bot for the claudeD bridge."""
+
+    def __init__(self, config: Config) -> None:
+        super().__init__(command_prefix="!", intents=_build_intents())
+        self.config = config
+
+    async def setup_hook(self) -> None:
+        """Register slash command groups and sync to Discord."""
+        self.tree.add_command(project_group)
+        self.tree.add_command(session_group)
+        synced = await self.tree.sync()
+        log.info("Synced %d application command(s)", len(synced))
+
+    async def on_ready(self) -> None:  # type: ignore[override]
+        user = self.user
+        log.info("Bot online as %s (id=%s)", user, getattr(user, "id", "?"))
+
+    async def on_message(self, message: discord.Message) -> None:  # type: ignore[override]
+        # Ignore self / other bots.
+        if message.author.bot:
+            return
+
+        log.info(
+            "on_message channel=%s thread=%s author=%s len=%d",
+            message.channel.id,
+            getattr(message.channel, "parent_id", None),
+            message.author,
+            len(message.content),
+        )
+        # Real bridging logic arrives in a later subtask.
+        await self.process_commands(message)
+
+
+# ---------------------------------------------------------------------------
+# Slash command groups (placeholder handlers).
+# ---------------------------------------------------------------------------
+
+project_group = app_commands.Group(
+    name="project",
+    description="Manage channel ↔ project-directory bindings.",
+)
+
+
+@project_group.command(name="bind", description="Bind this channel to a local directory.")
+@app_commands.describe(path="Absolute path to the project directory")
+async def project_bind(interaction: discord.Interaction, path: str) -> None:
+    log.info("/project bind path=%s channel=%s", path, interaction.channel_id)
+    await interaction.response.send_message(
+        f"(placeholder) would bind this channel to `{path}`",
+        ephemeral=True,
+    )
+
+
+@project_group.command(name="info", description="Show this channel's current binding.")
+async def project_info(interaction: discord.Interaction) -> None:
+    log.info("/project info channel=%s", interaction.channel_id)
+    await interaction.response.send_message(
+        "(placeholder) project info goes here",
+        ephemeral=True,
+    )
+
+
+@project_group.command(name="unbind", description="Remove this channel's binding.")
+async def project_unbind(interaction: discord.Interaction) -> None:
+    log.info("/project unbind channel=%s", interaction.channel_id)
+    await interaction.response.send_message(
+        "(placeholder) would unbind this channel",
+        ephemeral=True,
+    )
+
+
+session_group = app_commands.Group(
+    name="session",
+    description="Manage Claude sessions inside threads.",
+)
+
+
+@session_group.command(name="stop", description="Stop the Claude session in this thread.")
+async def session_stop(interaction: discord.Interaction) -> None:
+    log.info("/session stop channel=%s", interaction.channel_id)
+    await interaction.response.send_message(
+        "(placeholder) would stop the Claude session",
+        ephemeral=True,
+    )
+
+
+@session_group.command(name="info", description="Show the current session's status.")
+async def session_info(interaction: discord.Interaction) -> None:
+    log.info("/session info channel=%s", interaction.channel_id)
+    await interaction.response.send_message(
+        "(placeholder) session info goes here",
+        ephemeral=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    """Console-script entry point: load config and run the bot."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    config = load_config()
+    bot = ClaudedBot(config)
+    bot.run(config.discord_bot_token, log_handler=None)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -99,8 +99,21 @@ class ClaudedBot(commands.Bot):
         thread_name = (message.content or "claude session")[:80] or "claude session"
         try:
             thread = await message.create_thread(name=thread_name)
-        except Exception:
+        except discord.Forbidden:
+            log.exception("Missing permission to create threads in channel=%s", channel.id)
+            try:
+                await channel.send(
+                    "❌ I don't have permission to create threads in this channel."
+                )
+            except discord.HTTPException:
+                log.debug("Could not surface thread-permission error to channel")
+            return
+        except discord.HTTPException:
             log.exception("Failed to create thread for channel=%s", channel.id)
+            try:
+                await channel.send("❌ Failed to create a thread for this message.")
+            except discord.HTTPException:
+                log.debug("Could not surface thread-creation error to channel")
             return
 
         try:
@@ -113,11 +126,20 @@ class ClaudedBot(commands.Bot):
             )
         except Exception as exc:
             log.exception("Failed to start ClaudeBridge")
-            await thread.send(f"Failed to start Claude session: `{exc}`")
+            try:
+                await thread.send(f"❌ Failed to start Claude session: `{exc}`")
+            except discord.HTTPException:
+                log.debug("Could not post session-start error to thread")
             return
 
         renderer = DiscordRenderer(thread)
-        await renderer.render_response(bridge, message.content)
+        try:
+            await renderer.render_response(bridge, message.content)
+        except Exception:
+            log.exception("Renderer failed for thread=%s", thread.id)
+            # The bridge is likely in a bad state — drop it so the next
+            # message in this thread starts a fresh session.
+            await self.session_manager.stop_session(thread.id)
 
     async def _handle_thread_message(
         self, message: discord.Message, parent_id: int
@@ -144,11 +166,21 @@ class ClaudedBot(commands.Bot):
                 )
             except Exception as exc:
                 log.exception("Failed to start ClaudeBridge for thread=%s", thread_id)
-                await message.channel.send(f"Failed to start Claude session: `{exc}`")
+                try:
+                    await message.channel.send(
+                        f"❌ Failed to start Claude session: `{exc}`"
+                    )
+                except discord.HTTPException:
+                    log.debug("Could not post session-start error to thread")
                 return
 
         renderer = DiscordRenderer(message.channel)
-        await renderer.render_response(bridge, message.content)
+        try:
+            await renderer.render_response(bridge, message.content)
+        except Exception:
+            log.exception("Renderer failed for thread=%s", thread_id)
+            # Drop the dead bridge so the next message recreates it.
+            await self.session_manager.stop_session(thread_id)
 
 
 # ---------------------------------------------------------------------------

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -1,8 +1,8 @@
 """Discord bot entrypoint for claudeD.
 
 Wires up event handlers (on_ready, on_message) and registers slash command
-groups (`/project`, `/session`). Handlers are placeholders at this stage —
-real logic arrives in later subtasks.
+groups (`/project`, `/session`). The on_message handler bridges Discord
+messages to a per-thread :class:`ClaudeBridge` session.
 """
 
 from __future__ import annotations
@@ -13,9 +13,15 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from .claude_bridge import AssistantMessage, ClaudeBridge, TextBlock
 from .config import Config, load_config
+from .project_manager import ProjectManager
+from .session_manager import SessionManager
 
 log = logging.getLogger("clauded.bot")
+
+# Discord hard-caps message content at 2000 characters; leave a small margin.
+DISCORD_MAX_LEN = 1900
 
 
 def _build_intents() -> discord.Intents:
@@ -27,12 +33,72 @@ def _build_intents() -> discord.Intents:
     return intents
 
 
+def _split_for_discord(text: str, limit: int = DISCORD_MAX_LEN) -> list[str]:
+    """Split ``text`` into Discord-sized chunks, preferring line breaks."""
+    if not text:
+        return []
+    if len(text) <= limit:
+        return [text]
+
+    chunks: list[str] = []
+    remaining = text
+    while len(remaining) > limit:
+        # Prefer splitting on a newline within the limit window.
+        cut = remaining.rfind("\n", 0, limit)
+        if cut <= 0:
+            cut = limit
+        chunks.append(remaining[:cut])
+        remaining = remaining[cut:].lstrip("\n")
+    if remaining:
+        chunks.append(remaining)
+    return chunks
+
+
+def _collect_text(messages: list[object]) -> str:
+    """Collect text from ``AssistantMessage``/``TextBlock`` entries."""
+    parts: list[str] = []
+    for msg in messages:
+        if isinstance(msg, AssistantMessage):
+            for block in getattr(msg, "content", []) or []:
+                if isinstance(block, TextBlock):
+                    text = getattr(block, "text", "")
+                    if text:
+                        parts.append(text)
+    return "\n".join(parts).strip()
+
+
+async def _run_and_reply(
+    bridge: ClaudeBridge,
+    text: str,
+    target: discord.abc.Messageable,
+) -> None:
+    """Send ``text`` to ``bridge`` and forward Claude's text reply to ``target``."""
+    try:
+        collected: list[object] = []
+        async for msg in bridge.send_message(text):
+            collected.append(msg)
+    except Exception as exc:
+        log.exception("ClaudeBridge.send_message failed")
+        await target.send(f"Error talking to Claude: `{exc}`")
+        return
+
+    reply = _collect_text(collected)
+    if not reply:
+        await target.send("(Claude returned no text response)")
+        return
+
+    for chunk in _split_for_discord(reply):
+        await target.send(chunk)
+
+
 class ClaudedBot(commands.Bot):
     """Discord bot for the claudeD bridge."""
 
     def __init__(self, config: Config) -> None:
         super().__init__(command_prefix="!", intents=_build_intents())
         self.config = config
+        self.session_manager = SessionManager()
+        self.project_manager = ProjectManager()
 
     async def setup_hook(self) -> None:
         """Register slash command groups and sync to Discord."""
@@ -50,19 +116,93 @@ class ClaudedBot(commands.Bot):
         if message.author.bot:
             return
 
+        channel = message.channel
+        parent_id = getattr(channel, "parent_id", None)
+
         log.info(
             "on_message channel=%s thread=%s author=%s len=%d",
-            message.channel.id,
-            getattr(message.channel, "parent_id", None),
+            channel.id,
+            parent_id,
             message.author,
             len(message.content),
         )
-        # Real bridging logic arrives in a later subtask.
+
+        try:
+            if parent_id is None:
+                await self._handle_channel_message(message)
+            else:
+                await self._handle_thread_message(message, parent_id)
+        except Exception:
+            log.exception("on_message handling failed")
+
         await self.process_commands(message)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _handle_channel_message(self, message: discord.Message) -> None:
+        """Channel (non-thread) message: open a new thread + session."""
+        channel = message.channel
+        if not self.project_manager.is_bound(channel.id):
+            return  # Channel isn't wired up; ignore.
+
+        project_path = self.project_manager.get_path(channel.id)
+        if project_path is None:
+            log.warning("Channel %s reports bound but has no path", channel.id)
+            return
+
+        if not isinstance(channel, discord.TextChannel):
+            log.warning("Bound channel %s is not a TextChannel; skipping", channel.id)
+            return
+
+        thread_name = (message.content or "claude session")[:80] or "claude session"
+        try:
+            thread = await message.create_thread(name=thread_name)
+        except Exception:
+            log.exception("Failed to create thread for channel=%s", channel.id)
+            return
+
+        try:
+            bridge = await self.session_manager.create_session(
+                thread.id, project_path, self.config
+            )
+        except Exception as exc:
+            log.exception("Failed to start ClaudeBridge")
+            await thread.send(f"Failed to start Claude session: `{exc}`")
+            return
+
+        await _run_and_reply(bridge, message.content, thread)
+
+    async def _handle_thread_message(
+        self, message: discord.Message, parent_id: int
+    ) -> None:
+        """Thread message: route to the existing/new session for that thread."""
+        if not self.project_manager.is_bound(parent_id):
+            return  # Parent channel isn't bound; ignore.
+
+        project_path = self.project_manager.get_path(parent_id)
+        if project_path is None:
+            log.warning("Parent channel %s bound but has no path", parent_id)
+            return
+
+        thread_id = message.channel.id
+        bridge = self.session_manager.get_session(thread_id)
+        if bridge is None or not bridge.is_active:
+            try:
+                bridge = await self.session_manager.create_session(
+                    thread_id, project_path, self.config
+                )
+            except Exception as exc:
+                log.exception("Failed to start ClaudeBridge for thread=%s", thread_id)
+                await message.channel.send(f"Failed to start Claude session: `{exc}`")
+                return
+
+        await _run_and_reply(bridge, message.content, message.channel)
 
 
 # ---------------------------------------------------------------------------
-# Slash command groups (placeholder handlers).
+# Slash command groups.
 # ---------------------------------------------------------------------------
 
 project_group = app_commands.Group(
@@ -108,19 +248,49 @@ session_group = app_commands.Group(
 @session_group.command(name="stop", description="Stop the Claude session in this thread.")
 async def session_stop(interaction: discord.Interaction) -> None:
     log.info("/session stop channel=%s", interaction.channel_id)
-    await interaction.response.send_message(
-        "(placeholder) would stop the Claude session",
-        ephemeral=True,
-    )
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+
+    thread_id = interaction.channel_id
+    if thread_id is None:
+        await interaction.response.send_message(
+            "No thread context for this command.", ephemeral=True
+        )
+        return
+
+    stopped = await bot.session_manager.stop_session(thread_id)
+    if stopped:
+        await interaction.response.send_message(
+            "Claude session stopped.", ephemeral=True
+        )
+    else:
+        await interaction.response.send_message(
+            "No active Claude session in this thread.", ephemeral=True
+        )
 
 
 @session_group.command(name="info", description="Show the current session's status.")
 async def session_info(interaction: discord.Interaction) -> None:
     log.info("/session info channel=%s", interaction.channel_id)
-    await interaction.response.send_message(
-        "(placeholder) session info goes here",
-        ephemeral=True,
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+
+    thread_id = interaction.channel_id
+    bridge = (
+        bot.session_manager.get_session(thread_id) if thread_id is not None else None
     )
+    if bridge is not None and bridge.is_active:
+        await interaction.response.send_message(
+            f"Session active — cwd `{bridge.project_path}`.", ephemeral=True
+        )
+    else:
+        await interaction.response.send_message(
+            "No active Claude session in this thread.", ephemeral=True
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -13,15 +13,12 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from .claude_bridge import AssistantMessage, ClaudeBridge, TextBlock
 from .config import Config, load_config
+from .discord_renderer import DiscordRenderer
 from .project_manager import ProjectManager
 from .session_manager import SessionManager
 
 log = logging.getLogger("clauded.bot")
-
-# Discord hard-caps message content at 2000 characters; leave a small margin.
-DISCORD_MAX_LEN = 1900
 
 
 def _build_intents() -> discord.Intents:
@@ -31,64 +28,6 @@ def _build_intents() -> discord.Intents:
     intents.messages = True
     intents.guilds = True
     return intents
-
-
-def _split_for_discord(text: str, limit: int = DISCORD_MAX_LEN) -> list[str]:
-    """Split ``text`` into Discord-sized chunks, preferring line breaks."""
-    if not text:
-        return []
-    if len(text) <= limit:
-        return [text]
-
-    chunks: list[str] = []
-    remaining = text
-    while len(remaining) > limit:
-        # Prefer splitting on a newline within the limit window.
-        cut = remaining.rfind("\n", 0, limit)
-        if cut <= 0:
-            cut = limit
-        chunks.append(remaining[:cut])
-        remaining = remaining[cut:].lstrip("\n")
-    if remaining:
-        chunks.append(remaining)
-    return chunks
-
-
-def _collect_text(messages: list[object]) -> str:
-    """Collect text from ``AssistantMessage``/``TextBlock`` entries."""
-    parts: list[str] = []
-    for msg in messages:
-        if isinstance(msg, AssistantMessage):
-            for block in getattr(msg, "content", []) or []:
-                if isinstance(block, TextBlock):
-                    text = getattr(block, "text", "")
-                    if text:
-                        parts.append(text)
-    return "\n".join(parts).strip()
-
-
-async def _run_and_reply(
-    bridge: ClaudeBridge,
-    text: str,
-    target: discord.abc.Messageable,
-) -> None:
-    """Send ``text`` to ``bridge`` and forward Claude's text reply to ``target``."""
-    try:
-        collected: list[object] = []
-        async for msg in bridge.send_message(text):
-            collected.append(msg)
-    except Exception as exc:
-        log.exception("ClaudeBridge.send_message failed")
-        await target.send(f"Error talking to Claude: `{exc}`")
-        return
-
-    reply = _collect_text(collected)
-    if not reply:
-        await target.send("(Claude returned no text response)")
-        return
-
-    for chunk in _split_for_discord(reply):
-        await target.send(chunk)
 
 
 class ClaudedBot(commands.Bot):
@@ -171,7 +110,8 @@ class ClaudedBot(commands.Bot):
             await thread.send(f"Failed to start Claude session: `{exc}`")
             return
 
-        await _run_and_reply(bridge, message.content, thread)
+        renderer = DiscordRenderer(thread)
+        await renderer.render_response(bridge, message.content)
 
     async def _handle_thread_message(
         self, message: discord.Message, parent_id: int
@@ -197,7 +137,8 @@ class ClaudedBot(commands.Bot):
                 await message.channel.send(f"Failed to start Claude session: `{exc}`")
                 return
 
-        await _run_and_reply(bridge, message.content, message.channel)
+        renderer = DiscordRenderer(message.channel)
+        await renderer.render_response(bridge, message.content)
 
 
 # ---------------------------------------------------------------------------

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -14,6 +14,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from .config import Config, load_config
+from .project_manager import ProjectManager
 
 log = logging.getLogger("clauded.bot")
 
@@ -33,6 +34,7 @@ class ClaudedBot(commands.Bot):
     def __init__(self, config: Config) -> None:
         super().__init__(command_prefix="!", intents=_build_intents())
         self.config = config
+        self.project_manager = ProjectManager()
 
     async def setup_hook(self) -> None:
         """Register slash command groups and sync to Discord."""
@@ -62,7 +64,7 @@ class ClaudedBot(commands.Bot):
 
 
 # ---------------------------------------------------------------------------
-# Slash command groups (placeholder handlers).
+# Slash command groups.
 # ---------------------------------------------------------------------------
 
 project_group = app_commands.Group(
@@ -75,28 +77,64 @@ project_group = app_commands.Group(
 @app_commands.describe(path="Absolute path to the project directory")
 async def project_bind(interaction: discord.Interaction, path: str) -> None:
     log.info("/project bind path=%s channel=%s", path, interaction.channel_id)
+    bot: ClaudedBot = interaction.client  # type: ignore[assignment]
+    channel_id = interaction.channel_id
+    if channel_id is None:
+        await interaction.response.send_message(
+            "Cannot bind: no channel context.", ephemeral=True
+        )
+        return
+
+    try:
+        stored = bot.project_manager.bind(channel_id, path)
+    except ValueError as exc:
+        await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
+        return
+
     await interaction.response.send_message(
-        f"(placeholder) would bind this channel to `{path}`",
-        ephemeral=True,
+        f"✅ Bound this channel to `{stored}`", ephemeral=True
     )
 
 
 @project_group.command(name="info", description="Show this channel's current binding.")
 async def project_info(interaction: discord.Interaction) -> None:
     log.info("/project info channel=%s", interaction.channel_id)
+    bot: ClaudedBot = interaction.client  # type: ignore[assignment]
+    channel_id = interaction.channel_id
+    if channel_id is None:
+        await interaction.response.send_message("No channel context.", ephemeral=True)
+        return
+
+    bound_path = bot.project_manager.get_project(channel_id)
+    if bound_path is None:
+        await interaction.response.send_message(
+            "This channel is not bound to a project. Use `/project bind` to set one.",
+            ephemeral=True,
+        )
+        return
+
     await interaction.response.send_message(
-        "(placeholder) project info goes here",
-        ephemeral=True,
+        f"📁 This channel is bound to `{bound_path}`", ephemeral=True
     )
 
 
 @project_group.command(name="unbind", description="Remove this channel's binding.")
 async def project_unbind(interaction: discord.Interaction) -> None:
     log.info("/project unbind channel=%s", interaction.channel_id)
-    await interaction.response.send_message(
-        "(placeholder) would unbind this channel",
-        ephemeral=True,
-    )
+    bot: ClaudedBot = interaction.client  # type: ignore[assignment]
+    channel_id = interaction.channel_id
+    if channel_id is None:
+        await interaction.response.send_message("No channel context.", ephemeral=True)
+        return
+
+    if bot.project_manager.unbind(channel_id):
+        await interaction.response.send_message(
+            "✅ Removed this channel's project binding.", ephemeral=True
+        )
+    else:
+        await interaction.response.send_message(
+            "This channel had no binding to remove.", ephemeral=True
+        )
 
 
 session_group = app_commands.Group(

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -15,6 +15,7 @@ from discord.ext import commands
 
 from .config import Config, load_config
 from .discord_renderer import DiscordRenderer
+from .interaction_handler import InteractionHandler
 from .project_manager import ProjectManager
 from .session_manager import SessionManager
 
@@ -35,6 +36,7 @@ class ClaudedBot(commands.Bot):
 
     def __init__(self, config: Config) -> None:
         super().__init__(command_prefix="!", intents=_build_intents())
+        self.config = config
         self.session_manager = SessionManager()
         self.project_manager = ProjectManager()
 
@@ -102,8 +104,12 @@ class ClaudedBot(commands.Bot):
             return
 
         try:
+            handler = InteractionHandler(thread)
             bridge = await self.session_manager.create_session(
-                thread.id, project_path, self.config
+                thread.id,
+                project_path,
+                self.config,
+                on_ask_user=handler.handle_ask_user_question,
             )
         except Exception as exc:
             log.exception("Failed to start ClaudeBridge")
@@ -129,8 +135,12 @@ class ClaudedBot(commands.Bot):
         bridge = self.session_manager.get_session(thread_id)
         if bridge is None or not bridge.is_active:
             try:
+                handler = InteractionHandler(message.channel)
                 bridge = await self.session_manager.create_session(
-                    thread_id, project_path, self.config
+                    thread_id,
+                    project_path,
+                    self.config,
+                    on_ask_user=handler.handle_ask_user_question,
                 )
             except Exception as exc:
                 log.exception("Failed to start ClaudeBridge for thread=%s", thread_id)

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -87,13 +87,22 @@ class ClaudeBridge:
 
         Yields the raw SDK message objects (``AssistantMessage``,
         ``ResultMessage``, etc.) so callers can decide how to render them.
+
+        If the underlying SDK raises, the bridge marks itself inactive so
+        callers can detect the dead session and recreate it on the next
+        request. The exception is re-raised so the renderer can surface it.
         """
         if self._client is None or not self._active:
             raise RuntimeError("ClaudeBridge.send_message called before start()")
 
-        await self._client.query(text)
-        async for msg in self._client.receive_response():
-            yield msg
+        try:
+            await self._client.query(text)
+            async for msg in self._client.receive_response():
+                yield msg
+        except Exception:
+            log.exception("Claude SDK stream failed; marking bridge inactive")
+            self._active = False
+            raise
 
     async def stop(self) -> None:
         """Disconnect the underlying client (idempotent)."""

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -4,12 +4,18 @@ Each :class:`ClaudeBridge` wraps one ``ClaudeSDKClient`` connected to a
 project directory. A bridge is created per Discord thread, used until the
 session is stopped (manually or because the thread is unbound), and then
 disconnected.
+
+The bridge optionally accepts an ``on_ask_user`` callback that is invoked
+whenever Claude calls the ``AskUserQuestion`` tool. The callback returns the
+``updated_input`` dict (typically with an extra ``answers`` field) — that is
+forwarded to the SDK as a :class:`PermissionResultAllow`. All other tools are
+unconditionally allowed.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import AsyncIterator
+from typing import Any, AsyncIterator, Awaitable, Callable
 
 from claude_code_sdk import (
     AssistantMessage,
@@ -20,18 +26,36 @@ from claude_code_sdk import (
     ToolResultBlock,
     ToolUseBlock,
 )
+from claude_code_sdk.types import (
+    PermissionResultAllow,
+    PermissionResultDeny,
+    ToolPermissionContext,
+)
 
 from .config import Config
 
 log = logging.getLogger("clauded.claude_bridge")
 
 
+# Type alias for the async callback the bot supplies to handle
+# ``AskUserQuestion`` tool invocations. It receives the raw tool input and
+# returns either an updated input dict (forwarded to the SDK as
+# ``PermissionResultAllow.updated_input``) or ``None`` to deny the call.
+OnAskUser = Callable[[dict[str, Any]], Awaitable[dict[str, Any] | None]]
+
+
 class ClaudeBridge:
     """Wrapper around a ``ClaudeSDKClient`` for a single project session."""
 
-    def __init__(self, project_path: str, config: Config) -> None:
+    def __init__(
+        self,
+        project_path: str,
+        config: Config,
+        on_ask_user: OnAskUser | None = None,
+    ) -> None:
         self.project_path = project_path
         self.config = config
+        self.on_ask_user = on_ask_user
         self._client: ClaudeSDKClient | None = None
         self._active = False
 
@@ -46,12 +70,17 @@ class ClaudeBridge:
             cwd=self.project_path,
             permission_mode=self.config.claude_permission_mode,
             model=self.config.claude_model,
+            can_use_tool=self._can_use_tool if self.on_ask_user else None,
         )
         client = ClaudeSDKClient(options=options)
         await client.connect()
         self._client = client
         self._active = True
-        log.info("ClaudeBridge started for cwd=%s", self.project_path)
+        log.info(
+            "ClaudeBridge started for cwd=%s ask_user=%s",
+            self.project_path,
+            bool(self.on_ask_user),
+        )
 
     async def send_message(self, text: str) -> AsyncIterator[object]:
         """Send a user message and stream back response messages.
@@ -79,9 +108,40 @@ class ClaudeBridge:
             self._active = False
             log.info("ClaudeBridge stopped for cwd=%s", self.project_path)
 
+    # ------------------------------------------------------------------
+    # SDK callbacks
+    # ------------------------------------------------------------------
+
+    async def _can_use_tool(
+        self,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        context: ToolPermissionContext,
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        """SDK ``can_use_tool`` callback.
+
+        Intercepts ``AskUserQuestion`` and forwards everything else.
+        """
+        if tool_name == "AskUserQuestion" and self.on_ask_user is not None:
+            try:
+                updated = await self.on_ask_user(tool_input)
+            except Exception:
+                log.exception("on_ask_user callback raised; denying tool call")
+                return PermissionResultDeny(
+                    message="Internal error showing question UI."
+                )
+            if updated is None:
+                return PermissionResultDeny(
+                    message="No response from user (timed out)."
+                )
+            return PermissionResultAllow(updated_input=updated)
+
+        return PermissionResultAllow()
+
 
 __all__ = [
     "ClaudeBridge",
+    "OnAskUser",
     # Re-export for convenience so callers can ``isinstance`` against the
     # message/block types without importing the SDK directly.
     "AssistantMessage",

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -1,0 +1,92 @@
+"""Bridge to a single Claude Code SDK client session.
+
+Each :class:`ClaudeBridge` wraps one ``ClaudeSDKClient`` connected to a
+project directory. A bridge is created per Discord thread, used until the
+session is stopped (manually or because the thread is unbound), and then
+disconnected.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import AsyncIterator
+
+from claude_code_sdk import (
+    AssistantMessage,
+    ClaudeCodeOptions,
+    ClaudeSDKClient,
+    ResultMessage,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+)
+
+from .config import Config
+
+log = logging.getLogger("clauded.claude_bridge")
+
+
+class ClaudeBridge:
+    """Wrapper around a ``ClaudeSDKClient`` for a single project session."""
+
+    def __init__(self, project_path: str, config: Config) -> None:
+        self.project_path = project_path
+        self.config = config
+        self._client: ClaudeSDKClient | None = None
+        self._active = False
+
+    @property
+    def is_active(self) -> bool:
+        """True iff the underlying client is currently connected."""
+        return self._active
+
+    async def start(self) -> None:
+        """Create and connect the underlying ``ClaudeSDKClient``."""
+        options = ClaudeCodeOptions(
+            cwd=self.project_path,
+            permission_mode=self.config.claude_permission_mode,
+            model=self.config.claude_model,
+        )
+        client = ClaudeSDKClient(options=options)
+        await client.connect()
+        self._client = client
+        self._active = True
+        log.info("ClaudeBridge started for cwd=%s", self.project_path)
+
+    async def send_message(self, text: str) -> AsyncIterator[object]:
+        """Send a user message and stream back response messages.
+
+        Yields the raw SDK message objects (``AssistantMessage``,
+        ``ResultMessage``, etc.) so callers can decide how to render them.
+        """
+        if self._client is None or not self._active:
+            raise RuntimeError("ClaudeBridge.send_message called before start()")
+
+        await self._client.query(text)
+        async for msg in self._client.receive_response():
+            yield msg
+
+    async def stop(self) -> None:
+        """Disconnect the underlying client (idempotent)."""
+        if self._client is None:
+            return
+        try:
+            await self._client.disconnect()
+        except Exception:  # pragma: no cover - defensive
+            log.exception("Error while disconnecting ClaudeSDKClient")
+        finally:
+            self._client = None
+            self._active = False
+            log.info("ClaudeBridge stopped for cwd=%s", self.project_path)
+
+
+__all__ = [
+    "ClaudeBridge",
+    # Re-export for convenience so callers can ``isinstance`` against the
+    # message/block types without importing the SDK directly.
+    "AssistantMessage",
+    "TextBlock",
+    "ToolUseBlock",
+    "ToolResultBlock",
+    "ResultMessage",
+]

--- a/src/clauded/config.py
+++ b/src/clauded/config.py
@@ -1,0 +1,37 @@
+"""Configuration loading from environment / .env file."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from dotenv import load_dotenv
+
+
+@dataclass(frozen=True)
+class Config:
+    """Runtime configuration for the Discord-Claude bridge."""
+
+    discord_bot_token: str
+    claude_model: str
+    claude_permission_mode: str
+
+
+def load_config() -> Config:
+    """Load configuration from environment variables (and `.env` if present)."""
+    load_dotenv()
+
+    token = os.environ.get("DISCORD_BOT_TOKEN", "").strip()
+    if not token:
+        raise RuntimeError(
+            "DISCORD_BOT_TOKEN is not set. Copy .env.example to .env and fill it in."
+        )
+
+    return Config(
+        discord_bot_token=token,
+        claude_model=os.environ.get("CLAUDE_MODEL", "sonnet").strip() or "sonnet",
+        claude_permission_mode=(
+            os.environ.get("CLAUDE_PERMISSION_MODE", "bypassPermissions").strip()
+            or "bypassPermissions"
+        ),
+    )

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1,0 +1,378 @@
+"""Streaming renderer that bridges Claude SDK output to Discord.
+
+The renderer consumes the message stream from a :class:`ClaudeBridge` and
+writes it to a Discord channel/thread with three behaviors:
+
+1. **Fast-path**: if Claude finishes within :data:`FAST_PATH_SECONDS`, the
+   full reply is sent in one (smart-split) batch.
+2. **Typewriter mode**: if the response takes longer, an initial message is
+   sent with a trailing cursor and then edited in place every
+   :data:`EDIT_INTERVAL_SECONDS` until the buffer exceeds Discord's per-
+   message limit, at which point the current message is finalized and a
+   new one is started.
+3. **Tool status**: ``ToolUseBlock`` events render a ``⚙️ Running …``
+   status message which is updated to ``✅`` / ``❌`` when the matching
+   ``ToolResultBlock`` arrives.
+
+The renderer also smart-splits text on paragraph → line → space boundaries
+and protects unclosed ``` code fences by closing-and-reopening them across
+chunk boundaries.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING
+
+import discord
+
+from .claude_bridge import (
+    ResultMessage,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+)
+
+if TYPE_CHECKING:
+    from .claude_bridge import ClaudeBridge
+
+log = logging.getLogger("clauded.discord_renderer")
+
+
+# Discord caps message content at 2000 characters; we leave a small margin so
+# we can append a cursor or close-and-reopen a code fence safely.
+DISCORD_MAX_LEN = 1900
+
+# Single-character cursor appended to the in-flight typewriter message.
+CURSOR = "▌"
+
+# Below this, the response is considered "fast" and is sent as a single
+# (smart-split) batch of messages once the stream completes.
+FAST_PATH_SECONDS = 3.0
+
+# Minimum delay between successive edits of the live typewriter message.
+# Discord rate-limits edits aggressively; ~1.2s keeps us well under the cap.
+EDIT_INTERVAL_SECONDS = 1.2
+
+# Sleep used when an edit/send fails (likely rate-limited) before continuing.
+HTTP_BACKOFF_SECONDS = 0.5
+
+
+class DiscordRenderer:
+    """Render a Claude streaming response into a Discord channel/thread."""
+
+    def __init__(self, target: discord.abc.Messageable) -> None:
+        self.target = target
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    async def render_response(self, bridge: "ClaudeBridge", user_text: str) -> None:
+        """Stream Claude's response for ``user_text`` to :attr:`target`."""
+        buffer = ""                               # text not yet finalized into a sent msg
+        live_msg: discord.Message | None = None   # the in-flight typewriter message
+        start_time: float | None = None
+        last_edit = 0.0
+        typewriter = False                        # have we entered typewriter mode?
+        saw_text = False                          # any TextBlock seen?
+        # tool_use_id -> (discord.Message, tool_name)
+        tool_msgs: dict[str, tuple[discord.Message, str]] = {}
+
+        try:
+            async for event in bridge.send_message(user_text):
+                # Tool results can arrive on UserMessage objects too — handle any
+                # message that exposes a ``content`` list of blocks.
+                content = getattr(event, "content", None)
+                if isinstance(event, ResultMessage):
+                    break
+
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, TextBlock):
+                            text = getattr(block, "text", "") or ""
+                            if not text:
+                                continue
+                            saw_text = True
+                            buffer += text
+
+                            now = time.time()
+                            if start_time is None:
+                                start_time = now
+
+                            # Enter typewriter mode once we've been streaming long enough.
+                            if not typewriter and (now - start_time) > FAST_PATH_SECONDS:
+                                typewriter = True
+                                live_msg, buffer = await self._typewriter_tick(
+                                    live_msg, buffer
+                                )
+                                last_edit = now
+                            elif typewriter and (now - last_edit) >= EDIT_INTERVAL_SECONDS:
+                                live_msg, buffer = await self._typewriter_tick(
+                                    live_msg, buffer
+                                )
+                                last_edit = now
+
+                        elif isinstance(block, ToolUseBlock):
+                            # Finalize any pending typewriter message before
+                            # interleaving a tool-status message, so the order
+                            # in the channel matches the order of events.
+                            if live_msg is not None:
+                                await self._finalize_typewriter(live_msg, buffer)
+                                live_msg = None
+                                buffer = ""
+                                typewriter = False
+                                start_time = None
+
+                            name = getattr(block, "name", "tool") or "tool"
+                            tool_id = getattr(block, "id", None)
+                            tmsg = await self._safe_send(f"⚙️ Running: `{name}`…")
+                            if tmsg is not None and tool_id:
+                                tool_msgs[tool_id] = (tmsg, name)
+
+                        elif isinstance(block, ToolResultBlock):
+                            tool_id = getattr(block, "tool_use_id", None)
+                            if tool_id and tool_id in tool_msgs:
+                                tmsg, name = tool_msgs[tool_id]
+                                is_err = bool(getattr(block, "is_error", False))
+                                if is_err:
+                                    await self._safe_edit(
+                                        tmsg, f"❌ `{name}` failed"
+                                    )
+                                else:
+                                    await self._safe_edit(tmsg, f"✅ `{name}`")
+        except Exception as exc:
+            log.exception("ClaudeBridge stream failed")
+            # Best-effort: clean up the live cursor and report the error.
+            if live_msg is not None:
+                await self._safe_edit(live_msg, buffer[:DISCORD_MAX_LEN] or "…")
+            await self._safe_send(f"Error talking to Claude: `{exc}`")
+            return
+
+        # Stream finished cleanly. Flush whatever is left.
+        await self._flush(live_msg, buffer, typewriter, saw_text, tool_msgs)
+
+    # ------------------------------------------------------------------
+    # Streaming helpers
+    # ------------------------------------------------------------------
+
+    async def _typewriter_tick(
+        self, live_msg: discord.Message | None, buffer: str
+    ) -> tuple[discord.Message | None, str]:
+        """Update (or create) the live typewriter message.
+
+        If ``buffer`` still fits in one Discord message we just edit/send it
+        with a trailing cursor. If it doesn't, we finalize the current
+        message with the first smart-split chunk and start a new live
+        message containing the remainder + cursor. Returns the (possibly
+        new) live message and the (possibly truncated) live buffer.
+        """
+        # Reserve room for the cursor.
+        soft_limit = DISCORD_MAX_LEN - len(CURSOR)
+
+        if len(buffer) <= soft_limit:
+            content = buffer + CURSOR
+            if live_msg is None:
+                live_msg = await self._safe_send(content)
+            else:
+                await self._safe_edit(live_msg, content)
+            return live_msg, buffer
+
+        # Buffer too big for one message — split it.
+        chunks = self._smart_split(buffer, limit=soft_limit)
+        if not chunks:  # pragma: no cover - defensive
+            return live_msg, buffer
+
+        first, *middle_and_last = chunks
+        # Finalize the current live message with the first chunk (no cursor).
+        if live_msg is None:
+            live_msg = await self._safe_send(first)
+        else:
+            await self._safe_edit(live_msg, first)
+
+        # Any middle chunks are sent as their own messages with no cursor.
+        for mid in middle_and_last[:-1]:
+            await self._safe_send(mid)
+
+        # The last chunk becomes the new live buffer with a fresh cursor message.
+        tail = middle_and_last[-1] if middle_and_last else ""
+        new_live = await self._safe_send(tail + CURSOR) if tail else None
+        return new_live, tail
+
+    async def _finalize_typewriter(
+        self, live_msg: discord.Message, buffer: str
+    ) -> None:
+        """Replace the cursor in ``live_msg`` and emit any overflow as new messages."""
+        if len(buffer) <= DISCORD_MAX_LEN:
+            await self._safe_edit(live_msg, buffer)
+            return
+
+        chunks = self._smart_split(buffer, limit=DISCORD_MAX_LEN)
+        if not chunks:  # pragma: no cover - defensive
+            await self._safe_edit(live_msg, buffer[:DISCORD_MAX_LEN])
+            return
+
+        await self._safe_edit(live_msg, chunks[0])
+        for chunk in chunks[1:]:
+            await self._safe_send(chunk)
+
+    async def _flush(
+        self,
+        live_msg: discord.Message | None,
+        buffer: str,
+        typewriter: bool,
+        saw_text: bool,
+        tool_msgs: dict[str, tuple[discord.Message, str]],
+    ) -> None:
+        """Send any remaining text once the stream completes."""
+        if typewriter and live_msg is not None:
+            await self._finalize_typewriter(live_msg, buffer)
+            return
+
+        if buffer:
+            for chunk in self._smart_split(buffer, limit=DISCORD_MAX_LEN):
+                await self._safe_send(chunk)
+            return
+
+        # No text buffered. If we never showed *anything* (no text, no tools),
+        # leave a placeholder so the user knows the round-trip finished.
+        if not saw_text and not tool_msgs:
+            await self._safe_send("(Claude returned no text response)")
+
+    # ------------------------------------------------------------------
+    # Discord I/O wrappers
+    # ------------------------------------------------------------------
+
+    async def _safe_send(self, content: str) -> discord.Message | None:
+        """Send a message, swallowing transient HTTP errors with a short backoff."""
+        if not content:
+            return None
+        try:
+            return await self.target.send(content)
+        except discord.HTTPException:
+            log.warning("Discord send failed; backing off and retrying once")
+            await asyncio.sleep(HTTP_BACKOFF_SECONDS)
+            try:
+                return await self.target.send(content)
+            except discord.HTTPException:
+                log.exception("Discord send failed after retry; dropping content")
+                return None
+
+    async def _safe_edit(self, msg: discord.Message, content: str) -> None:
+        """Edit a message, swallowing transient HTTP errors with a short backoff."""
+        try:
+            await msg.edit(content=content)
+            return
+        except discord.HTTPException:
+            log.debug("Discord edit failed; backing off and retrying once")
+            await asyncio.sleep(HTTP_BACKOFF_SECONDS)
+            try:
+                await msg.edit(content=content)
+            except discord.HTTPException:
+                log.warning("Discord edit failed after retry; dropping update")
+
+    # ------------------------------------------------------------------
+    # Smart splitting
+    # ------------------------------------------------------------------
+
+    def _smart_split(self, text: str, limit: int = DISCORD_MAX_LEN) -> list[str]:
+        """Split ``text`` into <= ``limit``-char chunks.
+
+        Preference order for split points: paragraph (``\\n\\n``) > line
+        (``\\n``) > space > hard cut. If a chunk would leave an unclosed
+        triple-backtick code fence, we close it with ``\\n```\\n`` and
+        reopen the next chunk with ``\\n```\\n`` so each rendered Discord
+        message is syntactically self-contained.
+        """
+        if not text:
+            return []
+        if len(text) <= limit:
+            return [text]
+
+        chunks: list[str] = []
+        remaining = text
+        # Reserve a few chars for a possible "\n```" close fence.
+        fence_reserve = len("\n```")
+
+        while len(remaining) > limit:
+            cut = self._find_cut(remaining, limit - fence_reserve)
+            chunk = remaining[:cut]
+            tail = remaining[cut:]
+            # Strip a leading newline that we just split on.
+            if tail.startswith("\n"):
+                tail = tail.lstrip("\n")
+
+            # If the chunk leaves an unclosed code fence, close it here and
+            # reopen at the start of the next chunk so syntax highlighting
+            # doesn't bleed across messages.
+            if chunk.count("```") % 2 == 1:
+                # Try to detect the language tag of the open fence so we can
+                # reopen with the same one.
+                lang = self._detect_open_fence_lang(chunk)
+                chunk = chunk.rstrip() + "\n```"
+                tail = f"```{lang}\n" + tail
+
+            chunks.append(chunk)
+            remaining = tail
+
+        if remaining:
+            chunks.append(remaining)
+        return chunks
+
+    @staticmethod
+    def _find_cut(text: str, limit: int) -> int:
+        """Return a "good" cut index <= ``limit``.
+
+        Tries paragraph break, then line, then space, then a hard cut.
+        Cuts are required to be at least ~half the limit so we don't
+        produce tiny chunks just because the first paragraph is short.
+        """
+        if len(text) <= limit:
+            return len(text)
+
+        # Discord splits the text immediately after the cut, so
+        # ``rfind`` returns the index of the separator; we cut *after* it
+        # for "\n\n"/"\n" so the newline ends the previous chunk.
+        floor = max(1, limit // 2)
+
+        para = text.rfind("\n\n", 0, limit)
+        if para >= floor:
+            return para + 2
+
+        line = text.rfind("\n", 0, limit)
+        if line >= floor:
+            return line + 1
+
+        space = text.rfind(" ", 0, limit)
+        if space >= floor:
+            return space + 1
+
+        return limit
+
+    @staticmethod
+    def _detect_open_fence_lang(chunk: str) -> str:
+        """Return the language tag of the *open* fence in ``chunk`` (or "")."""
+        # Find the last ``` that opens a fence (i.e. an odd-indexed one).
+        idx = -1
+        cursor = 0
+        opens = 0
+        while True:
+            pos = chunk.find("```", cursor)
+            if pos < 0:
+                break
+            opens += 1
+            if opens % 2 == 1:
+                idx = pos
+            cursor = pos + 3
+        if idx < 0:
+            return ""
+        # Read up to the next newline as the language tag.
+        nl = chunk.find("\n", idx + 3)
+        if nl < 0:
+            return chunk[idx + 3 :].strip()
+        return chunk[idx + 3 : nl].strip()
+
+
+__all__ = ["DiscordRenderer"]

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -251,6 +251,15 @@ class DiscordRenderer:
             return None
         try:
             return await self.target.send(content)
+        except discord.RateLimited as exc:
+            retry = max(HTTP_BACKOFF_SECONDS, float(getattr(exc, "retry_after", 1.0)))
+            log.warning("Discord send rate-limited; sleeping %.2fs", retry)
+            await asyncio.sleep(retry)
+            try:
+                return await self.target.send(content)
+            except discord.HTTPException:
+                log.exception("Discord send failed after rate-limit backoff; dropping")
+                return None
         except discord.HTTPException:
             log.warning("Discord send failed; backing off and retrying once")
             await asyncio.sleep(HTTP_BACKOFF_SECONDS)
@@ -265,6 +274,14 @@ class DiscordRenderer:
         try:
             await msg.edit(content=content)
             return
+        except discord.RateLimited as exc:
+            retry = max(HTTP_BACKOFF_SECONDS, float(getattr(exc, "retry_after", 1.0)))
+            log.debug("Discord edit rate-limited; sleeping %.2fs", retry)
+            await asyncio.sleep(retry)
+            try:
+                await msg.edit(content=content)
+            except discord.HTTPException:
+                log.warning("Discord edit failed after rate-limit backoff; dropping")
         except discord.HTTPException:
             log.debug("Discord edit failed; backing off and retrying once")
             await asyncio.sleep(HTTP_BACKOFF_SECONDS)

--- a/src/clauded/interaction_handler.py
+++ b/src/clauded/interaction_handler.py
@@ -1,0 +1,315 @@
+"""Bridge ``AskUserQuestion`` tool calls to Discord buttons / select menus.
+
+When Claude (running inside a :class:`ClaudeBridge` session) invokes the
+``AskUserQuestion`` tool, the SDK's ``can_use_tool`` callback delegates to
+:meth:`InteractionHandler.handle_ask_user_question`. This class renders the
+question(s) as Discord interactive components in the bound thread, awaits the
+user's click, and returns an ``updated_input`` dict that augments the original
+tool input with an ``answers`` field — that becomes the ``updated_input`` of a
+``PermissionResultAllow`` returned to the SDK.
+
+UI rules:
+* single-select, ≤ 4 options → row of buttons
+* multi-select OR > 4 options → select menu (capped at Discord's 25 options)
+
+A single ``AskUserQuestion`` invocation may carry multiple sub-questions; they
+are asked one at a time, in order. If the user fails to answer any of them
+within :data:`DEFAULT_TIMEOUT_SECONDS`, the whole interaction returns ``None``
+and the bridge denies the tool call with a timeout message.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import discord
+
+log = logging.getLogger("clauded.interaction_handler")
+
+# Default time we will wait for the user to answer a single sub-question
+# before timing out and denying the AskUserQuestion tool call.
+DEFAULT_TIMEOUT_SECONDS = 300.0
+
+# Discord-imposed limits we respect when building components.
+_DISCORD_BUTTON_LABEL_MAX = 80
+_DISCORD_SELECT_LABEL_MAX = 100
+_DISCORD_SELECT_DESC_MAX = 100
+_DISCORD_SELECT_MAX_OPTIONS = 25
+_DISCORD_EMBED_DESC_MAX = 4000
+
+
+class InteractionHandler:
+    """Render ``AskUserQuestion`` calls into Discord UI in a single thread."""
+
+    def __init__(
+        self,
+        thread: discord.abc.Messageable,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self.thread = thread
+        self.timeout = timeout
+
+    # ------------------------------------------------------------------
+    # Entry point used as the ``on_ask_user`` callback by ClaudeBridge.
+    # ------------------------------------------------------------------
+
+    async def handle_ask_user_question(
+        self, tool_input: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """Drive a Discord UI for an ``AskUserQuestion`` tool call.
+
+        Returns the ``updated_input`` to pass back to the SDK on success
+        (a copy of ``tool_input`` with an additional ``answers`` field), or
+        ``None`` if the user did not respond in time / the input was empty.
+        """
+        questions = tool_input.get("questions") or []
+        if not questions:
+            log.warning("AskUserQuestion called with no questions; denying")
+            return None
+
+        answers: dict[str, Any] = {}
+        for q in questions:
+            if not isinstance(q, dict):
+                continue
+            q_text = str(q.get("question") or "").strip()
+            header = str(q.get("header") or "Question").strip() or "Question"
+            options = q.get("options") or []
+            multi_select = bool(q.get("multiSelect", False))
+
+            if not options:
+                # No choices to render → skip silently.
+                continue
+
+            answer = await self._ask_one(q_text, header, options, multi_select)
+            if answer is None:
+                log.info("AskUserQuestion timed out waiting for user")
+                return None
+            # Key answers by question text so the tool can correlate them.
+            answers[q_text or header] = answer
+
+        if not answers:
+            return None
+        return {**tool_input, "answers": answers}
+
+    # ------------------------------------------------------------------
+    # Per-question rendering
+    # ------------------------------------------------------------------
+
+    async def _ask_one(
+        self,
+        question_text: str,
+        header: str,
+        options: list[dict[str, Any]],
+        multi_select: bool,
+    ) -> Any:
+        """Show one sub-question and return the user's selection."""
+        labels = [
+            str(opt.get("label") or f"Option {i + 1}") for i, opt in enumerate(options)
+        ]
+        descriptions = [str(opt.get("description") or "") for opt in options]
+
+        use_buttons = (not multi_select) and len(options) <= 4
+        if use_buttons:
+            view: _BaseAskView = AskButtonView(labels, timeout=self.timeout)
+        else:
+            view = AskSelectView(
+                labels, descriptions, multi_select=multi_select, timeout=self.timeout
+            )
+
+        embed = discord.Embed(
+            title=f"❓ {header}"[:256],
+            description=_render_question_body(question_text, options),
+        )
+
+        try:
+            msg = await self.thread.send(embed=embed, view=view)
+        except discord.HTTPException:
+            log.exception("Failed to send AskUserQuestion UI to thread")
+            return None
+
+        try:
+            indices = await view.wait_for_result()
+        finally:
+            for item in view.children:
+                # Both Buttons and Selects expose ``.disabled``.
+                setattr(item, "disabled", True)
+            try:
+                await msg.edit(view=view)
+            except discord.HTTPException:
+                log.debug("Could not disable AskUserQuestion view (already gone)")
+
+        if not indices:
+            return None
+        if multi_select:
+            return [labels[i] for i in indices if 0 <= i < len(labels)]
+        first = indices[0]
+        if 0 <= first < len(labels):
+            return labels[first]
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _render_question_body(question: str, options: list[dict[str, Any]]) -> str:
+    """Render question + per-option descriptions as the embed body."""
+    parts: list[str] = []
+    if question:
+        parts.append(question)
+    bullet_lines: list[str] = []
+    for i, opt in enumerate(options):
+        label = str(opt.get("label") or f"Option {i + 1}")
+        desc = str(opt.get("description") or "").strip()
+        if desc:
+            bullet_lines.append(f"• **{label}** — {desc}")
+        else:
+            bullet_lines.append(f"• **{label}**")
+    if bullet_lines:
+        if parts:
+            parts.append("")
+        parts.extend(bullet_lines)
+    body = "\n".join(parts)
+    return body[:_DISCORD_EMBED_DESC_MAX] or "\u200b"
+
+
+# ---------------------------------------------------------------------------
+# Discord UI views
+# ---------------------------------------------------------------------------
+
+
+class _BaseAskView(discord.ui.View):
+    """Common future-resolution scaffolding shared by button/select views."""
+
+    def __init__(self, *, timeout: float) -> None:
+        super().__init__(timeout=timeout)
+        self._result_future: asyncio.Future[list[int] | None] = (
+            asyncio.get_running_loop().create_future()
+        )
+
+    async def wait_for_result(self) -> list[int] | None:
+        """Block until the user picks (or the view times out)."""
+        try:
+            return await self._result_future
+        except asyncio.CancelledError:
+            return None
+
+    async def on_timeout(self) -> None:  # type: ignore[override]
+        if not self._result_future.done():
+            self._result_future.set_result(None)
+
+    def _resolve(self, indices: list[int]) -> None:
+        if not self._result_future.done():
+            self._result_future.set_result(indices)
+        self.stop()
+
+
+class AskButtonView(_BaseAskView):
+    """Single-select view: renders ≤ 4 button options."""
+
+    def __init__(self, labels: list[str], timeout: float = DEFAULT_TIMEOUT_SECONDS):
+        super().__init__(timeout=timeout)
+        for i, label in enumerate(labels[:4]):
+            style = (
+                discord.ButtonStyle.primary
+                if i == 0
+                else discord.ButtonStyle.secondary
+            )
+            self.add_item(_AskButton(label=label, style=style, option_index=i))
+
+
+class _AskButton(discord.ui.Button):
+    def __init__(
+        self, *, label: str, style: discord.ButtonStyle, option_index: int
+    ) -> None:
+        super().__init__(
+            label=(label[:_DISCORD_BUTTON_LABEL_MAX] or "?"),
+            style=style,
+            custom_id=f"clauded_ask_btn_{option_index}",
+        )
+        self.option_index = option_index
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        # ``self.view`` is set by discord.py when the button is added to a view.
+        view = self.view
+        if isinstance(view, _BaseAskView):
+            view._resolve([self.option_index])
+        try:
+            await interaction.response.defer()
+        except discord.HTTPException:
+            log.debug("Failed to defer button interaction (already responded)")
+
+
+class AskSelectView(_BaseAskView):
+    """Select-menu view: used for > 4 options or when ``multiSelect`` is true."""
+
+    def __init__(
+        self,
+        labels: list[str],
+        descriptions: list[str],
+        *,
+        multi_select: bool,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        super().__init__(timeout=timeout)
+        capped = list(zip(labels, descriptions))[:_DISCORD_SELECT_MAX_OPTIONS]
+        select_options: list[discord.SelectOption] = []
+        for i, (label, desc) in enumerate(capped):
+            select_options.append(
+                discord.SelectOption(
+                    label=(label[:_DISCORD_SELECT_LABEL_MAX] or f"Option {i + 1}"),
+                    description=(desc[:_DISCORD_SELECT_DESC_MAX] if desc else None),
+                    value=str(i),
+                )
+            )
+        max_values = len(select_options) if multi_select else 1
+        self.add_item(
+            _AskSelect(
+                options=select_options,
+                min_values=1,
+                max_values=max_values,
+            )
+        )
+
+
+class _AskSelect(discord.ui.Select):
+    def __init__(
+        self,
+        *,
+        options: list[discord.SelectOption],
+        min_values: int,
+        max_values: int,
+    ) -> None:
+        super().__init__(
+            placeholder="Pick an option…",
+            min_values=min_values,
+            max_values=max_values,
+            options=options,
+            custom_id="clauded_ask_select",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        indices: list[int] = []
+        for value in self.values:
+            try:
+                indices.append(int(value))
+            except (TypeError, ValueError):
+                continue
+        if isinstance(view, _BaseAskView):
+            view._resolve(indices)
+        try:
+            await interaction.response.defer()
+        except discord.HTTPException:
+            log.debug("Failed to defer select interaction (already responded)")
+
+
+__all__ = [
+    "InteractionHandler",
+    "AskButtonView",
+    "AskSelectView",
+    "DEFAULT_TIMEOUT_SECONDS",
+]

--- a/src/clauded/project_manager.py
+++ b/src/clauded/project_manager.py
@@ -1,0 +1,84 @@
+"""Channel ↔ project-directory bindings, persisted to JSON.
+
+A `ProjectManager` maps Discord channel IDs to absolute filesystem paths.
+State is loaded from and saved to ``<data_dir>/projects.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Dict
+
+log = logging.getLogger("clauded.project_manager")
+
+
+class ProjectManager:
+    """Persisted store of channel-id → project-directory bindings."""
+
+    def __init__(self, data_dir: str = "data") -> None:
+        self.data_dir = data_dir
+        self.path = os.path.join(data_dir, "projects.json")
+        self._projects: Dict[str, Dict[str, str]] = {}
+        self._load()
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        if not os.path.isfile(self.path):
+            return
+        try:
+            with open(self.path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                self._projects = data
+        except (OSError, json.JSONDecodeError) as exc:
+            log.warning("Failed to load %s: %s — starting with empty state", self.path, exc)
+            self._projects = {}
+
+    def _save(self) -> None:
+        os.makedirs(self.data_dir, exist_ok=True)
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump(self._projects, f, indent=2, sort_keys=True)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def bind(self, channel_id: int, path: str) -> str:
+        """Bind ``channel_id`` to ``path``.
+
+        Expands ``~`` and validates the directory exists. Returns the
+        absolute, expanded path that was actually stored.
+
+        Raises:
+            ValueError: if the path does not point to an existing directory.
+        """
+        expanded = os.path.abspath(os.path.expanduser(path))
+        if not os.path.isdir(expanded):
+            raise ValueError(f"Not a directory: {expanded}")
+
+        self._projects[str(channel_id)] = {
+            "path": expanded,
+            "bound_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._save()
+        return expanded
+
+    def unbind(self, channel_id: int) -> bool:
+        """Remove the binding for ``channel_id``. Returns True if removed."""
+        if self._projects.pop(str(channel_id), None) is None:
+            return False
+        self._save()
+        return True
+
+    def get_project(self, channel_id: int) -> str | None:
+        """Return the bound path for ``channel_id``, or None if unbound."""
+        entry = self._projects.get(str(channel_id))
+        return entry["path"] if entry else None
+
+    def is_bound(self, channel_id: int) -> bool:
+        """Return True if ``channel_id`` has a binding."""
+        return str(channel_id) in self._projects

--- a/src/clauded/project_manager.py
+++ b/src/clauded/project_manager.py
@@ -79,6 +79,11 @@ class ProjectManager:
         entry = self._projects.get(str(channel_id))
         return entry["path"] if entry else None
 
+    # Alias used by callers that prefer the "path" terminology.
+    def get_path(self, channel_id: int) -> str | None:
+        """Alias of :meth:`get_project`."""
+        return self.get_project(channel_id)
+
     def is_bound(self, channel_id: int) -> bool:
         """Return True if ``channel_id`` has a binding."""
         return str(channel_id) in self._projects

--- a/src/clauded/session_manager.py
+++ b/src/clauded/session_manager.py
@@ -1,0 +1,56 @@
+"""In-memory registry of active Claude sessions, keyed by Discord thread id."""
+
+from __future__ import annotations
+
+import logging
+
+from .claude_bridge import ClaudeBridge
+from .config import Config
+
+log = logging.getLogger("clauded.session_manager")
+
+
+class SessionManager:
+    """Tracks one :class:`ClaudeBridge` per Discord thread."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[int, ClaudeBridge] = {}
+
+    async def create_session(
+        self, thread_id: int, project_path: str, config: Config
+    ) -> ClaudeBridge:
+        """Create, start, and register a new session for ``thread_id``.
+
+        If a session already exists for the thread it is stopped first so
+        we never leak a connected client.
+        """
+        existing = self._sessions.pop(thread_id, None)
+        if existing is not None:
+            log.info("Replacing existing session for thread=%s", thread_id)
+            await existing.stop()
+
+        bridge = ClaudeBridge(project_path=project_path, config=config)
+        await bridge.start()
+        self._sessions[thread_id] = bridge
+        log.info("Created session thread=%s cwd=%s", thread_id, project_path)
+        return bridge
+
+    def get_session(self, thread_id: int) -> ClaudeBridge | None:
+        """Return the live session for ``thread_id``, or ``None``."""
+        return self._sessions.get(thread_id)
+
+    async def stop_session(self, thread_id: int) -> bool:
+        """Stop and forget the session for ``thread_id``.
+
+        Returns ``True`` if a session was stopped, ``False`` if there was
+        nothing to stop.
+        """
+        bridge = self._sessions.pop(thread_id, None)
+        if bridge is None:
+            return False
+        await bridge.stop()
+        log.info("Stopped session thread=%s", thread_id)
+        return True
+
+
+__all__ = ["SessionManager"]

--- a/src/clauded/session_manager.py
+++ b/src/clauded/session_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from .claude_bridge import ClaudeBridge
+from .claude_bridge import ClaudeBridge, OnAskUser
 from .config import Config
 
 log = logging.getLogger("clauded.session_manager")
@@ -17,7 +17,11 @@ class SessionManager:
         self._sessions: dict[int, ClaudeBridge] = {}
 
     async def create_session(
-        self, thread_id: int, project_path: str, config: Config
+        self,
+        thread_id: int,
+        project_path: str,
+        config: Config,
+        on_ask_user: OnAskUser | None = None,
     ) -> ClaudeBridge:
         """Create, start, and register a new session for ``thread_id``.
 
@@ -29,7 +33,11 @@ class SessionManager:
             log.info("Replacing existing session for thread=%s", thread_id)
             await existing.stop()
 
-        bridge = ClaudeBridge(project_path=project_path, config=config)
+        bridge = ClaudeBridge(
+            project_path=project_path,
+            config=config,
+            on_ask_user=on_ask_user,
+        )
         await bridge.start()
         self._sessions[thread_id] = bridge
         log.info("Created session thread=%s cwd=%s", thread_id, project_path)


### PR DESCRIPTION
## Summary
- 项目骨架 + Discord Bot 入口（discord.py）
- ProjectManager：channel ↔ 本地目录绑定，JSON 持久化
- SessionManager + ClaudeBridge：thread ↔ ClaudeSDKClient 多轮对话
- DiscordRenderer：混合流式输出（<3s 等完，>3s 打字机），智能分片，工具状态提示
- InteractionHandler：AskUserQuestion → Discord Buttons/Select Menu
- 集成联调 + 错误处理 + 完整 README

Closes #1

## Subtasks
- [x] #2 — 项目骨架 + Bot 入口
- [x] #3 — ProjectManager
- [x] #4 — SessionManager + ClaudeBridge
- [x] #5 — DiscordRenderer
- [x] #6 — InteractionHandler
- [x] #7 — 集成联调 + README

## Test Plan
1. `pip install -e .`
2. 配置 `.env` 中的 `DISCORD_BOT_TOKEN`
3. `clauded` 启动 bot
4. `/project bind <path>` 绑定 channel
5. 在 channel 发消息验证自动创建 thread + Claude 回复

## PRD
See [docs/prd/discord-claude-bridge.md](docs/prd/discord-claude-bridge.md)