### PR TITLE
fix: address review round 1 findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,18 @@ DISCORD_BOT_TOKEN=your-bot-token-here
 # Claude model (sonnet, opus, haiku, or full model id). Optional, defaults to sonnet.
 CLAUDE_MODEL=sonnet
 
-# Claude permission mode (default, acceptEdits, plan, bypassPermissions). Defaults to bypassPermissions.
-CLAUDE_PERMISSION_MODE=bypassPermissions
+# Claude permission mode (default, acceptEdits, plan, bypassPermissions).
+# Defaults to "default" which prompts for risky tool calls.
+#
+# WARNING: "bypassPermissions" disables all tool-permission prompts and lets
+# Claude run any tool (including shell commands and file edits) without
+# confirmation. Anyone who can post in a bound Discord channel will be able to
+# trigger arbitrary code execution on this host. Only enable bypassPermissions
+# if every potential message author is fully trusted with shell access.
+CLAUDE_PERMISSION_MODE=default
+
+# Root directory under which `/project bind` paths must live. Optional,
+# defaults to the current user's home directory. Bindings that resolve outside
+# this root (including via symlinks) are rejected. Use this to prevent admins
+# from accidentally binding to e.g. `/etc` or another user's home.
+# CLAUDED_PROJECTS_ROOT=/home/youruser/projects

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -8,6 +8,9 @@ messages to a per-thread :class:`ClaudeBridge` session.
 from __future__ import annotations
 
 import logging
+import os
+import tempfile
+from pathlib import Path
 
 import discord
 from discord import app_commands
@@ -38,7 +41,7 @@ class ClaudedBot(commands.Bot):
         super().__init__(command_prefix="!", intents=_build_intents())
         self.config = config
         self.session_manager = SessionManager()
-        self.project_manager = ProjectManager()
+        self.project_manager = ProjectManager(projects_root=config.projects_root)
 
     async def setup_hook(self) -> None:
         """Register slash command groups and sync to Discord."""
@@ -96,7 +99,7 @@ class ClaudedBot(commands.Bot):
             log.warning("Bound channel %s is not a TextChannel; skipping", channel.id)
             return
 
-        thread_name = (message.content or "claude session")[:80] or "claude session"
+        thread_name = (message.content or "claude session")[:100] or "claude session"
         try:
             thread = await message.create_thread(name=thread_name)
         except discord.Forbidden:
@@ -132,14 +135,18 @@ class ClaudedBot(commands.Bot):
                 log.debug("Could not post session-start error to thread")
             return
 
+        user_text = await self._compose_user_text(message)
         renderer = DiscordRenderer(thread)
-        try:
-            await renderer.render_response(bridge, message.content)
-        except Exception:
-            log.exception("Renderer failed for thread=%s", thread.id)
-            # The bridge is likely in a bad state — drop it so the next
-            # message in this thread starts a fresh session.
-            await self.session_manager.stop_session(thread.id)
+        # Serialize against any concurrent message that lands in this brand-new
+        # thread (rare, but possible if Discord delivers events out of order).
+        async with self.session_manager.get_lock(thread.id):
+            await self._render_with_retry(
+                renderer=renderer,
+                bridge=bridge,
+                user_text=user_text,
+                thread=thread,
+                project_path=project_path,
+            )
 
     async def _handle_thread_message(
         self, message: discord.Message, parent_id: int
@@ -154,33 +161,139 @@ class ClaudedBot(commands.Bot):
             return
 
         thread_id = message.channel.id
-        bridge = self.session_manager.get_session(thread_id)
-        if bridge is None or not bridge.is_active:
-            try:
-                handler = InteractionHandler(message.channel)
-                bridge = await self.session_manager.create_session(
-                    thread_id,
-                    project_path,
-                    self.config,
-                    on_ask_user=handler.handle_ask_user_question,
-                )
-            except Exception as exc:
-                log.exception("Failed to start ClaudeBridge for thread=%s", thread_id)
+        # Acquire the per-thread lock for the entire send/render cycle so
+        # concurrent messages in the same thread are processed in order
+        # rather than racing each other into the SDK.
+        async with self.session_manager.get_lock(thread_id):
+            bridge = self.session_manager.get_session(thread_id)
+            if bridge is None or not bridge.is_active:
                 try:
-                    await message.channel.send(
-                        f"❌ Failed to start Claude session: `{exc}`"
+                    handler = InteractionHandler(message.channel)
+                    bridge = await self.session_manager.create_session(
+                        thread_id,
+                        project_path,
+                        self.config,
+                        on_ask_user=handler.handle_ask_user_question,
                     )
-                except discord.HTTPException:
-                    log.debug("Could not post session-start error to thread")
-                return
+                except Exception as exc:
+                    log.exception("Failed to start ClaudeBridge for thread=%s", thread_id)
+                    try:
+                        await message.channel.send(
+                            f"❌ Failed to start Claude session: `{exc}`"
+                        )
+                    except discord.HTTPException:
+                        log.debug("Could not post session-start error to thread")
+                    return
 
-        renderer = DiscordRenderer(message.channel)
+            user_text = await self._compose_user_text(message)
+            renderer = DiscordRenderer(message.channel)
+            await self._render_with_retry(
+                renderer=renderer,
+                bridge=bridge,
+                user_text=user_text,
+                thread=message.channel,
+                project_path=project_path,
+            )
+
+    # ------------------------------------------------------------------
+    # Helpers used by both channel- and thread-message handlers
+    # ------------------------------------------------------------------
+
+    async def _compose_user_text(self, message: discord.Message) -> str:
+        """Build the text prompt sent to Claude, including any attachments.
+
+        For each attachment we download it to a per-message temp directory
+        and prepend a line announcing the filename and on-disk path so
+        Claude can choose to ``Read`` it. The temp directory persists for
+        the life of the bot process — we don't try to clean it up here
+        because Claude may still be reading from it after this method
+        returns. Discord caps attachment size at 25MB on free guilds, so
+        the on-disk footprint is bounded.
+        """
+        text = message.content or ""
+        attachments = list(message.attachments or [])
+        if not attachments:
+            return text
+
+        tmp_dir = Path(tempfile.mkdtemp(prefix="clauded_att_"))
+        notes: list[str] = []
+        for att in attachments:
+            # Sanitize the filename: take the basename and drop anything that
+            # looks like path traversal. Discord already restricts these but
+            # better safe.
+            safe_name = os.path.basename(att.filename or "attachment")
+            if not safe_name or safe_name in ("", ".", ".."):
+                safe_name = f"attachment-{att.id}"
+            target = tmp_dir / safe_name
+            try:
+                await att.save(target)
+            except (discord.HTTPException, OSError):
+                log.exception("Failed to save attachment %s", safe_name)
+                continue
+            notes.append(f"User attached file: {safe_name} at {target}")
+
+        if not notes:
+            return text
+        # Prepend so Claude sees the file references before the user's prose.
+        prefix = "\n".join(notes)
+        return f"{prefix}\n\n{text}" if text else prefix
+
+    async def _render_with_retry(
+        self,
+        *,
+        renderer: DiscordRenderer,
+        bridge,  # ClaudeBridge — typed loosely to avoid an extra import
+        user_text: str,
+        thread: discord.abc.Messageable,
+        project_path: str,
+    ) -> None:
+        """Run ``renderer.render_response`` and surface a retry button on crash.
+
+        On exception we drop the (now-dead) bridge so the next message —
+        either via the retry button or a fresh user message — recreates a
+        clean session.
+        """
         try:
-            await renderer.render_response(bridge, message.content)
-        except Exception:
-            log.exception("Renderer failed for thread=%s", thread_id)
-            # Drop the dead bridge so the next message recreates it.
-            await self.session_manager.stop_session(thread_id)
+            await renderer.render_response(bridge, user_text)
+        except Exception as exc:
+            log.exception("Renderer failed; offering retry button")
+            thread_id = getattr(thread, "id", None)
+            if thread_id is not None:
+                await self.session_manager.stop_session(thread_id)
+
+            async def _on_retry() -> None:
+                # Re-acquire the lock so a manual click can't race with a
+                # follow-up message the user just typed.
+                if thread_id is None:
+                    return
+                async with self.session_manager.get_lock(thread_id):
+                    try:
+                        new_handler = InteractionHandler(thread)
+                        new_bridge = await self.session_manager.create_session(
+                            thread_id,
+                            project_path,
+                            self.config,
+                            on_ask_user=new_handler.handle_ask_user_question,
+                        )
+                    except Exception as start_exc:
+                        log.exception("Retry: failed to restart ClaudeBridge")
+                        try:
+                            await thread.send(
+                                f"❌ Retry failed to start session: `{start_exc}`"
+                            )
+                        except discord.HTTPException:
+                            log.debug("Retry: could not surface restart error")
+                        return
+                    new_renderer = DiscordRenderer(thread)
+                    await self._render_with_retry(
+                        renderer=new_renderer,
+                        bridge=new_bridge,
+                        user_text=user_text,
+                        thread=thread,
+                        project_path=project_path,
+                    )
+
+            await renderer.send_error_with_retry(exc, _on_retry)
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +303,13 @@ class ClaudedBot(commands.Bot):
 project_group = app_commands.Group(
     name="project",
     description="Manage channel ↔ project-directory bindings.",
+    # Restrict the entire /project group to guild administrators. Binding a
+    # channel to a directory effectively grants every poster shell access to
+    # that path (Claude can run tools); this is not a power we want to give
+    # to ordinary members. ``default_permissions`` is the slash-command
+    # equivalent of a permission gate — non-admins won't even see the
+    # commands in their picker.
+    default_permissions=discord.Permissions(administrator=True),
 )
 
 
@@ -302,9 +422,18 @@ async def session_info(interaction: discord.Interaction) -> None:
         bot.session_manager.get_session(thread_id) if thread_id is not None else None
     )
     if bridge is not None and bridge.is_active:
-        await interaction.response.send_message(
-            f"Session active — cwd `{bridge.project_path}`.", ephemeral=True
-        )
+        # Pull the running totals the bridge has been collecting from
+        # ResultMessage events. Defaults are sensible for a session that
+        # hasn't completed a turn yet.
+        model = bridge.model or bot.config.claude_model
+        cost_str = f"${bridge.total_cost:.4f}" if bridge.total_cost else "$0.0000"
+        lines = [
+            f"📡 **Session active** — cwd `{bridge.project_path}`",
+            f"• Model: `{model}`",
+            f"• Turns: `{bridge.num_turns}`",
+            f"• Total cost: `{cost_str}`",
+        ]
+        await interaction.response.send_message("\n".join(lines), ephemeral=True)
     else:
         await interaction.response.send_message(
             "No active Claude session in this thread.", ephemeral=True

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -58,6 +58,13 @@ class ClaudeBridge:
         self.on_ask_user = on_ask_user
         self._client: ClaudeSDKClient | None = None
         self._active = False
+        # Aggregate stats updated whenever we observe a ResultMessage. They
+        # are purely informational (surfaced via /session info) so the
+        # exact semantics — total cost across the session, last-known turn
+        # count and model — are good enough.
+        self.total_cost: float = 0.0
+        self.num_turns: int = 0
+        self.model: str | None = None
 
     @property
     def is_active(self) -> bool:
@@ -98,10 +105,26 @@ class ClaudeBridge:
         try:
             await self._client.query(text)
             async for msg in self._client.receive_response():
+                # Update session stats opportunistically — ResultMessage
+                # carries the per-turn totals from the SDK.
+                if isinstance(msg, ResultMessage):
+                    self._update_stats(msg)
                 yield msg
         except Exception:
             log.exception("Claude SDK stream failed; marking bridge inactive")
             self._active = False
+            # Best-effort: tear down the underlying client so we don't leak
+            # a half-broken connection. Swallow disconnect errors — the
+            # original exception is what callers care about.
+            client = self._client
+            self._client = None
+            if client is not None:
+                try:
+                    await client.disconnect()
+                except Exception:  # pragma: no cover - defensive
+                    log.exception(
+                        "Error disconnecting ClaudeSDKClient after stream failure"
+                    )
             raise
 
     async def stop(self) -> None:
@@ -120,6 +143,26 @@ class ClaudeBridge:
     # ------------------------------------------------------------------
     # SDK callbacks
     # ------------------------------------------------------------------
+
+    def _update_stats(self, msg: ResultMessage) -> None:
+        """Pull per-turn totals off a ``ResultMessage`` into instance state.
+
+        The Claude SDK exposes ``total_cost_usd``, ``num_turns`` and
+        ``model`` on ``ResultMessage``. We tolerate any of those being
+        missing — newer/older SDKs may rename fields, and we'd rather
+        surface partial stats than crash the stream.
+        """
+        cost = getattr(msg, "total_cost_usd", None)
+        if isinstance(cost, (int, float)):
+            # ResultMessage carries the cumulative cost of the whole
+            # conversation so we replace rather than accumulate.
+            self.total_cost = float(cost)
+        turns = getattr(msg, "num_turns", None)
+        if isinstance(turns, int):
+            self.num_turns = turns
+        model = getattr(msg, "model", None)
+        if isinstance(model, str) and model:
+            self.model = model
 
     async def _can_use_tool(
         self,

--- a/src/clauded/config.py
+++ b/src/clauded/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -15,6 +16,7 @@ class Config:
     discord_bot_token: str
     claude_model: str
     claude_permission_mode: str
+    projects_root: str
 
 
 def load_config() -> Config:
@@ -27,11 +29,18 @@ def load_config() -> Config:
             "DISCORD_BOT_TOKEN is not set. Copy .env.example to .env and fill it in."
         )
 
+    raw_root = os.environ.get("CLAUDED_PROJECTS_ROOT", "").strip()
+    if raw_root:
+        projects_root = str(Path(raw_root).expanduser().resolve())
+    else:
+        projects_root = str(Path.home().resolve())
+
     return Config(
         discord_bot_token=token,
         claude_model=os.environ.get("CLAUDE_MODEL", "sonnet").strip() or "sonnet",
         claude_permission_mode=(
-            os.environ.get("CLAUDE_PERMISSION_MODE", "bypassPermissions").strip()
-            or "bypassPermissions"
+            os.environ.get("CLAUDE_PERMISSION_MODE", "default").strip()
+            or "default"
         ),
+        projects_root=projects_root,
     )

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Awaitable, Callable
 
 import discord
 
@@ -143,13 +143,15 @@ class DiscordRenderer:
                                     )
                                 else:
                                     await self._safe_edit(tmsg, f"✅ `{name}`")
-        except Exception as exc:
+        except Exception:
             log.exception("ClaudeBridge stream failed")
-            # Best-effort: clean up the live cursor and report the error.
+            # Best-effort: clean up the live cursor. Don't try to surface a
+            # plain-text error here — callers (bot.py) wrap render_response
+            # in the crash-notification flow which posts a richer embed
+            # with a retry button. Re-raise so they can do so.
             if live_msg is not None:
                 await self._safe_edit(live_msg, buffer[:DISCORD_MAX_LEN] or "…")
-            await self._safe_send(f"Error talking to Claude: `{exc}`")
-            return
+            raise
 
         # Stream finished cleanly. Flush whatever is left.
         await self._flush(live_msg, buffer, typewriter, saw_text, tool_msgs)
@@ -391,5 +393,93 @@ class DiscordRenderer:
             return chunk[idx + 3 :].strip()
         return chunk[idx + 3 : nl].strip()
 
+    # ------------------------------------------------------------------
+    # Crash notification with retry
+    # ------------------------------------------------------------------
 
-__all__ = ["DiscordRenderer"]
+    async def send_error_with_retry(
+        self,
+        exc: BaseException,
+        on_retry: Callable[[], Awaitable[None]],
+    ) -> None:
+        """Post a crash embed with a 🔄 Retry button.
+
+        ``on_retry`` is invoked when the user clicks the button. It should
+        re-send the last user message through a fresh bridge; this class
+        does not know about sessions, so the wiring lives in the bot.
+        """
+        embed = discord.Embed(
+            title="❌ Claude session crashed",
+            description=(
+                "Something went wrong while talking to Claude. You can retry the "
+                "last message — a fresh session will be started for it.\n\n"
+                f"Error: `{exc}`"
+            )[:_RETRY_EMBED_DESC_MAX],
+            color=discord.Color.red(),
+        )
+        view = RetryView(on_retry=on_retry)
+        try:
+            await self.target.send(embed=embed, view=view)
+        except discord.HTTPException:
+            log.exception("Failed to post crash-with-retry embed")
+
+
+# ---------------------------------------------------------------------------
+# Retry view
+# ---------------------------------------------------------------------------
+
+
+_RETRY_EMBED_DESC_MAX = 4000
+_RETRY_TIMEOUT_SECONDS = 600.0
+
+
+class RetryView(discord.ui.View):
+    """View attached to a crash embed that re-runs the last user message."""
+
+    def __init__(
+        self,
+        *,
+        on_retry: Callable[[], Awaitable[None]],
+        timeout: float = _RETRY_TIMEOUT_SECONDS,
+    ) -> None:
+        super().__init__(timeout=timeout)
+        self._on_retry = on_retry
+        self._fired = False
+
+    @discord.ui.button(
+        label="Retry",
+        style=discord.ButtonStyle.primary,
+        emoji="🔄",
+        custom_id="clauded_retry_btn",
+    )
+    async def retry_button(  # type: ignore[override]
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        # Single-shot: disable the button immediately so a double-click
+        # doesn't queue two retries against the same dead session.
+        if self._fired:
+            try:
+                await interaction.response.defer()
+            except discord.HTTPException:
+                pass
+            return
+        self._fired = True
+        button.disabled = True
+        try:
+            await interaction.response.edit_message(view=self)
+        except discord.HTTPException:
+            try:
+                await interaction.response.defer()
+            except discord.HTTPException:
+                log.debug("Retry: failed to defer interaction")
+        try:
+            await self._on_retry()
+        except Exception:
+            log.exception("Retry callback raised")
+        finally:
+            self.stop()
+
+
+__all__ = ["DiscordRenderer", "RetryView"]

--- a/src/clauded/project_manager.py
+++ b/src/clauded/project_manager.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Dict
 
 log = logging.getLogger("clauded.project_manager")
@@ -18,9 +19,19 @@ log = logging.getLogger("clauded.project_manager")
 class ProjectManager:
     """Persisted store of channel-id → project-directory bindings."""
 
-    def __init__(self, data_dir: str = "data") -> None:
+    def __init__(
+        self,
+        data_dir: str = "data",
+        projects_root: str | None = None,
+    ) -> None:
         self.data_dir = data_dir
         self.path = os.path.join(data_dir, "projects.json")
+        # Path under which all bindings must live. Defaults to the user's
+        # home directory if not supplied. Stored as a fully-resolved Path so
+        # symlink-escapes are caught by the bind-time validation.
+        root = projects_root if projects_root is not None else str(Path.home())
+        self.projects_root: Path = Path(root).expanduser().resolve()
+        self._path = Path(self.path)
         self._projects: Dict[str, Dict[str, str]] = {}
         self._load()
 
@@ -41,8 +52,14 @@ class ProjectManager:
 
     def _save(self) -> None:
         os.makedirs(self.data_dir, exist_ok=True)
-        with open(self.path, "w", encoding="utf-8") as f:
+        # Atomic write: dump to a sibling .tmp file then rename, so a crash
+        # mid-write can't truncate the live projects.json.
+        tmp_path = self._path.with_suffix(".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
             json.dump(self._projects, f, indent=2, sort_keys=True)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, self._path)
 
     # ------------------------------------------------------------------
     # Public API
@@ -50,16 +67,48 @@ class ProjectManager:
     def bind(self, channel_id: int, path: str) -> str:
         """Bind ``channel_id`` to ``path``.
 
-        Expands ``~`` and validates the directory exists. Returns the
-        absolute, expanded path that was actually stored.
+        Expands ``~``, fully resolves symlinks, and validates that the
+        resulting absolute path is a directory living *under*
+        :attr:`projects_root`. Raw (unresolved) ``..`` components in the
+        user-supplied path are rejected outright.
+
+        Returns the absolute, resolved path that was actually stored.
 
         Raises:
-            ValueError: if the path does not point to an existing directory.
+            ValueError: if the path traverses out of the allowed root or
+                does not point to an existing directory.
         """
-        expanded = os.path.abspath(os.path.expanduser(path))
-        if not os.path.isdir(expanded):
-            raise ValueError(f"Not a directory: {expanded}")
+        if not isinstance(path, str) or not path.strip():
+            raise ValueError("Path must be a non-empty string.")
 
+        # Reject raw `..` traversal in the input. We also resolve symlinks
+        # below; this is a belt-and-braces check that catches sneaky inputs
+        # before they ever touch the filesystem.
+        raw_parts = Path(path).expanduser().parts
+        if any(part == ".." for part in raw_parts):
+            raise ValueError("Path may not contain '..' segments.")
+
+        try:
+            resolved = Path(path).expanduser().resolve(strict=True)
+        except FileNotFoundError as exc:
+            raise ValueError(f"Path does not exist: {path}") from exc
+        except OSError as exc:
+            raise ValueError(f"Could not resolve path: {exc}") from exc
+
+        if not resolved.is_dir():
+            raise ValueError(f"Not a directory: {resolved}")
+
+        # Confirm the resolved (symlink-followed) path stays under the
+        # configured root. ``Path.is_relative_to`` is available in 3.9+.
+        try:
+            resolved.relative_to(self.projects_root)
+        except ValueError as exc:
+            raise ValueError(
+                f"Path {resolved} is outside the allowed projects root "
+                f"{self.projects_root}."
+            ) from exc
+
+        expanded = str(resolved)
         self._projects[str(channel_id)] = {
             "path": expanded,
             "bound_at": datetime.now(timezone.utc).isoformat(),

--- a/src/clauded/session_manager.py
+++ b/src/clauded/session_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from .claude_bridge import ClaudeBridge, OnAskUser
@@ -15,6 +16,23 @@ class SessionManager:
 
     def __init__(self) -> None:
         self._sessions: dict[int, ClaudeBridge] = {}
+        # One asyncio.Lock per thread, used by callers to serialize message
+        # processing against the same Claude session. The lock outlives any
+        # single bridge so concurrent producers don't all race to (re)create
+        # a session in parallel.
+        self._locks: dict[int, asyncio.Lock] = {}
+
+    def get_lock(self, thread_id: int) -> asyncio.Lock:
+        """Return (creating if needed) the lock for ``thread_id``.
+
+        Callers should ``async with manager.get_lock(thread_id):`` around
+        any send/render cycle so messages in the same thread don't race.
+        """
+        lock = self._locks.get(thread_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[thread_id] = lock
+        return lock
 
     async def create_session(
         self,
@@ -40,6 +58,8 @@ class SessionManager:
         )
         await bridge.start()
         self._sessions[thread_id] = bridge
+        # Make sure a lock exists for this thread; future callers will reuse it.
+        self.get_lock(thread_id)
         log.info("Created session thread=%s cwd=%s", thread_id, project_path)
         return bridge
 
@@ -54,6 +74,9 @@ class SessionManager:
         nothing to stop.
         """
         bridge = self._sessions.pop(thread_id, None)
+        # Note: we deliberately keep the lock around. A retry handler or
+        # follow-up message may still want to serialize against the just-
+        # stopped session, and locks are cheap.
         if bridge is None:
             return False
         await bridge.stop()


### PR DESCRIPTION
## Summary

Addresses all critical and important findings from 7-perspective code review (round 1/3).

### Security Fixes
- **Path validation**: Added `CLAUDED_PROJECTS_ROOT` env var — `bind()` now rejects paths outside root, rejects `..` traversal and escaping symlinks
- **Default permission mode**: Changed from `bypassPermissions` to `default` — requires explicit opt-in for dangerous mode
- **Admin-only commands**: `/project` commands now require administrator permission

### Engineer Fixes
- **Per-thread asyncio.Lock**: Serializes `render_response` calls per thread — prevents concurrent message corruption
- **Atomic file writes**: `ProjectManager._save()` uses tmp + `os.replace` pattern
- **Resource cleanup**: `ClaudeBridge.send_message` exception handler now calls `disconnect()`

### Product Fixes
- **File attachment handling** (R3.2): Downloads attachments to temp dir, forwards paths to Claude
- **Crash notification** (R8.1): Error embed + 🔄 Retry button on Claude failures
- **Session stats** (R7.5): `/session info` now shows cost, turns, model
- **Thread name** (R2.2): Changed slice from `[:80]` to `[:100]`

## Review Context
See `.crew/discord-claude-bridge/reviews/round-1.md` for full review findings.