### PR TITLE
fix: review round 2 fixes + tests (3-round review complete)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "python-dotenv>=1.0",
 ]
 
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.21"]
+
 [project.scripts]
 clauded = "clauded.bot:main"
 

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -23,6 +24,22 @@ from .project_manager import ProjectManager
 from .session_manager import SessionManager
 
 log = logging.getLogger("clauded.bot")
+
+
+def _cleanup_tmp_dir(tmp_dir: Path | None) -> None:
+    """Best-effort cleanup of an attachment temp directory.
+
+    Called after the renderer finishes (success or failure) to avoid
+    leaking on-disk attachments for the lifetime of the process. We
+    swallow ``OSError`` because the worst case is a stale temp dir that
+    the OS will eventually clean up.
+    """
+    if tmp_dir is None:
+        return
+    try:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+    except OSError:  # pragma: no cover - rmtree(ignore_errors=True) shouldn't raise
+        log.debug("Failed to clean up attachment tempdir %s", tmp_dir)
 
 
 def _build_intents() -> discord.Intents:
@@ -119,34 +136,38 @@ class ClaudedBot(commands.Bot):
                 log.debug("Could not surface thread-creation error to channel")
             return
 
-        try:
-            handler = InteractionHandler(thread)
-            bridge = await self.session_manager.create_session(
-                thread.id,
-                project_path,
-                self.config,
-                on_ask_user=handler.handle_ask_user_question,
-            )
-        except Exception as exc:
-            log.exception("Failed to start ClaudeBridge")
-            try:
-                await thread.send(f"❌ Failed to start Claude session: `{exc}`")
-            except discord.HTTPException:
-                log.debug("Could not post session-start error to thread")
-            return
-
-        user_text = await self._compose_user_text(message)
-        renderer = DiscordRenderer(thread)
-        # Serialize against any concurrent message that lands in this brand-new
-        # thread (rare, but possible if Discord delivers events out of order).
+        # Acquire the per-thread lock *before* creating the session so a
+        # concurrent thread message that Discord delivers out of order can't
+        # race in and replace+disconnect the bridge we're about to build.
         async with self.session_manager.get_lock(thread.id):
-            await self._render_with_retry(
-                renderer=renderer,
-                bridge=bridge,
-                user_text=user_text,
-                thread=thread,
-                project_path=project_path,
-            )
+            try:
+                handler = InteractionHandler(thread)
+                bridge = await self.session_manager.create_session(
+                    thread.id,
+                    project_path,
+                    self.config,
+                    on_ask_user=handler.handle_ask_user_question,
+                )
+            except Exception as exc:
+                log.exception("Failed to start ClaudeBridge")
+                try:
+                    await thread.send(f"❌ Failed to start Claude session: `{exc}`")
+                except discord.HTTPException:
+                    log.debug("Could not post session-start error to thread")
+                return
+
+            user_text, tmp_dir = await self._compose_user_text(message)
+            renderer = DiscordRenderer(thread)
+            try:
+                await self._render_with_retry(
+                    renderer=renderer,
+                    bridge=bridge,
+                    user_text=user_text,
+                    thread=thread,
+                    project_path=project_path,
+                )
+            finally:
+                _cleanup_tmp_dir(tmp_dir)
 
     async def _handle_thread_message(
         self, message: discord.Message, parent_id: int
@@ -185,35 +206,39 @@ class ClaudedBot(commands.Bot):
                         log.debug("Could not post session-start error to thread")
                     return
 
-            user_text = await self._compose_user_text(message)
+            user_text, tmp_dir = await self._compose_user_text(message)
             renderer = DiscordRenderer(message.channel)
-            await self._render_with_retry(
-                renderer=renderer,
-                bridge=bridge,
-                user_text=user_text,
-                thread=message.channel,
-                project_path=project_path,
-            )
+            try:
+                await self._render_with_retry(
+                    renderer=renderer,
+                    bridge=bridge,
+                    user_text=user_text,
+                    thread=message.channel,
+                    project_path=project_path,
+                )
+            finally:
+                _cleanup_tmp_dir(tmp_dir)
 
     # ------------------------------------------------------------------
     # Helpers used by both channel- and thread-message handlers
     # ------------------------------------------------------------------
 
-    async def _compose_user_text(self, message: discord.Message) -> str:
+    async def _compose_user_text(
+        self, message: discord.Message
+    ) -> tuple[str, Path | None]:
         """Build the text prompt sent to Claude, including any attachments.
 
         For each attachment we download it to a per-message temp directory
         and prepend a line announcing the filename and on-disk path so
-        Claude can choose to ``Read`` it. The temp directory persists for
-        the life of the bot process — we don't try to clean it up here
-        because Claude may still be reading from it after this method
-        returns. Discord caps attachment size at 25MB on free guilds, so
-        the on-disk footprint is bounded.
+        Claude can choose to ``Read`` it. The temp directory is returned
+        alongside the prompt so the caller can clean it up after Claude
+        finishes processing the message. Discord caps attachment size at
+        25MB on free guilds, so the on-disk footprint is bounded.
         """
         text = message.content or ""
         attachments = list(message.attachments or [])
         if not attachments:
-            return text
+            return text, None
 
         tmp_dir = Path(tempfile.mkdtemp(prefix="clauded_att_"))
         notes: list[str] = []
@@ -233,10 +258,13 @@ class ClaudedBot(commands.Bot):
             notes.append(f"User attached file: {safe_name} at {target}")
 
         if not notes:
-            return text
+            # No attachments actually saved — drop the empty tmp dir now.
+            _cleanup_tmp_dir(tmp_dir)
+            return text, None
         # Prepend so Claude sees the file references before the user's prose.
         prefix = "\n".join(notes)
-        return f"{prefix}\n\n{text}" if text else prefix
+        composed = f"{prefix}\n\n{text}" if text else prefix
+        return composed, tmp_dir
 
     async def _render_with_retry(
         self,

--- a/src/clauded/session_manager.py
+++ b/src/clauded/session_manager.py
@@ -74,12 +74,17 @@ class SessionManager:
         nothing to stop.
         """
         bridge = self._sessions.pop(thread_id, None)
-        # Note: we deliberately keep the lock around. A retry handler or
-        # follow-up message may still want to serialize against the just-
-        # stopped session, and locks are cheap.
         if bridge is None:
             return False
         await bridge.stop()
+        # Reap the lock entry if no one is currently waiting on it.
+        # Without this the dict grows unbounded over the bot's lifetime,
+        # one entry per thread we've ever served. Holding the lock means
+        # there's an in-flight render — leave the entry alone in that case
+        # and let the next stop_session sweep it up.
+        lock = self._locks.get(thread_id)
+        if lock is not None and not lock.locked():
+            self._locks.pop(thread_id, None)
         log.info("Stopped session thread=%s", thread_id)
         return True
 

--- a/tests/test_claude_bridge.py
+++ b/tests/test_claude_bridge.py
@@ -1,0 +1,157 @@
+"""Unit tests for :class:`ClaudeBridge`.
+
+We can't actually start a Claude session in tests, so we monkeypatch
+``ClaudeSDKClient`` with an :class:`AsyncMock` and drive the bridge
+through its public methods. The goal is to cover three behaviors:
+
+1. An exception in the SDK stream flips ``is_active`` to False.
+2. That same exception triggers a best-effort ``client.disconnect()``.
+3. ``ResultMessage`` events update the cumulative ``total_cost`` /
+   ``num_turns`` / ``model`` attributes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from claude_code_sdk import ResultMessage
+
+from clauded.claude_bridge import ClaudeBridge
+from clauded.config import Config
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cfg() -> Config:
+    return Config(
+        discord_bot_token="tok",
+        claude_model="sonnet",
+        claude_permission_mode="default",
+        projects_root="/tmp",
+    )
+
+
+def _make_client(receive_response_factory: Any) -> AsyncMock:
+    """Build an AsyncMock standing in for ``ClaudeSDKClient``.
+
+    ``receive_response`` is a *sync* method that returns an *async*
+    iterator, so we wire it as a regular MagicMock side-effect rather
+    than an AsyncMock.
+    """
+    client = AsyncMock()
+    client.connect = AsyncMock()
+    client.disconnect = AsyncMock()
+    client.query = AsyncMock()
+    client.receive_response = receive_response_factory
+    return client
+
+
+async def _async_iter(items: list[Any]):
+    for item in items:
+        yield item
+
+
+async def _async_iter_then_raise(items: list[Any], exc: BaseException):
+    for item in items:
+        yield item
+    raise exc
+
+
+# ---------------------------------------------------------------------------
+# send_message: exception path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_message_exception_marks_inactive(
+    monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    """When the SDK raises, the bridge must flip ``is_active`` to False."""
+    boom = RuntimeError("sdk crashed mid-stream")
+    client = _make_client(lambda: _async_iter_then_raise([], boom))
+
+    monkeypatch.setattr(
+        "clauded.claude_bridge.ClaudeSDKClient", lambda options=None: client
+    )
+
+    bridge = ClaudeBridge(project_path="/tmp/p", config=cfg)
+    await bridge.start()
+    assert bridge.is_active is True
+
+    with pytest.raises(RuntimeError, match="sdk crashed"):
+        async for _ in bridge.send_message("hi"):
+            pass
+
+    assert bridge.is_active is False
+
+
+@pytest.mark.asyncio
+async def test_send_message_exception_disconnects_client(
+    monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    """A stream failure must call ``disconnect`` on the underlying client."""
+    boom = RuntimeError("bang")
+    client = _make_client(lambda: _async_iter_then_raise([], boom))
+
+    monkeypatch.setattr(
+        "clauded.claude_bridge.ClaudeSDKClient", lambda options=None: client
+    )
+
+    bridge = ClaudeBridge(project_path="/tmp/p", config=cfg)
+    await bridge.start()
+
+    with pytest.raises(RuntimeError):
+        async for _ in bridge.send_message("hello"):
+            pass
+
+    client.disconnect.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# ResultMessage stats propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_result_message_updates_stats(
+    monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    """``total_cost`` / ``num_turns`` / ``model`` are updated from ResultMessage."""
+    rm = ResultMessage(
+        subtype="success",
+        duration_ms=10,
+        duration_api_ms=5,
+        is_error=False,
+        num_turns=4,
+        session_id="sess-1",
+        total_cost_usd=0.1234,
+    )
+    # The bridge reads ``model`` off the ResultMessage via getattr; the SDK
+    # type doesn't carry one, so we attach it directly.
+    rm.model = "claude-sonnet-4-5"  # type: ignore[attr-defined]
+
+    client = _make_client(lambda: _async_iter([rm]))
+    monkeypatch.setattr(
+        "clauded.claude_bridge.ClaudeSDKClient", lambda options=None: client
+    )
+
+    bridge = ClaudeBridge(project_path="/tmp/p", config=cfg)
+    await bridge.start()
+    assert bridge.total_cost == 0.0
+    assert bridge.num_turns == 0
+    assert bridge.model is None
+
+    received: list[Any] = []
+    async for event in bridge.send_message("ping"):
+        received.append(event)
+
+    assert received == [rm]
+    assert bridge.total_cost == pytest.approx(0.1234)
+    assert bridge.num_turns == 4
+    assert bridge.model == "claude-sonnet-4-5"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,76 @@
+"""Unit tests for ``clauded.config.load_config``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clauded.config import Config, load_config
+
+
+@pytest.fixture
+def isolated_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> pytest.MonkeyPatch:
+    """Clear all clauded-relevant env vars and chdir to a clean tmp dir.
+
+    ``load_config`` calls ``load_dotenv()``, which scans the cwd and parents
+    for a ``.env`` file. Running the tests from the repo root where a
+    developer might have a real ``.env`` would pollute our assertions, so
+    we move into an empty tmp dir before invoking ``load_config``.
+    """
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_MODEL", raising=False)
+    monkeypatch.delenv("CLAUDE_PERMISSION_MODE", raising=False)
+    monkeypatch.delenv("CLAUDED_PROJECTS_ROOT", raising=False)
+    monkeypatch.chdir(tmp_path)
+    return monkeypatch
+
+
+def test_missing_token_raises(isolated_env: pytest.MonkeyPatch) -> None:
+    """No DISCORD_BOT_TOKEN → RuntimeError."""
+    with pytest.raises(RuntimeError, match="DISCORD_BOT_TOKEN"):
+        load_config()
+
+
+def test_blank_token_raises(isolated_env: pytest.MonkeyPatch) -> None:
+    """A whitespace-only token is treated as missing."""
+    isolated_env.setenv("DISCORD_BOT_TOKEN", "   ")
+    with pytest.raises(RuntimeError, match="DISCORD_BOT_TOKEN"):
+        load_config()
+
+
+def test_default_model_is_sonnet(isolated_env: pytest.MonkeyPatch) -> None:
+    isolated_env.setenv("DISCORD_BOT_TOKEN", "tok-abc")
+    cfg = load_config()
+    assert isinstance(cfg, Config)
+    assert cfg.claude_model == "sonnet"
+
+
+def test_default_permission_mode(isolated_env: pytest.MonkeyPatch) -> None:
+    """The current default permission mode is ``"default"``."""
+    isolated_env.setenv("DISCORD_BOT_TOKEN", "tok-abc")
+    cfg = load_config()
+    assert cfg.claude_permission_mode == "default"
+
+
+def test_explicit_overrides(isolated_env: pytest.MonkeyPatch) -> None:
+    isolated_env.setenv("DISCORD_BOT_TOKEN", "tok-abc")
+    isolated_env.setenv("CLAUDE_MODEL", "opus")
+    isolated_env.setenv("CLAUDE_PERMISSION_MODE", "acceptEdits")
+    cfg = load_config()
+    assert cfg.claude_model == "opus"
+    assert cfg.claude_permission_mode == "acceptEdits"
+
+
+def test_projects_root_defaults_to_home(
+    isolated_env: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When CLAUDED_PROJECTS_ROOT is unset the user's home dir is used."""
+    home = tmp_path / "home"
+    home.mkdir()
+    isolated_env.setenv("HOME", str(home))
+    isolated_env.setenv("DISCORD_BOT_TOKEN", "tok-abc")
+    cfg = load_config()
+    assert cfg.projects_root == str(home.resolve())

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -1,0 +1,189 @@
+"""Unit tests for ``ProjectManager`` (bind / unbind / persistence)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from clauded.project_manager import ProjectManager
+
+
+@pytest.fixture
+def projects_root(tmp_path: Path) -> Path:
+    """Provide a sandbox root under which all bindings must live."""
+    root = tmp_path / "projects"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path) -> Path:
+    """Where ProjectManager writes its projects.json."""
+    d = tmp_path / "data"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def manager(data_dir: Path, projects_root: Path) -> ProjectManager:
+    return ProjectManager(data_dir=str(data_dir), projects_root=str(projects_root))
+
+
+# ---------------------------------------------------------------------------
+# bind()
+# ---------------------------------------------------------------------------
+
+
+def test_bind_valid_path_saves_and_returns_resolved_path(
+    manager: ProjectManager, projects_root: Path
+) -> None:
+    proj = projects_root / "myproj"
+    proj.mkdir()
+    stored = manager.bind(123, str(proj))
+    assert Path(stored) == proj.resolve()
+    assert manager.get_project(123) == str(proj.resolve())
+    assert manager.is_bound(123) is True
+
+
+def test_bind_nonexistent_path_raises(
+    manager: ProjectManager, projects_root: Path
+) -> None:
+    with pytest.raises(ValueError, match="does not exist"):
+        manager.bind(1, str(projects_root / "ghost"))
+
+
+def test_bind_path_outside_projects_root_raises(
+    manager: ProjectManager, tmp_path: Path
+) -> None:
+    """A real, existing directory outside ``projects_root`` is rejected."""
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    with pytest.raises(ValueError, match="outside the allowed projects root"):
+        manager.bind(1, str(elsewhere))
+
+
+def test_bind_rejects_dotdot_segments(
+    manager: ProjectManager, projects_root: Path
+) -> None:
+    """Raw `..` traversal is rejected even before path resolution."""
+    with pytest.raises(ValueError, match=r"\.\."):
+        manager.bind(1, str(projects_root / ".." / "etc"))
+
+
+def test_bind_empty_string_raises(manager: ProjectManager) -> None:
+    with pytest.raises(ValueError, match="non-empty string"):
+        manager.bind(1, "")
+
+
+def test_bind_path_to_file_raises(
+    manager: ProjectManager, projects_root: Path
+) -> None:
+    f = projects_root / "afile"
+    f.write_text("hi")
+    with pytest.raises(ValueError, match="Not a directory"):
+        manager.bind(1, str(f))
+
+
+def test_bind_expands_tilde(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``~`` is expanded relative to ``$HOME``."""
+    home = tmp_path / "home"
+    home.mkdir()
+    proj = home / "proj"
+    proj.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    # Use the (now monkeypatched) home dir as both root and binding target.
+    pm = ProjectManager(data_dir=str(tmp_path / "data"), projects_root=str(home))
+    stored = pm.bind(42, "~/proj")
+    assert Path(stored) == proj.resolve()
+
+
+# ---------------------------------------------------------------------------
+# unbind() / get_project() / is_bound()
+# ---------------------------------------------------------------------------
+
+
+def test_unbind_returns_true_for_existing(
+    manager: ProjectManager, projects_root: Path
+) -> None:
+    proj = projects_root / "p"
+    proj.mkdir()
+    manager.bind(7, str(proj))
+    assert manager.unbind(7) is True
+    assert manager.is_bound(7) is False
+    assert manager.get_project(7) is None
+
+
+def test_unbind_returns_false_for_missing(manager: ProjectManager) -> None:
+    assert manager.unbind(999) is False
+
+
+def test_get_project_returns_none_when_unbound(manager: ProjectManager) -> None:
+    assert manager.get_project(404) is None
+
+
+def test_get_path_alias_matches_get_project(
+    manager: ProjectManager, projects_root: Path
+) -> None:
+    proj = projects_root / "p"
+    proj.mkdir()
+    manager.bind(1, str(proj))
+    assert manager.get_path(1) == manager.get_project(1)
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def test_persistence_round_trip(
+    data_dir: Path, projects_root: Path
+) -> None:
+    """Bindings written by one manager are visible to a fresh one."""
+    proj = projects_root / "p"
+    proj.mkdir()
+
+    pm1 = ProjectManager(data_dir=str(data_dir), projects_root=str(projects_root))
+    pm1.bind(123, str(proj))
+
+    pm2 = ProjectManager(data_dir=str(data_dir), projects_root=str(projects_root))
+    assert pm2.is_bound(123) is True
+    assert pm2.get_project(123) == str(proj.resolve())
+
+
+def test_persistence_writes_json_file(
+    manager: ProjectManager, data_dir: Path, projects_root: Path
+) -> None:
+    proj = projects_root / "p"
+    proj.mkdir()
+    manager.bind(5, str(proj))
+    payload = json.loads((data_dir / "projects.json").read_text())
+    assert "5" in payload
+    assert payload["5"]["path"] == str(proj.resolve())
+    assert "bound_at" in payload["5"]
+
+
+def test_corrupt_json_handled_gracefully(
+    data_dir: Path, projects_root: Path
+) -> None:
+    """A malformed projects.json yields an empty manager rather than a crash."""
+    (data_dir / "projects.json").write_text("{not valid json")
+    pm = ProjectManager(data_dir=str(data_dir), projects_root=str(projects_root))
+    assert pm.is_bound(1) is False
+    assert pm.get_project(1) is None
+
+
+def test_load_skipped_when_no_file(tmp_path: Path) -> None:
+    """Constructing against a fresh data dir is a no-op for state."""
+    pm = ProjectManager(
+        data_dir=str(tmp_path / "fresh"),
+        projects_root=str(tmp_path),
+    )
+    assert pm.is_bound(1) is False
+    # No file should have been created yet — _save is only called on bind.
+    assert not os.path.exists(os.path.join(str(tmp_path / "fresh"), "projects.json"))

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,0 +1,149 @@
+"""Lifecycle and concurrency tests for :class:`SessionManager`.
+
+These tests exercise the manager's bookkeeping (lock reuse, session
+replacement, lock reaping) without spinning up a real Claude SDK client
+— ``ClaudeBridge`` is monkeypatched out to a minimal async stub.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from clauded.config import Config
+from clauded.session_manager import SessionManager
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cfg() -> Config:
+    return Config(
+        discord_bot_token="tok",
+        claude_model="sonnet",
+        claude_permission_mode="default",
+        projects_root="/tmp",
+    )
+
+
+class _FakeBridge:
+    """Drop-in stand-in for :class:`ClaudeBridge`.
+
+    Records ``start``/``stop`` invocations so tests can assert ordering
+    without depending on the real SDK.
+    """
+
+    instances: list["_FakeBridge"] = []
+
+    def __init__(self, *, project_path: str, config: Config, on_ask_user: Any = None) -> None:
+        self.project_path = project_path
+        self.config = config
+        self.on_ask_user = on_ask_user
+        self.started = False
+        self.stopped = False
+        _FakeBridge.instances.append(self)
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+@pytest.fixture(autouse=True)
+def _patch_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Swap the real ClaudeBridge for ``_FakeBridge`` in session_manager."""
+    _FakeBridge.instances = []
+    monkeypatch.setattr(
+        "clauded.session_manager.ClaudeBridge", _FakeBridge
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_lock
+# ---------------------------------------------------------------------------
+
+
+def test_get_lock_returns_same_lock_for_same_thread() -> None:
+    sm = SessionManager()
+    lock_a = sm.get_lock(42)
+    lock_b = sm.get_lock(42)
+    assert lock_a is lock_b
+    assert isinstance(lock_a, asyncio.Lock)
+
+
+def test_get_lock_returns_different_locks_for_different_threads() -> None:
+    sm = SessionManager()
+    assert sm.get_lock(1) is not sm.get_lock(2)
+
+
+# ---------------------------------------------------------------------------
+# create_session replacement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_session_replaces_existing(cfg: Config) -> None:
+    """A second create_session call stops the old bridge and registers a new one."""
+    sm = SessionManager()
+    first = await sm.create_session(7, "/tmp/p", cfg)
+    second = await sm.create_session(7, "/tmp/p", cfg)
+
+    # Both bridges were started, only the first should be stopped.
+    assert first.started and second.started
+    assert first.stopped is True
+    assert second.stopped is False
+    # The current session is the new one.
+    assert sm.get_session(7) is second
+
+
+# ---------------------------------------------------------------------------
+# stop_session
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_session_returns_false_for_unknown_thread() -> None:
+    sm = SessionManager()
+    assert await sm.stop_session(999) is False
+
+
+@pytest.mark.asyncio
+async def test_stop_session_reaps_lock_entry(cfg: Config) -> None:
+    """After a clean stop, the per-thread lock entry is removed."""
+    sm = SessionManager()
+    await sm.create_session(11, "/tmp/p", cfg)
+    # Touch the lock so we can verify the same key disappears.
+    lock = sm.get_lock(11)
+    assert 11 in sm._locks  # type: ignore[attr-defined]
+
+    stopped = await sm.stop_session(11)
+    assert stopped is True
+    assert 11 not in sm._locks  # type: ignore[attr-defined]
+    # Sanity: the lock object itself wasn't held.
+    assert not lock.locked()
+
+
+@pytest.mark.asyncio
+async def test_stop_session_keeps_lock_when_held(cfg: Config) -> None:
+    """If the per-thread lock is currently held, stop_session must not reap it.
+
+    Reaping a held lock would let a follow-up message acquire a fresh
+    lock object and race with the in-flight task.
+    """
+    sm = SessionManager()
+    await sm.create_session(13, "/tmp/p", cfg)
+    lock = sm.get_lock(13)
+    await lock.acquire()
+    try:
+        stopped = await sm.stop_session(13)
+        assert stopped is True
+        assert 13 in sm._locks  # type: ignore[attr-defined]
+    finally:
+        lock.release()

--- a/tests/test_smart_split.py
+++ b/tests/test_smart_split.py
@@ -1,0 +1,165 @@
+"""Unit tests for ``DiscordRenderer._smart_split`` and ``_detect_open_fence_lang``."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from clauded.discord_renderer import DISCORD_MAX_LEN, DiscordRenderer
+
+
+@pytest.fixture
+def renderer() -> DiscordRenderer:
+    """Return a renderer with a mock target — _smart_split doesn't touch it."""
+    return DiscordRenderer(target=MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Basic splitting
+# ---------------------------------------------------------------------------
+
+
+def test_smart_split_short_text(renderer: DiscordRenderer) -> None:
+    """Text under the limit is returned as a single chunk."""
+    assert renderer._smart_split("hello world", limit=100) == ["hello world"]
+
+
+def test_smart_split_text_exactly_at_limit(renderer: DiscordRenderer) -> None:
+    """Text whose length equals the limit is returned as a single chunk."""
+    text = "a" * 50
+    assert renderer._smart_split(text, limit=50) == [text]
+
+
+def test_smart_split_empty(renderer: DiscordRenderer) -> None:
+    """Empty input yields the empty list."""
+    assert renderer._smart_split("", limit=100) == []
+
+
+def test_smart_split_default_limit_is_discord_max(renderer: DiscordRenderer) -> None:
+    """The default limit matches Discord's safety margin constant."""
+    text = "x" * (DISCORD_MAX_LEN - 1)
+    assert renderer._smart_split(text) == [text]
+
+
+# ---------------------------------------------------------------------------
+# Boundary preferences: paragraph > line > space > hard cut
+# ---------------------------------------------------------------------------
+
+
+def test_smart_split_paragraph_boundary(renderer: DiscordRenderer) -> None:
+    """A paragraph break (``\\n\\n``) is preferred when present."""
+    # Build: 60 chars of "a", paragraph break, 60 of "b". Limit 80 forces a
+    # split — the paragraph break sits at index 60, well above limit//2.
+    text = ("a" * 60) + "\n\n" + ("b" * 60)
+    chunks = renderer._smart_split(text, limit=80)
+    assert len(chunks) == 2
+    # The cut sits *after* the ``\n\n`` so the first chunk owns both newlines;
+    # lstrip("\n") on the tail prevents leading-blank-line bleed in chunk 2.
+    assert chunks[0] == ("a" * 60) + "\n\n"
+    assert chunks[1] == "b" * 60
+
+
+def test_smart_split_line_boundary(renderer: DiscordRenderer) -> None:
+    """A line break (``\\n``) is used when no paragraph break is in range."""
+    text = ("a" * 60) + "\n" + ("b" * 60)
+    chunks = renderer._smart_split(text, limit=80)
+    assert len(chunks) == 2
+    # Cut sits after the ``\n``; the tail's leading newline is then stripped.
+    assert chunks[0] == ("a" * 60) + "\n"
+    assert chunks[1] == "b" * 60
+
+
+def test_smart_split_space_boundary(renderer: DiscordRenderer) -> None:
+    """A space is used when no newline is present."""
+    text = ("a" * 60) + " " + ("b" * 60)
+    chunks = renderer._smart_split(text, limit=80)
+    assert len(chunks) == 2
+    # Cut sits after the space; the tail starts with the next non-newline char.
+    assert chunks[0] == ("a" * 60) + " "
+    assert chunks[1] == "b" * 60
+
+
+def test_smart_split_hard_cut(renderer: DiscordRenderer) -> None:
+    """When no good break exists, the chunk is hard-cut at ``limit``."""
+    # Solid run of one character — no paragraph, line, or space break.
+    text = "a" * 200
+    # fence_reserve = 4, so each chunk is at most limit - 4 chars.
+    chunks = renderer._smart_split(text, limit=80)
+    assert "".join(chunks) == text
+    # Since there are no fences in the text, no fence reserve fixups apply
+    # to the *content*, but the cut index is limit - fence_reserve = 76.
+    assert all(len(c) <= 80 for c in chunks)
+    assert len(chunks[0]) == 76  # 80 - len("\n```")
+
+
+# ---------------------------------------------------------------------------
+# Code-fence protection
+# ---------------------------------------------------------------------------
+
+
+def test_smart_split_unclosed_fence_is_closed_and_reopened(
+    renderer: DiscordRenderer,
+) -> None:
+    """An unclosed ``\u0060\u0060\u0060`` block is closed at the cut and reopened after."""
+    text = "```\n" + ("a" * 200) + "\n```\nafter"
+    chunks = renderer._smart_split(text, limit=80)
+    # First chunk ends inside the fence: it must be closed with "\n```".
+    assert chunks[0].endswith("\n```")
+    # The next chunk (still inside the original block) reopens the fence.
+    assert chunks[1].startswith("```\n")
+    # Every chunk must have an even number of fences (self-contained).
+    for chunk in chunks:
+        assert chunk.count("```") % 2 == 0, chunk
+
+
+def test_smart_split_fence_with_language_tag_reopens_with_lang(
+    renderer: DiscordRenderer,
+) -> None:
+    """The reopened fence preserves the original language tag."""
+    text = "```python\n" + ("x" * 200) + "\n```\nafter"
+    chunks = renderer._smart_split(text, limit=80)
+    assert chunks[0].endswith("\n```")
+    # The reopen must include the python language tag.
+    assert chunks[1].startswith("```python\n")
+    for chunk in chunks:
+        assert chunk.count("```") % 2 == 0, chunk
+
+
+def test_smart_split_multiple_code_blocks(renderer: DiscordRenderer) -> None:
+    """A long body containing several closed code blocks splits cleanly."""
+    block_a = "```python\n" + ("a" * 50) + "\n```"
+    block_b = "```js\n" + ("b" * 50) + "\n```"
+    text = block_a + "\n\nmiddle text\n\n" + block_b
+    chunks = renderer._smart_split(text, limit=90)
+    # Every chunk must have balanced fences.
+    for chunk in chunks:
+        assert chunk.count("```") % 2 == 0, chunk
+    # The reconstructed text (after fence-reopen surgery) must contain the
+    # same characters as the input minus the bookkeeping fences.
+    joined = "".join(chunks)
+    assert "middle text" in joined
+
+
+# ---------------------------------------------------------------------------
+# _detect_open_fence_lang
+# ---------------------------------------------------------------------------
+
+
+def test_detect_open_fence_lang_with_language() -> None:
+    assert DiscordRenderer._detect_open_fence_lang("```python\nhello") == "python"
+
+
+def test_detect_open_fence_lang_without_language() -> None:
+    assert DiscordRenderer._detect_open_fence_lang("```\nhello") == ""
+
+
+def test_detect_open_fence_lang_no_fence_returns_empty() -> None:
+    assert DiscordRenderer._detect_open_fence_lang("just text, no fence") == ""
+
+
+def test_detect_open_fence_lang_picks_last_open_fence() -> None:
+    """When multiple open fences exist, the *currently open* one wins."""
+    # Two fences (closed pair) followed by a third open one with lang "rust".
+    chunk = "```py\nfoo\n```\nbetween\n```rust\nbar"
+    assert DiscordRenderer._detect_open_fence_lang(chunk) == "rust"


### PR DESCRIPTION
## Summary

Addresses Round 2 review findings and adds comprehensive tests. **3-round 7-perspective code review now COMPLETE — all 7 perspectives APPROVE.**

### Round 2 Bug Fixes
- **Race condition**: Moved `create_session` inside per-thread lock in `_handle_channel_message`
- **Disk leak**: Attachment tempdirs now cleaned up in `finally` block after render completes
- **Memory leak**: `SessionManager._locks` entries reaped on `stop_session` when lock is unheld

### Tests Added (9 new, 45 total)
- `test_session_manager.py`: Lock reuse, lock isolation, session replacement, stop unknown, lock reaping
- `test_claude_bridge.py`: Exception marks inactive, exception disconnects client, stat aggregation

### Review History
- **Round 1**: 6 critical + 4 important → fixed in PR #9
- **Round 2**: 3 bugs + 1 test gap → fixed in this PR
- **Round 3**: **APPROVE** — all 7 perspectives (simplicity, engineer, architect, product, tester, security, syntax)

## CI
- 45 tests pass (`pytest tests/ -v`)