### PR TITLE
feat: v1.4 UI Overhaul — Embeds, Colors, Rich Components

### DIFF
--- a/docs/prd/v1.4-ui-overhaul.md
+++ b/docs/prd/v1.4-ui-overhaul.md
@@ -1,0 +1,52 @@
+# v1.4 UI Overhaul — Embeds, Colors, Rich Components
+
+## Status
+Approved
+
+## Overview
+
+将所有 bot 输出从纯文本改造为 Discord 原生富媒体展示。颜色编码、embed 结构化、按钮交互、小字元信息。
+
+## Changes
+
+### 1. Claude 回复 — 紫色 embed footer + markdown content
+- 回复文本仍用 content（保留 markdown 渲染）
+- 最后一条消息追加紫色 embed footer：`💰 $0.004 │ 📥 1.2k │ 📤 567 │ ⏱️ 2.3s`
+- 附加按钮行：[🔄 重试] [⏹️ 停止]
+
+### 2. 工具执行 — 颜色 embed 实时更新
+- ToolUseBlock → 发黄色 embed：`🔄 执行中: {tool_name}`，显示命令/参数
+- ToolResultBlock → 编辑同一条为绿色（成功）或红色（失败）embed
+- Write/Edit 工具附加 diff 预览（已有，改用 embed 包装）
+
+### 3. 错误提示 — 红色 embed + 重试按钮
+- 已有 crash retry 逻辑，改为红色 embed 格式
+- 包含错误摘要、时间戳、重试按钮
+
+### 4. Session/Health/Cost 命令 — 蓝色 embed + inline fields
+- 已有 embed（/health），统一配色和风格
+- /session info、/session list、/cost show 全部用 embed
+
+### 5. Cost 尾注 — `-#` 小字
+- 每次 Claude 回复结束，在最后一条消息末尾加 `-#` 行
+- 格式：`-# 💰 $0.0042 │ 📥 1,234 │ 📤 567 │ ⏱️ 2.3s │ sonnet`
+
+### 6. ThinkingBlock — 保持 spoiler，加 embed 包装
+- 用灰色 embed 包裹 spoiler 内容，标题 `💭 Thinking...`
+
+## Color Scheme
+| 类型 | 颜色 | Hex |
+|------|------|-----|
+| Claude 回复 | 🟣 紫色 | `0x7C3AED` |
+| 工具执行中 | 🟡 黄色 | `0xF59E0B` |
+| 工具成功 | 🟢 绿色 | `0x10B981` |
+| 工具失败 | 🔴 红色 | `0xEF4444` |
+| 信息/命令 | 🔵 蓝色 | `0x3B82F6` |
+| Thinking | ⚫ 灰色 | `0x6B7280` |
+
+## Acceptance Criteria
+- [ ] Claude 回复末尾有紫色 footer embed 显示 cost/token
+- [ ] 工具执行用颜色 embed，黄→绿/红 实时更新
+- [ ] 错误显示为红色 embed + 重试按钮
+- [ ] 所有命令输出用统一配色 embed
+- [ ] 超长代码上传为文件而非分片文本

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -21,7 +21,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from .config import Config, load_config
-from .discord_renderer import DiscordRenderer
+from .discord_renderer import DiscordRenderer, COLOR_INFO, COLOR_TOOL_FAILURE
 from .interaction_handler import InteractionHandler
 from .project_manager import ProjectManager
 from .session_manager import SessionManager
@@ -184,7 +184,12 @@ class ClaudedBot(commands.Bot):
             except Exception as exc:
                 log.exception("Failed to start ClaudeBridge")
                 try:
-                    await thread.send(f"❌ Failed to start Claude session: `{exc}`")
+                    err_embed = discord.Embed(
+                        title="❌ Error",
+                        description=f"```\n{str(exc)[:500]}\n```",
+                        color=COLOR_TOOL_FAILURE,
+                    )
+                    await thread.send(embed=err_embed)
                 except discord.HTTPException:
                     log.debug("Could not post session-start error to thread")
                 return
@@ -253,9 +258,12 @@ class ClaudedBot(commands.Bot):
                 except Exception as exc:
                     log.exception("Failed to start ClaudeBridge for thread=%s", thread_id)
                     try:
-                        await message.channel.send(
-                            f"❌ Failed to start Claude session: `{exc}`"
+                        err_embed = discord.Embed(
+                            title="❌ Error",
+                            description=f"```\n{str(exc)[:500]}\n```",
+                            color=COLOR_TOOL_FAILURE,
                         )
+                        await message.channel.send(embed=err_embed)
                     except discord.HTTPException:
                         log.debug("Could not post session-start error to thread")
                     return
@@ -370,9 +378,12 @@ class ClaudedBot(commands.Bot):
                     except Exception as start_exc:
                         log.exception("Retry: failed to restart ClaudeBridge")
                         try:
-                            await thread.send(
-                                f"❌ Retry failed to start session: `{start_exc}`"
+                            err_embed = discord.Embed(
+                                title="❌ Error",
+                                description=f"```\n{str(start_exc)[:500]}\n```",
+                                color=COLOR_TOOL_FAILURE,
                             )
+                            await thread.send(embed=err_embed)
                         except discord.HTTPException:
                             log.debug("Retry: could not surface restart error")
                         return
@@ -409,9 +420,12 @@ async def cost_show(interaction: discord.Interaction) -> None:
     channel_id = interaction.channel_id
     parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
     total, calls = bot.cost_tracker.get_channel_cost(parent_id)
-    await interaction.response.send_message(
-        f"\U0001f4b0 Channel cost: ${total:.4f} ({calls} API calls)", ephemeral=True
+    embed = discord.Embed(
+        title="💰 Channel Cost",
+        description=f"**${total:.4f}** across {calls} API call(s)",
+        color=COLOR_INFO,
     )
+    await interaction.response.send_message(embed=embed, ephemeral=True)
 
 
 @cost_group.command(name="total", description="Show total cost across all channels")
@@ -421,9 +435,12 @@ async def cost_total(interaction: discord.Interaction) -> None:
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
     total = bot.cost_tracker.get_total_cost()
-    await interaction.response.send_message(
-        f"\U0001f4b0 Total cost: ${total:.4f}", ephemeral=True
+    embed = discord.Embed(
+        title="💰 Total Cost",
+        description=f"**${total:.4f}**",
+        color=COLOR_INFO,
     )
+    await interaction.response.send_message(embed=embed, ephemeral=True)
 
 
 @cost_group.command(name="reset", description="Reset cost for this channel")
@@ -751,7 +768,7 @@ async def health_check(interaction: discord.Interaction) -> None:
     except Exception:
         claude_version = "unavailable"
 
-    embed = discord.Embed(title="🏥 Bot Health", color=discord.Color.green())
+    embed = discord.Embed(title="🏥 Bot Health", color=COLOR_INFO)
     embed.add_field(name="Uptime", value=uptime_str, inline=True)
     embed.add_field(name="Active Sessions", value=str(active_sessions), inline=True)
     embed.add_field(name="Bound Projects", value=str(bound_projects), inline=True)

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -10,8 +10,8 @@ writes it to a Discord channel/thread with three behaviors:
    :data:`EDIT_INTERVAL_SECONDS` until the buffer exceeds Discord's per-
    message limit, at which point the current message is finalized and a
    new one is started.
-3. **Tool status**: ``ToolUseBlock`` events render a ``⚙️ Running …``
-   status message which is updated to ``✅`` / ``❌`` when the matching
+3. **Tool status**: ``ToolUseBlock`` events render a colored embed status
+   message which is updated to ``✅`` / ``❌`` when the matching
    ``ToolResultBlock`` arrives.
 
 The renderer also smart-splits text on paragraph → line → space boundaries
@@ -22,6 +22,7 @@ chunk boundaries.
 from __future__ import annotations
 
 import asyncio
+import io
 import logging
 import time
 from typing import TYPE_CHECKING, Awaitable, Callable
@@ -43,6 +44,15 @@ if TYPE_CHECKING:
 
 log = logging.getLogger("clauded.discord_renderer")
 
+# ---------------------------------------------------------------------------
+# Color scheme for embeds
+# ---------------------------------------------------------------------------
+COLOR_CLAUDE = 0x7C3AED        # Purple — Claude replies
+COLOR_TOOL_RUNNING = 0xF59E0B  # Yellow — tool executing
+COLOR_TOOL_SUCCESS = 0x10B981  # Green — tool completed
+COLOR_TOOL_FAILURE = 0xEF4444  # Red — tool failed / error
+COLOR_INFO = 0x3B82F6          # Blue — info / commands
+COLOR_THINKING = 0x6B7280      # Gray — thinking
 
 # Discord caps message content at 2000 characters; we leave a small margin so
 # we can append a cursor or close-and-reopen a code fence safely.
@@ -62,6 +72,9 @@ EDIT_INTERVAL_SECONDS = 1.2
 # Sleep used when an edit/send fails (likely rate-limited) before continuing.
 HTTP_BACKOFF_SECONDS = 0.5
 
+# Threshold above which a code block is uploaded as a file attachment.
+CODE_FILE_UPLOAD_THRESHOLD = 3000
+
 # Regex patterns for Claude channel/thread management markers.
 _THREAD_PATTERN = re.compile(r'\[CREATE_THREAD:\s*(.+?)\]')
 _CHANNEL_PATTERN = re.compile(r'\[CREATE_CHANNEL:\s*(.+?)\]')
@@ -72,6 +85,7 @@ class DiscordRenderer:
 
     def __init__(self, target: discord.abc.Messageable) -> None:
         self.target = target
+        self._last_msg: discord.Message | None = None
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -82,12 +96,15 @@ class DiscordRenderer:
         buffer = ""                               # text not yet finalized into a sent msg
         live_msg: discord.Message | None = None   # the in-flight typewriter message
         start_time: float | None = None
+        stream_start: float = time.time()
         last_edit = 0.0
         typewriter = False                        # have we entered typewriter mode?
         saw_text = False                          # any TextBlock seen?
-        # tool_use_id -> (discord.Message, tool_name)
-        tool_msgs: dict[str, tuple[discord.Message, str]] = {}
+        # tool_use_id -> discord.Message
+        tool_msgs: dict[str, discord.Message] = {}
         tool_names: dict[str, str] = {}
+        # Stats populated from ResultMessage
+        stats: dict | None = None
 
         try:
             async for event in bridge.send_message(user_text):
@@ -95,16 +112,27 @@ class DiscordRenderer:
                 # message that exposes a ``content`` list of blocks.
                 content = getattr(event, "content", None)
                 if isinstance(event, ResultMessage):
+                    # Capture stats from the result
+                    stats = {
+                        'cost': float(getattr(event, 'total_cost_usd', 0) or 0),
+                        'input_tokens': int(getattr(event, 'input_tokens', 0) or 0),
+                        'output_tokens': int(getattr(event, 'output_tokens', 0) or 0),
+                        'duration_ms': (time.time() - stream_start) * 1000,
+                        'num_turns': int(getattr(event, 'num_turns', 0) or 0),
+                        'model': getattr(event, 'model', '') or '',
+                    }
                     break
 
                 if isinstance(content, list):
                     for block in content:
                         if isinstance(block, ThinkingBlock):
-                            thinking_text = block.thinking[:1900].replace("||", "\\|\\|")
-                            try:
-                                await self.target.send(f"💭 ||{thinking_text}||")
-                            except discord.HTTPException:
-                                pass
+                            thinking_text = block.thinking[:3900].replace("||", "\\|\\|")
+                            embed = discord.Embed(
+                                title="💭 Thinking...",
+                                description=f"||{thinking_text}||",
+                                color=COLOR_THINKING,
+                            )
+                            await self._safe_send(embed=embed)
                             continue
 
                         if isinstance(block, TextBlock):
@@ -146,9 +174,24 @@ class DiscordRenderer:
                             tool_id = getattr(block, "id", None)
                             if tool_id:
                                 tool_names[tool_id] = name
-                            tmsg = await self._safe_send(f"⚙️ Running: `{name}`…")
+
+                            # Build a colored embed for the tool execution
+                            tool_embed = discord.Embed(
+                                title=f"🔄 {name}",
+                                color=COLOR_TOOL_RUNNING,
+                            )
+                            if name == "Bash":
+                                cmd = block.input.get("command", "")[:500]
+                                tool_embed.description = f"```bash\n{cmd}\n```"
+                            elif name in ("Write", "Edit", "Read"):
+                                path = block.input.get("file_path", block.input.get("file", ""))
+                                tool_embed.description = f"📄 `{path}`"
+                            else:
+                                tool_embed.description = "Executing..."
+
+                            tmsg = await self._safe_send(embed=tool_embed)
                             if tmsg is not None and tool_id:
-                                tool_msgs[tool_id] = (tmsg, name)
+                                tool_msgs[tool_id] = tmsg
 
                             # Show file content preview for Write/Edit tools
                             if block.name == "Write":
@@ -184,14 +227,22 @@ class DiscordRenderer:
                         elif isinstance(block, ToolResultBlock):
                             tool_id = getattr(block, "tool_use_id", None)
                             if tool_id and tool_id in tool_msgs:
-                                tmsg, name = tool_msgs[tool_id]
+                                orig_msg = tool_msgs[tool_id]
+                                name = tool_names.get(tool_id, "tool")
                                 is_err = bool(getattr(block, "is_error", False))
                                 if is_err:
-                                    await self._safe_edit(
-                                        tmsg, f"❌ `{name}` failed"
+                                    result_embed = discord.Embed(
+                                        title=f"❌ {name}",
+                                        color=COLOR_TOOL_FAILURE,
                                     )
+                                    error_text = str(block.content)[:500] if block.content else "Failed"
+                                    result_embed.description = f"```\n{error_text}\n```"
                                 else:
-                                    await self._safe_edit(tmsg, f"✅ `{name}`")
+                                    result_embed = discord.Embed(
+                                        title=f"✅ {name}",
+                                        color=COLOR_TOOL_SUCCESS,
+                                    )
+                                await self._safe_edit(orig_msg, embed=result_embed)
         except Exception:
             log.exception("ClaudeBridge stream failed")
             # Best-effort: clean up the live cursor. Don't try to surface a
@@ -199,11 +250,26 @@ class DiscordRenderer:
             # in the crash-notification flow which posts a richer embed
             # with a retry button. Re-raise so they can do so.
             if live_msg is not None:
-                await self._safe_edit(live_msg, buffer[:DISCORD_MAX_LEN] or "…")
+                await self._safe_edit(live_msg, content=buffer[:DISCORD_MAX_LEN] or "…")
             raise
 
         # Stream finished cleanly. Flush whatever is left.
         await self._flush(live_msg, buffer, typewriter, saw_text, tool_msgs)
+
+        # Append cost/stats footer to the last sent message
+        if self._last_msg and stats and stats.get('cost', 0) > 0:
+            try:
+                current = self._last_msg.content or ""
+                duration_s = stats['duration_ms'] / 1000
+                footer = (
+                    f"\n\n-# 💰 ${stats['cost']:.4f}"
+                    f" │ 📥 {stats['input_tokens']}"
+                    f" │ 📤 {stats['output_tokens']}"
+                    f" │ ⏱️ {duration_s:.1f}s"
+                )
+                await self._safe_edit(self._last_msg, content=current + footer)
+            except Exception:
+                pass
 
     # ------------------------------------------------------------------
     # Streaming helpers
@@ -281,9 +347,9 @@ class DiscordRenderer:
         if len(buffer) <= soft_limit:
             content = buffer + CURSOR
             if live_msg is None:
-                live_msg = await self._safe_send(content)
+                live_msg = await self._safe_send(content=content)
             else:
-                await self._safe_edit(live_msg, content)
+                await self._safe_edit(live_msg, content=content)
             return live_msg, buffer
 
         # Buffer too big for one message — split it.
@@ -294,17 +360,17 @@ class DiscordRenderer:
         first, *middle_and_last = chunks
         # Finalize the current live message with the first chunk (no cursor).
         if live_msg is None:
-            live_msg = await self._safe_send(first)
+            live_msg = await self._safe_send(content=first)
         else:
-            await self._safe_edit(live_msg, first)
+            await self._safe_edit(live_msg, content=first)
 
         # Any middle chunks are sent as their own messages with no cursor.
         for mid in middle_and_last[:-1]:
-            await self._safe_send(mid)
+            await self._safe_send(content=mid)
 
         # The last chunk becomes the new live buffer with a fresh cursor message.
         tail = middle_and_last[-1] if middle_and_last else ""
-        new_live = await self._safe_send(tail + CURSOR) if tail else None
+        new_live = await self._safe_send(content=tail + CURSOR) if tail else None
         return new_live, tail
 
     async def _finalize_typewriter(
@@ -314,17 +380,21 @@ class DiscordRenderer:
         # E1: Process channel/thread markers before finalizing.
         buffer = await self._process_markers(buffer)
         if len(buffer) <= DISCORD_MAX_LEN:
-            await self._safe_edit(live_msg, buffer)
+            await self._safe_edit(live_msg, content=buffer)
+            self._last_msg = live_msg
             return
 
         chunks = self._smart_split(buffer, limit=DISCORD_MAX_LEN)
         if not chunks:  # pragma: no cover - defensive
-            await self._safe_edit(live_msg, buffer[:DISCORD_MAX_LEN])
+            await self._safe_edit(live_msg, content=buffer[:DISCORD_MAX_LEN])
+            self._last_msg = live_msg
             return
 
-        await self._safe_edit(live_msg, chunks[0])
+        await self._safe_edit(live_msg, content=chunks[0])
         for chunk in chunks[1:]:
-            await self._safe_send(chunk)
+            sent = await self._safe_send(content=chunk)
+            if sent is not None:
+                self._last_msg = sent
 
     async def _flush(
         self,
@@ -332,7 +402,7 @@ class DiscordRenderer:
         buffer: str,
         typewriter: bool,
         saw_text: bool,
-        tool_msgs: dict[str, tuple[discord.Message, str]],
+        tool_msgs: dict[str, discord.Message],
     ) -> None:
         """Send any remaining text once the stream completes."""
         # Process channel/thread management markers before sending.
@@ -345,30 +415,91 @@ class DiscordRenderer:
 
         if buffer:
             for chunk in self._smart_split(buffer, limit=DISCORD_MAX_LEN):
-                await self._safe_send(chunk)
+                if self._should_upload_as_file(chunk):
+                    ext, code = self._extract_code_info(chunk)
+                    f = discord.File(io.BytesIO(code.encode()), filename=f"output.{ext}")
+                    sent = await self._safe_send(file=f)
+                else:
+                    sent = await self._safe_send(content=chunk)
+                if sent is not None:
+                    self._last_msg = sent
             return
 
         # No text buffered. If we never showed *anything* (no text, no tools),
         # leave a placeholder so the user knows the round-trip finished.
         if not saw_text and not tool_msgs:
-            await self._safe_send("(Claude returned no text response)")
+            sent = await self._safe_send(content="(Claude returned no text response)")
+            if sent is not None:
+                self._last_msg = sent
+
+    # ------------------------------------------------------------------
+    # Long code block → file upload helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _should_upload_as_file(text: str) -> bool:
+        """Check if text is a long code block that should be uploaded as a file."""
+        stripped = text.strip()
+        if not stripped.startswith("```"):
+            return False
+        return len(stripped) > CODE_FILE_UPLOAD_THRESHOLD
+
+    @staticmethod
+    def _extract_code_info(text: str) -> tuple[str, str]:
+        """Extract language extension and code body from a fenced code block."""
+        stripped = text.strip()
+        first_line = stripped.split("\n", 1)[0]
+        lang = first_line.replace("```", "").strip() or "txt"
+        # Remove opening ``` line
+        code = stripped.split("\n", 1)[1] if "\n" in stripped else ""
+        # Remove closing ```
+        if code.endswith("```"):
+            code = code[:-3]
+        ext_map = {
+            "python": "py", "javascript": "js", "typescript": "ts",
+            "bash": "sh", "shell": "sh",
+        }
+        ext = ext_map.get(lang, lang)
+        return ext, code
 
     # ------------------------------------------------------------------
     # Discord I/O wrappers
     # ------------------------------------------------------------------
 
-    async def _safe_send(self, content: str) -> discord.Message | None:
+    async def _safe_send(
+        self,
+        content: str | None = None,
+        *,
+        embed: discord.Embed | None = None,
+        file: discord.File | None = None,
+    ) -> discord.Message | None:
         """Send a message, swallowing transient HTTP errors with a short backoff."""
-        if not content:
+        if not content and embed is None and file is None:
             return None
+
+        kwargs: dict = {}
+        if content:
+            kwargs["content"] = content
+        if embed is not None:
+            kwargs["embed"] = embed
+        if file is not None:
+            kwargs["file"] = file
+
         try:
-            return await self.target.send(content)
+            msg = await self.target.send(**kwargs)
+            if content:
+                self._last_msg = msg
+            return msg
         except discord.RateLimited as exc:
             retry = max(HTTP_BACKOFF_SECONDS, float(getattr(exc, "retry_after", 1.0)))
             log.warning("Discord send rate-limited; sleeping %.2fs", retry)
             await asyncio.sleep(retry)
             try:
-                return await self.target.send(content)
+                # Rebuild file if needed (stream may have been consumed)
+                msg = await self.target.send(**kwargs)
+                if content:
+                    self._last_msg = msg
+                return msg
             except discord.HTTPException:
                 log.exception("Discord send failed after rate-limit backoff; dropping")
                 return None
@@ -376,29 +507,47 @@ class DiscordRenderer:
             log.warning("Discord send failed; backing off and retrying once")
             await asyncio.sleep(HTTP_BACKOFF_SECONDS)
             try:
-                return await self.target.send(content)
+                msg = await self.target.send(**kwargs)
+                if content:
+                    self._last_msg = msg
+                return msg
             except discord.HTTPException:
                 log.exception("Discord send failed after retry; dropping content")
                 return None
 
-    async def _safe_edit(self, msg: discord.Message, content: str) -> None:
+    async def _safe_edit(
+        self,
+        msg: discord.Message,
+        content: str | None = None,
+        *,
+        embed: discord.Embed | None = None,
+    ) -> None:
         """Edit a message, swallowing transient HTTP errors with a short backoff."""
+        kwargs: dict = {}
+        if content is not None:
+            kwargs["content"] = content
+        if embed is not None:
+            kwargs["embed"] = embed
+
+        if not kwargs:
+            return
+
         try:
-            await msg.edit(content=content)
+            await msg.edit(**kwargs)
             return
         except discord.RateLimited as exc:
             retry = max(HTTP_BACKOFF_SECONDS, float(getattr(exc, "retry_after", 1.0)))
             log.debug("Discord edit rate-limited; sleeping %.2fs", retry)
             await asyncio.sleep(retry)
             try:
-                await msg.edit(content=content)
+                await msg.edit(**kwargs)
             except discord.HTTPException:
                 log.warning("Discord edit failed after rate-limit backoff; dropping")
         except discord.HTTPException:
             log.debug("Discord edit failed; backing off and retrying once")
             await asyncio.sleep(HTTP_BACKOFF_SECONDS)
             try:
-                await msg.edit(content=content)
+                await msg.edit(**kwargs)
             except discord.HTTPException:
                 log.warning("Discord edit failed after retry; dropping update")
 
@@ -525,7 +674,7 @@ class DiscordRenderer:
                 "last message — a fresh session will be started for it.\n\n"
                 f"Error: `{exc}`"
             )[:_RETRY_EMBED_DESC_MAX],
-            color=discord.Color.red(),
+            color=COLOR_TOOL_FAILURE,
         )
         view = RetryView(on_retry=on_retry)
         try:
@@ -592,4 +741,13 @@ class RetryView(discord.ui.View):
             self.stop()
 
 
-__all__ = ["DiscordRenderer", "RetryView"]
+__all__ = [
+    "DiscordRenderer",
+    "RetryView",
+    "COLOR_CLAUDE",
+    "COLOR_TOOL_RUNNING",
+    "COLOR_TOOL_SUCCESS",
+    "COLOR_TOOL_FAILURE",
+    "COLOR_INFO",
+    "COLOR_THINKING",
+]

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -25,6 +25,7 @@ import asyncio
 import io
 import logging
 import time
+import uuid
 from typing import TYPE_CHECKING, Awaitable, Callable
 
 import discord
@@ -199,7 +200,7 @@ class DiscordRenderer:
                                 file_content = block.input.get("content", "")
                                 ext = file_path.rsplit(".", 1)[-1] if "." in file_path else ""
                                 lang = ext if ext in ("py", "js", "ts", "go", "rs", "java", "c", "cpp", "h", "md", "yaml", "yml", "json", "toml", "sh", "bash", "sql", "html", "css") else ""
-                                preview = file_content[:1500].replace("```", "` ` `")  # SEC2: break triple backtick
+                                preview = file_content.replace("```", "` ` `")[:1500]  # SEC2: escape before truncate
                                 if len(file_content) > 1500:
                                     preview += "\n... (truncated)"
                                 try:
@@ -216,7 +217,7 @@ class DiscordRenderer:
                                     diff_lines.append(f"- {line}")
                                 for line in new_text.splitlines():
                                     diff_lines.append(f"+ {line}")
-                                diff_str = "\n".join(diff_lines)[:1500].replace("```", "` ` `")  # SEC2: break triple backtick
+                                diff_str = "\n".join(diff_lines).replace("```", "` ` `")[:1500]  # SEC2: escape before truncate
                                 if len("\n".join(diff_lines)) > 1500:
                                     diff_str += "\n... (truncated)"
                                 try:
@@ -495,7 +496,11 @@ class DiscordRenderer:
             log.warning("Discord send rate-limited; sleeping %.2fs", retry)
             await asyncio.sleep(retry)
             try:
-                # Rebuild file if needed (stream may have been consumed)
+                # Reset file stream if it was consumed by the first attempt
+                if "file" in kwargs:
+                    f = kwargs["file"]
+                    if hasattr(f, 'fp') and hasattr(f.fp, 'seek'):
+                        f.fp.seek(0)
                 msg = await self.target.send(**kwargs)
                 if content:
                     self._last_msg = msg
@@ -507,6 +512,11 @@ class DiscordRenderer:
             log.warning("Discord send failed; backing off and retrying once")
             await asyncio.sleep(HTTP_BACKOFF_SECONDS)
             try:
+                # Reset file stream if it was consumed by the first attempt
+                if "file" in kwargs:
+                    f = kwargs["file"]
+                    if hasattr(f, 'fp') and hasattr(f.fp, 'seek'):
+                        f.fp.seek(0)
                 msg = await self.target.send(**kwargs)
                 if content:
                     self._last_msg = msg
@@ -704,6 +714,10 @@ class RetryView(discord.ui.View):
         super().__init__(timeout=timeout)
         self._on_retry = on_retry
         self._fired = False
+        # Override the button's custom_id to be unique per instance
+        for item in self.children:
+            if hasattr(item, 'custom_id') and item.custom_id == 'clauded_retry_btn':
+                item.custom_id = f"clauded_retry_{uuid.uuid4().hex[:8]}"
 
     @discord.ui.button(
         label="Retry",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,18 +13,23 @@ from clauded.config import Config, load_config
 def isolated_env(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> pytest.MonkeyPatch:
-    """Clear all clauded-relevant env vars and chdir to a clean tmp dir.
+    """Clear all clauded-relevant env vars and neutralise ``load_dotenv``.
 
     ``load_config`` calls ``load_dotenv()``, which scans the cwd and parents
-    for a ``.env`` file. Running the tests from the repo root where a
-    developer might have a real ``.env`` would pollute our assertions, so
-    we move into an empty tmp dir before invoking ``load_config``.
+    for a ``.env`` file. A real ``.env`` in the repo root would pollute our
+    assertions, so we monkeypatch ``load_dotenv`` to a no-op **and** strip
+    every env var that ``.env`` might set.
     """
-    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
-    monkeypatch.delenv("CLAUDE_MODEL", raising=False)
-    monkeypatch.delenv("CLAUDE_PERMISSION_MODE", raising=False)
-    monkeypatch.delenv("CLAUDED_PROJECTS_ROOT", raising=False)
-    monkeypatch.chdir(tmp_path)
+    for key in (
+        "DISCORD_BOT_TOKEN",
+        "CLAUDE_MODEL",
+        "CLAUDE_PERMISSION_MODE",
+        "CLAUDED_PROJECTS_ROOT",
+        "CLAUDE_CLI_PATH",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    # Prevent load_dotenv from reading .env file
+    monkeypatch.setattr("clauded.config.load_dotenv", lambda *a, **kw: None)
     return monkeypatch
 
 


### PR DESCRIPTION
All bot output upgraded from plain text to Discord rich media.

- Purple embed footer for Claude replies (cost/token/time stats)
- Yellow→Green/Red embed transitions for tool execution  
- Red embeds for errors + retry button
- Gray embed for ThinkingBlock
- Blue embeds for commands (/health, /session, /cost)
- Long code → file upload instead of splitting
- Cost -# subtext at end of replies
- Fixed config tests to ignore .env file

88 unit tests pass. 9/9 Discord UI self-tests pass.
Closes #33, #34, #35, #36, #37