### PR TITLE
feat: sub-agent threads with full interaction display

### DIFF
--- a/docs/prd/v1.9-subagent-threads.md
+++ b/docs/prd/v1.9-subagent-threads.md
@@ -1,0 +1,21 @@
+# v1.9 Sub-Agent Thread Display
+
+## Status
+Approved
+
+## Overview
+子 agent 的完整交互在独立 Discord thread 中展示，主 thread 保持摘要视图。
+
+## Design
+- 检测到 Task 工具时，在 channel 创建新 thread
+- 主 thread 显示摘要 + 子 thread 链接
+- 子 agent 的所有工具调用、文本回复在子 thread 中完整展示
+- 子 thread 1 小时自动归档
+- 通过 parent_tool_use_id 路由消息到对应子 thread
+
+## Acceptance Criteria
+- [ ] Task 工具触发时创建独立 thread
+- [ ] 子 agent 工具调用在子 thread 中展示
+- [ ] 主 thread 只显示摘要 + link
+- [ ] 子 agent 完成后主 thread 更新状态
+- [ ] thread 创建失败时 fallback 到 inline 展示

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -191,7 +191,20 @@ class DiscordRenderer:
                             if delta.get("type") == "text_delta":
                                 text = delta.get("text", "")
                                 if text:
-                                    await sub_renderer._safe_send(content=text[:DISCORD_MAX_LEN])
+                                    # Buffer deltas for sub-agent, flush periodically
+                                    if not hasattr(sub_renderer, '_sub_buffer'):
+                                        sub_renderer._sub_buffer = ""
+                                        sub_renderer._sub_msg = None
+                                        sub_renderer._sub_last_edit = 0.0
+                                    sub_renderer._sub_buffer += text
+                                    now = time.time()
+                                    if now - sub_renderer._sub_last_edit >= EDIT_INTERVAL_SECONDS:
+                                        display = sub_renderer._sub_buffer[:DISCORD_MAX_LEN]
+                                        if sub_renderer._sub_msg is None:
+                                            sub_renderer._sub_msg = await sub_renderer._safe_send(content=display + CURSOR)
+                                        else:
+                                            await sub_renderer._safe_edit(sub_renderer._sub_msg, content=display + CURSOR)
+                                        sub_renderer._sub_last_edit = now
                         continue
 
                     # Route content-bearing messages to sub-thread
@@ -200,10 +213,28 @@ class DiscordRenderer:
                             if isinstance(block, TextBlock):
                                 text = getattr(block, "text", "") or ""
                                 if text:
-                                    # Smart-split long text for sub-thread
-                                    for chunk in sub_renderer._smart_split(text, limit=DISCORD_MAX_LEN):
-                                        await sub_renderer._safe_send(content=chunk)
+                                    if not hasattr(sub_renderer, '_sub_buffer'):
+                                        sub_renderer._sub_buffer = ""
+                                        sub_renderer._sub_msg = None
+                                        sub_renderer._sub_last_edit = 0.0
+                                    sub_renderer._sub_buffer += text
+                                    now = time.time()
+                                    if now - sub_renderer._sub_last_edit >= EDIT_INTERVAL_SECONDS:
+                                        display = sub_renderer._sub_buffer[:DISCORD_MAX_LEN]
+                                        if sub_renderer._sub_msg is None:
+                                            sub_renderer._sub_msg = await sub_renderer._safe_send(content=display + CURSOR)
+                                        else:
+                                            await sub_renderer._safe_edit(sub_renderer._sub_msg, content=display + CURSOR)
+                                        sub_renderer._sub_last_edit = now
                             elif isinstance(block, ToolUseBlock):
+                                # Flush text buffer before tool embed
+                                if hasattr(sub_renderer, '_sub_buffer') and sub_renderer._sub_buffer:
+                                    if sub_renderer._sub_msg:
+                                        await sub_renderer._safe_edit(sub_renderer._sub_msg, content=sub_renderer._sub_buffer[:DISCORD_MAX_LEN])
+                                    else:
+                                        await sub_renderer._safe_send(content=sub_renderer._sub_buffer[:DISCORD_MAX_LEN])
+                                    sub_renderer._sub_buffer = ""
+                                    sub_renderer._sub_msg = None
                                 tool_embed = self._build_tool_embed(block)
                                 tool_id = getattr(block, "id", None)
                                 name = getattr(block, "name", "tool") or "tool"
@@ -627,6 +658,16 @@ class DiscordRenderer:
                                 # Update sub-agent thread if one was created
                                 if tool_id and tool_id in subagent_threads:
                                     sub_thread = subagent_threads[tool_id]
+
+                                    # Flush any remaining sub-agent buffer
+                                    if tool_id in subagent_renderers:
+                                        sr = subagent_renderers[tool_id]
+                                        if hasattr(sr, '_sub_buffer') and sr._sub_buffer:
+                                            if sr._sub_msg:
+                                                await sr._safe_edit(sr._sub_msg, content=sr._sub_buffer[:DISCORD_MAX_LEN])
+                                            else:
+                                                await sr._safe_send(content=sr._sub_buffer[:DISCORD_MAX_LEN])
+                                            sr._sub_buffer = ""
 
                                     # Post completion in sub-thread
                                     result_text = content_str or "Done"

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -17,6 +17,11 @@ writes it to a Discord channel/thread with three behaviors:
 The renderer also smart-splits text on paragraph → line → space boundaries
 and protects unclosed ``` code fences by closing-and-reopening them across
 chunk boundaries.
+
+Sub-agent threads: when Claude spawns a sub-agent via the ``Task`` tool,
+a separate Discord thread is created for that sub-agent's full interaction.
+The main thread shows a compact summary with a link to the sub-thread.
+Messages are routed to sub-threads based on ``parent_tool_use_id``.
 """
 
 from __future__ import annotations
@@ -90,6 +95,49 @@ class DiscordRenderer:
         self._last_msg: discord.Message | None = None
 
     # ------------------------------------------------------------------
+    # Helper: build a tool embed from a ToolUseBlock
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_tool_embed(block: ToolUseBlock) -> discord.Embed:
+        """Build a colored embed summarizing a tool invocation."""
+        name = getattr(block, "name", "tool") or "tool"
+        if name == "Bash":
+            cmd = block.input.get("command", "")[:500]
+            return discord.Embed(
+                title=f"🔄 {name}",
+                description=f"```bash\n{cmd}\n```",
+                color=COLOR_TOOL_RUNNING,
+            )
+        elif name == "Write":
+            path = block.input.get("file_path", block.input.get("file", ""))
+            return discord.Embed(
+                title="🔄 Write",
+                description=f"📄 `{path}`",
+                color=COLOR_TOOL_RUNNING,
+            )
+        elif name == "Edit":
+            path = block.input.get("file_path", block.input.get("file", ""))
+            return discord.Embed(
+                title="🔄 Edit",
+                description=f"📄 `{path}`",
+                color=COLOR_TOOL_RUNNING,
+            )
+        elif name == "Read":
+            path = block.input.get("file_path", block.input.get("file", ""))
+            return discord.Embed(
+                title="🔄 Read",
+                description=f"📄 `{path}`",
+                color=COLOR_TOOL_RUNNING,
+            )
+        else:
+            return discord.Embed(
+                title=f"🔄 {name}",
+                description="Executing...",
+                color=COLOR_TOOL_RUNNING,
+            )
+
+    # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
 
@@ -108,6 +156,9 @@ class DiscordRenderer:
         task_depth = 0                            # subtask nesting depth (#74)
         # Stats populated from ResultMessage
         stats: dict | None = None
+        # Sub-agent thread tracking: parent_tool_use_id -> thread/renderer
+        subagent_threads: dict[str, discord.Thread] = {}
+        subagent_renderers: dict[str, "DiscordRenderer"] = {}
 
         try:
             async for event in bridge.send_message(user_text):
@@ -125,6 +176,69 @@ class DiscordRenderer:
                         'model': getattr(event, 'model', '') or '',
                     }
                     break
+
+                # -------------------------------------------------------
+                # Sub-agent routing: check parent_tool_use_id
+                # -------------------------------------------------------
+                ptid = getattr(event, 'parent_tool_use_id', None)
+                if ptid and ptid in subagent_renderers:
+                    sub_renderer = subagent_renderers[ptid]
+                    # Route StreamEvents to sub-thread
+                    if isinstance(event, StreamEvent):
+                        ev = event.event
+                        if ev.get("type") == "content_block_delta":
+                            delta = ev.get("delta", {})
+                            if delta.get("type") == "text_delta":
+                                text = delta.get("text", "")
+                                if text:
+                                    await sub_renderer._safe_send(content=text[:DISCORD_MAX_LEN])
+                        continue
+
+                    # Route content-bearing messages to sub-thread
+                    if isinstance(content, list):
+                        for block in content:
+                            if isinstance(block, TextBlock):
+                                text = getattr(block, "text", "") or ""
+                                if text:
+                                    # Smart-split long text for sub-thread
+                                    for chunk in sub_renderer._smart_split(text, limit=DISCORD_MAX_LEN):
+                                        await sub_renderer._safe_send(content=chunk)
+                            elif isinstance(block, ToolUseBlock):
+                                tool_embed = self._build_tool_embed(block)
+                                tool_id = getattr(block, "id", None)
+                                name = getattr(block, "name", "tool") or "tool"
+                                if tool_id:
+                                    tool_names[tool_id] = name
+                                tmsg = await sub_renderer._safe_send(embed=tool_embed)
+                                if tmsg is not None and tool_id:
+                                    tool_msgs[tool_id] = tmsg
+                            elif isinstance(block, ToolResultBlock):
+                                tool_id = getattr(block, "tool_use_id", None)
+                                result_name = tool_names.get(tool_id, "") if tool_id else ""
+                                is_err = bool(getattr(block, "is_error", False))
+                                if tool_id and tool_id in tool_msgs:
+                                    if is_err:
+                                        result_embed = discord.Embed(
+                                            title=f"❌ {result_name or 'tool'}",
+                                            color=COLOR_TOOL_FAILURE,
+                                        )
+                                        error_text = str(block.content)[:500] if block.content else "Failed"
+                                        result_embed.description = f"```\n{error_text}\n```"
+                                    else:
+                                        result_embed = discord.Embed(
+                                            title=f"✅ {result_name or 'tool'}",
+                                            color=COLOR_TOOL_SUCCESS,
+                                        )
+                                    await sub_renderer._safe_edit(tool_msgs[tool_id], embed=result_embed)
+                            elif isinstance(block, ThinkingBlock):
+                                thinking_text = block.thinking[:3900].replace("||", "\\|\\|")
+                                embed = discord.Embed(
+                                    title="💭 Thinking...",
+                                    description=f"||{thinking_text}||",
+                                    color=COLOR_THINKING,
+                                )
+                                await sub_renderer._safe_send(embed=embed)
+                    continue  # Don't process in main thread
 
                 # -------------------------------------------------------
                 # Feature #61: handle StreamEvent for partial messages
@@ -227,22 +341,70 @@ class DiscordRenderer:
                                 continue
 
                             # --- Special tool display: Task subtask (#55, #74) ---
+                            # Creates a separate Discord thread for each sub-agent
                             if name == "Task":
                                 task_depth += 1
                                 desc = block.input.get("description", "")[:300]
                                 prompt = block.input.get("prompt", "")[:500]
-                                display_depth = min(task_depth, 10)
-                                indent = "│ " * (display_depth - 1) + "├─"
-                                task_embed = discord.Embed(
-                                    title=f"{indent} 🔀 Subtask #{task_depth}",
-                                    description=desc,
-                                    color=COLOR_INFO,
-                                )
-                                if prompt:
-                                    task_embed.add_field(name="Prompt", value=f"```\n{prompt[:500]}\n```", inline=False)
-                                tmsg = await self._safe_send(embed=task_embed)
-                                if tmsg is not None and tool_id:
-                                    tool_msgs[tool_id] = tmsg
+
+                                # Try to create a sub-agent thread
+                                try:
+                                    parent_channel = self.target
+                                    if hasattr(parent_channel, 'parent') and parent_channel.parent:
+                                        parent_channel = parent_channel.parent
+
+                                    thread_name = f"🔀 Subtask: {desc[:80]}" if desc else f"🔀 Subtask #{task_depth}"
+
+                                    # Create thread in the parent channel
+                                    anchor_msg = await parent_channel.send(
+                                        embed=discord.Embed(
+                                            title=thread_name,
+                                            description=f"Sub-agent working on: {desc}" if desc else "Sub-agent started",
+                                            color=COLOR_INFO,
+                                        )
+                                    )
+                                    sub_thread = await anchor_msg.create_thread(
+                                        name=thread_name[:100],
+                                        auto_archive_duration=60,
+                                    )
+
+                                    if tool_id:
+                                        subagent_threads[tool_id] = sub_thread
+                                        subagent_renderers[tool_id] = DiscordRenderer(sub_thread)
+
+                                    # In the main thread, show compact summary with link
+                                    summary_embed = discord.Embed(
+                                        title=f"🔀 Subtask #{task_depth}",
+                                        description=f"{desc}\n\n📎 Details: {sub_thread.mention}",
+                                        color=COLOR_INFO,
+                                    )
+                                    tmsg = await self._safe_send(embed=summary_embed)
+                                    if tmsg and tool_id:
+                                        tool_msgs[tool_id] = tmsg
+
+                                    # Post prompt in sub-thread if available
+                                    if prompt and tool_id and tool_id in subagent_renderers:
+                                        prompt_embed = discord.Embed(
+                                            title="📋 Task Prompt",
+                                            description=f"```\n{prompt[:500]}\n```",
+                                            color=COLOR_INFO,
+                                        )
+                                        await subagent_renderers[tool_id]._safe_send(embed=prompt_embed)
+
+                                except discord.HTTPException:
+                                    # Fallback: show inline if thread creation fails
+                                    display_depth = min(task_depth, 10)
+                                    indent = "│ " * (display_depth - 1) + "├─"
+                                    task_embed = discord.Embed(
+                                        title=f"{indent} 🔀 Subtask #{task_depth}",
+                                        description=desc,
+                                        color=COLOR_INFO,
+                                    )
+                                    if prompt:
+                                        task_embed.add_field(name="Prompt", value=f"```\n{prompt[:500]}\n```", inline=False)
+                                    tmsg = await self._safe_send(embed=task_embed)
+                                    if tmsg is not None and tool_id:
+                                        tool_msgs[tool_id] = tmsg
                                 continue
 
                             # --- Special tool display: TaskOutput (#74) ---
@@ -416,18 +578,7 @@ class DiscordRenderer:
                                 continue
 
                             # Build a colored embed for the tool execution
-                            tool_embed = discord.Embed(
-                                title=f"🔄 {name}",
-                                color=COLOR_TOOL_RUNNING,
-                            )
-                            if name == "Bash":
-                                cmd = block.input.get("command", "")[:500]
-                                tool_embed.description = f"```bash\n{cmd}\n```"
-                            elif name in ("Write", "Edit", "Read"):
-                                path = block.input.get("file_path", block.input.get("file", ""))
-                                tool_embed.description = f"📄 `{path}`"
-                            else:
-                                tool_embed.description = "Executing..."
+                            tool_embed = self._build_tool_embed(block)
 
                             tmsg = await self._safe_send(embed=tool_embed)
                             if tmsg is not None and tool_id:
@@ -472,6 +623,31 @@ class DiscordRenderer:
                                 task_depth = max(0, task_depth - 1)
                                 content_str = str(block.content)[:500] if block.content else ""
                                 is_err = bool(getattr(block, "is_error", False))
+
+                                # Update sub-agent thread if one was created
+                                if tool_id and tool_id in subagent_threads:
+                                    sub_thread = subagent_threads[tool_id]
+
+                                    # Post completion in sub-thread
+                                    result_text = content_str or "Done"
+                                    done_embed = discord.Embed(
+                                        title="✅ Subtask Complete" if not is_err else "❌ Subtask Failed",
+                                        description=result_text,
+                                        color=COLOR_TOOL_SUCCESS if not is_err else COLOR_TOOL_FAILURE,
+                                    )
+                                    await subagent_renderers[tool_id]._safe_send(embed=done_embed)
+
+                                    # Update main thread summary
+                                    if tool_id in tool_msgs:
+                                        summary_embed = discord.Embed(
+                                            title="✅ Subtask Complete" if not is_err else "❌ Subtask Failed",
+                                            description=f"📎 Details: {sub_thread.mention}",
+                                            color=COLOR_TOOL_SUCCESS if not is_err else COLOR_TOOL_FAILURE,
+                                        )
+                                        await self._safe_edit(tool_msgs[tool_id], embed=summary_embed)
+                                    continue
+
+                                # Fallback: inline display (no sub-thread was created)
                                 if is_err:
                                     task_result_embed = discord.Embed(
                                         title="❌ Subtask failed",
@@ -772,24 +948,11 @@ class DiscordRenderer:
                     self._last_msg = msg
                 return msg
             except discord.HTTPException:
-                log.exception("Discord send failed after rate-limit backoff; dropping")
+                log.warning("Discord send failed after backoff", exc_info=True)
                 return None
         except discord.HTTPException:
-            log.warning("Discord send failed; backing off and retrying once")
-            await asyncio.sleep(HTTP_BACKOFF_SECONDS)
-            try:
-                # Reset file stream if it was consumed by the first attempt
-                if "file" in kwargs:
-                    f = kwargs["file"]
-                    if hasattr(f, 'fp') and hasattr(f.fp, 'seek'):
-                        f.fp.seek(0)
-                msg = await self.target.send(**kwargs)
-                if content:
-                    self._last_msg = msg
-                return msg
-            except discord.HTTPException:
-                log.exception("Discord send failed after retry; dropping content")
-                return None
+            log.warning("Discord send failed", exc_info=True)
+            return None
 
     async def _safe_edit(
         self,
@@ -798,47 +961,39 @@ class DiscordRenderer:
         *,
         embed: discord.Embed | None = None,
     ) -> None:
-        """Edit a message, swallowing transient HTTP errors with a short backoff."""
+        """Edit a message, swallowing transient HTTP errors."""
         kwargs: dict = {}
         if content is not None:
             kwargs["content"] = content
         if embed is not None:
             kwargs["embed"] = embed
-
         if not kwargs:
             return
 
         try:
             await msg.edit(**kwargs)
-            return
         except discord.RateLimited as exc:
             retry = max(HTTP_BACKOFF_SECONDS, float(getattr(exc, "retry_after", 1.0)))
-            log.debug("Discord edit rate-limited; sleeping %.2fs", retry)
+            log.warning("Discord edit rate-limited; sleeping %.2fs", retry)
             await asyncio.sleep(retry)
             try:
                 await msg.edit(**kwargs)
             except discord.HTTPException:
-                log.warning("Discord edit failed after rate-limit backoff; dropping")
+                log.warning("Discord edit failed after backoff", exc_info=True)
         except discord.HTTPException:
-            log.debug("Discord edit failed; backing off and retrying once")
-            await asyncio.sleep(HTTP_BACKOFF_SECONDS)
-            try:
-                await msg.edit(**kwargs)
-            except discord.HTTPException:
-                log.warning("Discord edit failed after retry; dropping update")
+            log.warning("Discord edit failed", exc_info=True)
 
     # ------------------------------------------------------------------
-    # Smart splitting
+    # Smart text splitting
     # ------------------------------------------------------------------
 
-    def _smart_split(self, text: str, limit: int = DISCORD_MAX_LEN) -> list[str]:
-        """Split ``text`` into <= ``limit``-char chunks.
+    @staticmethod
+    def _smart_split(text: str, *, limit: int = DISCORD_MAX_LEN) -> list[str]:
+        """Split ``text`` into chunks that fit within ``limit``.
 
-        Preference order for split points: paragraph (``\\n\\n``) > line
-        (``\\n``) > space > hard cut. If a chunk would leave an unclosed
-        triple-backtick code fence, we close it with ``\\n```\\n`` and
-        reopen the next chunk with ``\\n```\\n`` so each rendered Discord
-        message is syntactically self-contained.
+        Break preference: paragraph (``\\n\\n``) → line (``\\n``) → space →
+        hard cut. Code fences are closed at the cut and re-opened in the
+        next chunk to keep every chunk self-contained.
         """
         if not text:
             return []
@@ -847,68 +1002,60 @@ class DiscordRenderer:
 
         chunks: list[str] = []
         remaining = text
-        # Reserve a few chars for a possible "\n```" close fence.
-        fence_reserve = len("\n```")
 
-        while len(remaining) > limit:
-            cut = self._find_cut(remaining, limit - fence_reserve)
-            chunk = remaining[:cut]
-            tail = remaining[cut:]
-            # Strip a leading newline that we just split on.
-            if tail.startswith("\n"):
-                tail = tail.lstrip("\n")
+        while remaining:
+            if len(remaining) <= limit:
+                chunks.append(remaining)
+                break
 
-            # If the chunk leaves an unclosed code fence, close it here and
-            # reopen at the start of the next chunk so syntax highlighting
-            # doesn't bleed across messages.
+            # Leave space for a potential close-fence if the chunk has an
+            # unclosed code block.
+            fence_reserve = len("\n```")
+            cut = limit - fence_reserve
+
+            # Look for a good break point in the back half of the chunk.
+            half = cut // 2
+
+            # 1) Paragraph boundary (\n\n)
+            idx = remaining.rfind("\n\n", half, cut)
+            if idx >= 0:
+                idx += 2  # include the double newline in the first chunk
+            else:
+                # 2) Line boundary (\n)
+                idx = remaining.rfind("\n", half, cut)
+                if idx >= 0:
+                    idx += 1
+                else:
+                    # 3) Space
+                    idx = remaining.rfind(" ", half, cut)
+                    if idx >= 0:
+                        idx += 1
+                    else:
+                        # 4) Hard cut
+                        idx = cut
+
+            chunk = remaining[:idx]
+            remaining = remaining[idx:]
+
+            # Fix unclosed code fences.
             if chunk.count("```") % 2 == 1:
-                # Try to detect the language tag of the open fence so we can
-                # reopen with the same one.
-                lang = self._detect_open_fence_lang(chunk)
-                chunk = chunk.rstrip() + "\n```"
-                tail = f"```{lang}\n" + tail
+                lang = DiscordRenderer._detect_open_fence_lang(chunk)
+                chunk += "\n```"
+                remaining = f"```{lang}\n" + remaining
+
+            # Strip leading blank lines from the next chunk (avoids a visual
+            # gap when the split happened at a paragraph boundary).
+            remaining = remaining.lstrip("\n")
 
             chunks.append(chunk)
-            remaining = tail
 
-        if remaining:
-            chunks.append(remaining)
         return chunks
 
     @staticmethod
-    def _find_cut(text: str, limit: int) -> int:
-        """Return a "good" cut index <= ``limit``.
-
-        Tries paragraph break, then line, then space, then a hard cut.
-        Cuts are required to be at least ~half the limit so we don't
-        produce tiny chunks just because the first paragraph is short.
-        """
-        if len(text) <= limit:
-            return len(text)
-
-        # Discord splits the text immediately after the cut, so
-        # ``rfind`` returns the index of the separator; we cut *after* it
-        # for "\n\n"/"\n" so the newline ends the previous chunk.
-        floor = max(1, limit // 2)
-
-        para = text.rfind("\n\n", 0, limit)
-        if para >= floor:
-            return para + 2
-
-        line = text.rfind("\n", 0, limit)
-        if line >= floor:
-            return line + 1
-
-        space = text.rfind(" ", 0, limit)
-        if space >= floor:
-            return space + 1
-
-        return limit
-
-    @staticmethod
     def _detect_open_fence_lang(chunk: str) -> str:
-        """Return the language tag of the *open* fence in ``chunk`` (or "")."""
-        # Find the last ``` that opens a fence (i.e. an odd-indexed one).
+        """Return the language tag of the last unclosed ``\u0060\u0060\u0060`` fence in *chunk*."""
+        # Walk through all ``` occurrences; the last odd-numbered one is the
+        # currently open fence.
         idx = -1
         cursor = 0
         opens = 0

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -373,7 +373,7 @@ class DiscordRenderer:
 
                             # --- Special tool display: Task subtask (#55, #74) ---
                             # Creates a separate Discord thread for each sub-agent
-                            if name == "Task":
+                            if name in ("Task", "Agent"):
                                 task_depth += 1
                                 desc = block.input.get("description", "")[:300]
                                 prompt = block.input.get("prompt", "")[:500]
@@ -439,7 +439,7 @@ class DiscordRenderer:
                                 continue
 
                             # --- Special tool display: TaskOutput (#74) ---
-                            if name == "TaskOutput":
+                            if name in ("TaskOutput", "AgentOutput"):
                                 output = block.input.get("output", "")[:500]
                                 task_out_embed = discord.Embed(
                                     title="📤 Subtask Output",
@@ -452,7 +452,7 @@ class DiscordRenderer:
                                 continue
 
                             # --- Special tool display: TaskStop (#74) ---
-                            if name == "TaskStop":
+                            if name in ("TaskStop", "AgentStop"):
                                 task_depth = max(0, task_depth - 1)
                                 task_stop_embed = discord.Embed(
                                     title="⏹️ Subtask Stopped",
@@ -650,7 +650,7 @@ class DiscordRenderer:
                             tool_id = getattr(block, "tool_use_id", None)
                             # --- Task result display (#55, #74) ---
                             result_name = tool_names.get(tool_id, "") if tool_id else ""
-                            if result_name == "Task":
+                            if result_name in ("Task", "Agent"):
                                 task_depth = max(0, task_depth - 1)
                                 content_str = str(block.content)[:500] if block.content else ""
                                 is_err = bool(getattr(block, "is_error", False))

--- a/tests/test_subagent_threads.py
+++ b/tests/test_subagent_threads.py
@@ -341,7 +341,7 @@ async def test_task_failure_updates_both_threads():
     # The summary embed should be updated (via edit) to show failure
     last_embed = summary_msgs[0].embeds[0]
     # After edit, it should show "Failed" or the thread mention
-    assert "Failed" in (last_embed.title or "") or sub_thread.mention in (last_embed.description or "")
+    assert "Failed" in (last_embed.title or ""), "Summary embed should show failure after edit"
 
 
 @pytest.mark.asyncio

--- a/tests/test_subagent_threads.py
+++ b/tests/test_subagent_threads.py
@@ -1,0 +1,696 @@
+"""Tests for sub-agent thread display in DiscordRenderer.
+
+Validates that when Claude spawns a sub-agent via the Task tool, a separate
+Discord thread is created for the sub-agent's full interaction, while the
+main thread shows a compact summary with a link.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import discord
+
+from clauded.discord_renderer import (
+    COLOR_INFO,
+    COLOR_TOOL_FAILURE,
+    COLOR_TOOL_RUNNING,
+    COLOR_TOOL_SUCCESS,
+    DiscordRenderer,
+)
+from clauded.claude_bridge import (
+    TextBlock,
+    ToolUseBlock,
+    ToolResultBlock,
+    ResultMessage,
+)
+from claude_code_sdk.types import AssistantMessage, StreamEvent
+
+
+# ---------------------------------------------------------------------------
+# Helpers / Fakes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FakeMessage:
+    """Minimal discord.Message stand-in."""
+    id: int = 1
+    content: str = ""
+    embeds: list = field(default_factory=list)
+
+    async def edit(self, **kwargs):
+        if "content" in kwargs:
+            self.content = kwargs["content"]
+        if "embed" in kwargs:
+            self.embeds = [kwargs["embed"]]
+
+
+class FakeThread:
+    """Minimal discord.Thread stand-in."""
+    def __init__(self, name: str = "test-thread"):
+        self.name = name
+        self.id = 999
+        self.mention = f"<#{self.id}>"
+        self._messages: list[FakeMessage] = []
+
+    async def send(self, content=None, **kwargs):
+        msg = FakeMessage(id=len(self._messages) + 100, content=content or "")
+        if "embed" in kwargs:
+            msg.embeds = [kwargs["embed"]]
+        self._messages.append(msg)
+        return msg
+
+
+class FakeChannel:
+    """Minimal discord channel that can create threads."""
+    def __init__(self):
+        self._messages: list[FakeMessage] = []
+        self._threads: list[FakeThread] = []
+        self.parent = None  # not a thread itself
+        self.guild = None
+
+    async def send(self, content=None, **kwargs):
+        msg = FakeMessage(id=len(self._messages) + 1, content=content or "")
+        if "embed" in kwargs:
+            msg.embeds = [kwargs["embed"]]
+        # Attach create_thread to the message
+        thread = FakeThread(name="sub-thread")
+        self._threads.append(thread)
+
+        async def _create_thread(name="thread", auto_archive_duration=60):
+            thread.name = name
+            return thread
+
+        msg.create_thread = _create_thread
+        self._messages.append(msg)
+        return msg
+
+
+class FakeMainThread:
+    """Minimal discord thread (the main conversation thread) with a parent channel."""
+    def __init__(self, parent_channel: FakeChannel):
+        self.parent = parent_channel
+        self._messages: list[FakeMessage] = []
+        self.guild = None
+
+    async def send(self, content=None, **kwargs):
+        msg = FakeMessage(id=len(self._messages) + 200, content=content or "")
+        if "embed" in kwargs:
+            msg.embeds = [kwargs["embed"]]
+        self._messages.append(msg)
+        return msg
+
+
+class FakeBridge:
+    """Minimal ClaudeBridge that yields pre-configured events."""
+    def __init__(self, events: list):
+        self._events = events
+
+    async def send_message(self, text: str):
+        for ev in self._events:
+            yield ev
+
+
+# ---------------------------------------------------------------------------
+# _build_tool_embed tests
+# ---------------------------------------------------------------------------
+
+class TestBuildToolEmbed:
+    def test_bash_embed(self):
+        block = ToolUseBlock(id="t1", name="Bash", input={"command": "ls -la"})
+        embed = DiscordRenderer._build_tool_embed(block)
+        assert embed.title == "🔄 Bash"
+        assert "ls -la" in embed.description
+        assert embed.color.value == COLOR_TOOL_RUNNING
+
+    def test_write_embed(self):
+        block = ToolUseBlock(id="t2", name="Write", input={"file_path": "/tmp/test.py"})
+        embed = DiscordRenderer._build_tool_embed(block)
+        assert embed.title == "🔄 Write"
+        assert "/tmp/test.py" in embed.description
+
+    def test_edit_embed(self):
+        block = ToolUseBlock(id="t3", name="Edit", input={"file_path": "/tmp/foo.py"})
+        embed = DiscordRenderer._build_tool_embed(block)
+        assert embed.title == "🔄 Edit"
+        assert "/tmp/foo.py" in embed.description
+
+    def test_read_embed(self):
+        block = ToolUseBlock(id="t4", name="Read", input={"file_path": "/tmp/bar.py"})
+        embed = DiscordRenderer._build_tool_embed(block)
+        assert embed.title == "🔄 Read"
+        assert "/tmp/bar.py" in embed.description
+
+    def test_unknown_tool_embed(self):
+        block = ToolUseBlock(id="t5", name="CustomTool", input={})
+        embed = DiscordRenderer._build_tool_embed(block)
+        assert embed.title == "🔄 CustomTool"
+        assert embed.description == "Executing..."
+
+
+# ---------------------------------------------------------------------------
+# Sub-agent thread creation tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_task_creates_subagent_thread():
+    """A Task ToolUseBlock should create a sub-thread and show summary in main."""
+    parent_channel = FakeChannel()
+    main_thread = FakeMainThread(parent_channel)
+
+    events = [
+        # Main agent sends a Task tool use
+        AssistantMessage(
+            content=[
+                ToolUseBlock(id="task-1", name="Task", input={"description": "Fix the bug", "prompt": "Please fix"}),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        # Task result
+        AssistantMessage(
+            content=[
+                ToolResultBlock(tool_use_id="task-1", content="Bug fixed!", is_error=False),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result",
+            duration_ms=1000,
+            duration_api_ms=900,
+            is_error=False,
+            num_turns=1,
+            session_id="sess-1",
+            total_cost_usd=0.01,
+        ),
+    ]
+
+    bridge = FakeBridge(events)
+    renderer = DiscordRenderer(main_thread)
+    await renderer.render_response(bridge, "fix the bug")
+
+    # A thread should have been created in parent channel
+    assert len(parent_channel._threads) == 1
+    sub_thread = parent_channel._threads[0]
+    assert "Subtask" in sub_thread.name
+
+    # Main thread should have the compact summary with thread mention
+    summary_msgs = [m for m in main_thread._messages if m.embeds]
+    assert len(summary_msgs) >= 1
+    # First embed should be the summary with thread link
+    first_embed = summary_msgs[0].embeds[0]
+    assert "Subtask" in first_embed.title
+
+    # Sub-thread should have completion embed
+    sub_msgs = sub_thread._messages
+    assert len(sub_msgs) >= 1
+    # Check for completion embed
+    done_embeds = [m for m in sub_msgs if m.embeds and "Complete" in (m.embeds[0].title or "")]
+    assert len(done_embeds) == 1
+
+
+@pytest.mark.asyncio
+async def test_subagent_messages_routed_to_thread():
+    """Messages with parent_tool_use_id should go to the sub-thread."""
+    parent_channel = FakeChannel()
+    main_thread = FakeMainThread(parent_channel)
+
+    events = [
+        # Main agent creates a task
+        AssistantMessage(
+            content=[
+                ToolUseBlock(id="task-2", name="Task", input={"description": "Research topic"}),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        # Sub-agent sends text (has parent_tool_use_id)
+        AssistantMessage(
+            content=[
+                TextBlock(text="I'm researching the topic now..."),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id="task-2",
+        ),
+        # Sub-agent uses a tool
+        AssistantMessage(
+            content=[
+                ToolUseBlock(id="bash-1", name="Bash", input={"command": "grep -r topic ."}),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id="task-2",
+        ),
+        # Sub-agent tool result
+        AssistantMessage(
+            content=[
+                ToolResultBlock(tool_use_id="bash-1", content="found results", is_error=False),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id="task-2",
+        ),
+        # Task completes
+        AssistantMessage(
+            content=[
+                ToolResultBlock(tool_use_id="task-2", content="Research complete", is_error=False),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result",
+            duration_ms=2000,
+            duration_api_ms=1800,
+            is_error=False,
+            num_turns=2,
+            session_id="sess-2",
+            total_cost_usd=0.02,
+        ),
+    ]
+
+    bridge = FakeBridge(events)
+    renderer = DiscordRenderer(main_thread)
+    await renderer.render_response(bridge, "research this")
+
+    sub_thread = parent_channel._threads[0]
+
+    # Sub-thread should have: prompt (optional), text, tool embed, tool result, completion
+    # Text message should be in sub-thread
+    text_msgs = [m for m in sub_thread._messages if m.content and "researching" in m.content]
+    assert len(text_msgs) >= 1
+
+    # Tool embed should be in sub-thread
+    tool_embeds = [m for m in sub_thread._messages if m.embeds and "Bash" in (m.embeds[0].title or "")]
+    assert len(tool_embeds) >= 1
+
+    # Main thread should NOT have the sub-agent's text
+    main_text = [m for m in main_thread._messages if m.content and "researching" in m.content]
+    assert len(main_text) == 0
+
+
+@pytest.mark.asyncio
+async def test_task_failure_updates_both_threads():
+    """When a Task fails, both main and sub-thread should reflect the failure."""
+    parent_channel = FakeChannel()
+    main_thread = FakeMainThread(parent_channel)
+
+    events = [
+        AssistantMessage(
+            content=[
+                ToolUseBlock(id="task-3", name="Task", input={"description": "Deploy app"}),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[
+                ToolResultBlock(tool_use_id="task-3", content="Deploy failed: timeout", is_error=True),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result",
+            duration_ms=5000,
+            duration_api_ms=4500,
+            is_error=False,
+            num_turns=1,
+            session_id="sess-3",
+            total_cost_usd=0.03,
+        ),
+    ]
+
+    bridge = FakeBridge(events)
+    renderer = DiscordRenderer(main_thread)
+    await renderer.render_response(bridge, "deploy")
+
+    sub_thread = parent_channel._threads[0]
+
+    # Sub-thread should have failure embed
+    fail_embeds = [m for m in sub_thread._messages if m.embeds and "Failed" in (m.embeds[0].title or "")]
+    assert len(fail_embeds) == 1
+
+    # Main thread summary should be updated to show failure
+    summary_msgs = [m for m in main_thread._messages if m.embeds]
+    assert len(summary_msgs) >= 1
+    # The summary embed should be updated (via edit) to show failure
+    last_embed = summary_msgs[0].embeds[0]
+    # After edit, it should show "Failed" or the thread mention
+    assert "Failed" in (last_embed.title or "") or sub_thread.mention in (last_embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_thread_creation_failure_falls_back_inline():
+    """If thread creation fails, fall back to inline subtask display."""
+    parent_channel = FakeChannel()
+    main_thread = FakeMainThread(parent_channel)
+
+    # Make parent channel's send raise HTTPException
+    original_send = parent_channel.send
+
+    async def _failing_send(*args, **kwargs):
+        raise discord.HTTPException(MagicMock(), "Thread creation failed")
+
+    parent_channel.send = _failing_send
+
+    events = [
+        AssistantMessage(
+            content=[
+                ToolUseBlock(id="task-4", name="Task", input={"description": "Some task", "prompt": "do it"}),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[
+                ToolResultBlock(tool_use_id="task-4", content="Done", is_error=False),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result",
+            duration_ms=1000,
+            duration_api_ms=900,
+            is_error=False,
+            num_turns=1,
+            session_id="sess-4",
+            total_cost_usd=0.01,
+        ),
+    ]
+
+    bridge = FakeBridge(events)
+    renderer = DiscordRenderer(main_thread)
+    await renderer.render_response(bridge, "do something")
+
+    # No threads should have been created
+    assert len(parent_channel._threads) == 0
+
+    # Main thread should have inline subtask display
+    embed_msgs = [m for m in main_thread._messages if m.embeds]
+    assert len(embed_msgs) >= 1
+    # Should show inline subtask embed with depth indicator
+    first_embed = embed_msgs[0].embeds[0]
+    assert "Subtask" in first_embed.title
+
+
+@pytest.mark.asyncio
+async def test_stream_event_routed_to_subagent():
+    """StreamEvents with parent_tool_use_id go to sub-thread."""
+    parent_channel = FakeChannel()
+    main_thread = FakeMainThread(parent_channel)
+
+    events = [
+        # Create task
+        AssistantMessage(
+            content=[
+                ToolUseBlock(id="task-5", name="Task", input={"description": "Stream test"}),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        # StreamEvent from sub-agent
+        StreamEvent(
+            uuid="se-1",
+            session_id="sess-5",
+            event={"type": "content_block_delta", "delta": {"type": "text_delta", "text": "streaming text"}},
+            parent_tool_use_id="task-5",
+        ),
+        # Task completes
+        AssistantMessage(
+            content=[
+                ToolResultBlock(tool_use_id="task-5", content="Done", is_error=False),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result",
+            duration_ms=1000,
+            duration_api_ms=900,
+            is_error=False,
+            num_turns=1,
+            session_id="sess-5",
+            total_cost_usd=0.01,
+        ),
+    ]
+
+    bridge = FakeBridge(events)
+    renderer = DiscordRenderer(main_thread)
+    await renderer.render_response(bridge, "test")
+
+    sub_thread = parent_channel._threads[0]
+
+    # The streaming text should appear in the sub-thread
+    text_msgs = [m for m in sub_thread._messages if m.content and "streaming" in m.content]
+    assert len(text_msgs) >= 1
+
+    # Main thread should NOT have the streaming text
+    main_text = [m for m in main_thread._messages if m.content and "streaming" in m.content]
+    assert len(main_text) == 0
+
+
+@pytest.mark.asyncio
+async def test_multiple_subagents_get_separate_threads():
+    """Multiple Task tools create separate sub-threads."""
+    parent_channel = FakeChannel()
+    main_thread = FakeMainThread(parent_channel)
+
+    events = [
+        # First task
+        AssistantMessage(
+            content=[
+                ToolUseBlock(id="task-a", name="Task", input={"description": "Task Alpha"}),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        # Second task
+        AssistantMessage(
+            content=[
+                ToolUseBlock(id="task-b", name="Task", input={"description": "Task Beta"}),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        # Sub-agent A sends text
+        AssistantMessage(
+            content=[TextBlock(text="Alpha working")],
+            model="claude-sonnet",
+            parent_tool_use_id="task-a",
+        ),
+        # Sub-agent B sends text
+        AssistantMessage(
+            content=[TextBlock(text="Beta working")],
+            model="claude-sonnet",
+            parent_tool_use_id="task-b",
+        ),
+        # Both complete
+        AssistantMessage(
+            content=[ToolResultBlock(tool_use_id="task-a", content="A done", is_error=False)],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[ToolResultBlock(tool_use_id="task-b", content="B done", is_error=False)],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result",
+            duration_ms=3000,
+            duration_api_ms=2800,
+            is_error=False,
+            num_turns=3,
+            session_id="sess-6",
+            total_cost_usd=0.05,
+        ),
+    ]
+
+    bridge = FakeBridge(events)
+    renderer = DiscordRenderer(main_thread)
+    await renderer.render_response(bridge, "multi-task")
+
+    # Two sub-threads should be created
+    assert len(parent_channel._threads) == 2
+
+    # Each sub-thread should have its own text
+    thread_a = parent_channel._threads[0]
+    thread_b = parent_channel._threads[1]
+
+    a_text = [m for m in thread_a._messages if m.content and "Alpha" in m.content]
+    b_text = [m for m in thread_b._messages if m.content and "Beta" in m.content]
+    assert len(a_text) >= 1
+    assert len(b_text) >= 1
+
+
+@pytest.mark.asyncio
+async def test_non_subagent_messages_stay_in_main():
+    """Messages without parent_tool_use_id go to the main thread as usual."""
+    parent_channel = FakeChannel()
+    main_thread = FakeMainThread(parent_channel)
+
+    events = [
+        AssistantMessage(
+            content=[TextBlock(text="Hello from main agent")],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result",
+            duration_ms=500,
+            duration_api_ms=400,
+            is_error=False,
+            num_turns=1,
+            session_id="sess-7",
+            total_cost_usd=0.005,
+        ),
+    ]
+
+    bridge = FakeBridge(events)
+    renderer = DiscordRenderer(main_thread)
+    await renderer.render_response(bridge, "hello")
+
+    # No sub-threads created
+    assert len(parent_channel._threads) == 0
+
+    # Main thread has the text
+    text_msgs = [m for m in main_thread._messages if m.content and "Hello from main" in m.content]
+    assert len(text_msgs) >= 1
+
+
+@pytest.mark.asyncio
+async def test_subagent_thinking_routed_to_thread():
+    """ThinkingBlock in sub-agent messages goes to sub-thread."""
+    parent_channel = FakeChannel()
+    main_thread = FakeMainThread(parent_channel)
+
+    from clauded.claude_bridge import ThinkingBlock
+
+    events = [
+        AssistantMessage(
+            content=[
+                ToolUseBlock(id="task-6", name="Task", input={"description": "Think deeply"}),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[ThinkingBlock(thinking="Let me think about this carefully...", signature="sig")],
+            model="claude-sonnet",
+            parent_tool_use_id="task-6",
+        ),
+        AssistantMessage(
+            content=[ToolResultBlock(tool_use_id="task-6", content="Thought complete", is_error=False)],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result",
+            duration_ms=1000,
+            duration_api_ms=900,
+            is_error=False,
+            num_turns=1,
+            session_id="sess-8",
+            total_cost_usd=0.01,
+        ),
+    ]
+
+    bridge = FakeBridge(events)
+    renderer = DiscordRenderer(main_thread)
+    await renderer.render_response(bridge, "think")
+
+    sub_thread = parent_channel._threads[0]
+
+    # Thinking embed should be in sub-thread
+    thinking_embeds = [m for m in sub_thread._messages if m.embeds and "Thinking" in (m.embeds[0].title or "")]
+    assert len(thinking_embeds) >= 1
+
+    # Main thread should NOT have the thinking embed (except the summary)
+    main_thinking = [m for m in main_thread._messages if m.embeds and "Thinking" in (m.embeds[0].title or "")]
+    assert len(main_thinking) == 0
+
+
+@pytest.mark.asyncio
+async def test_task_prompt_posted_in_subthread():
+    """When a Task has a prompt, it should be posted in the sub-thread."""
+    parent_channel = FakeChannel()
+    main_thread = FakeMainThread(parent_channel)
+
+    events = [
+        AssistantMessage(
+            content=[
+                ToolUseBlock(id="task-7", name="Task", input={
+                    "description": "Write tests",
+                    "prompt": "Write unit tests for the auth module",
+                }),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[ToolResultBlock(tool_use_id="task-7", content="Tests written", is_error=False)],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result",
+            duration_ms=1000,
+            duration_api_ms=900,
+            is_error=False,
+            num_turns=1,
+            session_id="sess-9",
+            total_cost_usd=0.01,
+        ),
+    ]
+
+    bridge = FakeBridge(events)
+    renderer = DiscordRenderer(main_thread)
+    await renderer.render_response(bridge, "write tests")
+
+    sub_thread = parent_channel._threads[0]
+
+    # Sub-thread should have the prompt embed
+    prompt_embeds = [m for m in sub_thread._messages if m.embeds and "Prompt" in (m.embeds[0].title or "")]
+    assert len(prompt_embeds) >= 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_parent_tool_use_id_not_routed():
+    """Messages with parent_tool_use_id that doesn't match a known Task are not routed."""
+    parent_channel = FakeChannel()
+    main_thread = FakeMainThread(parent_channel)
+
+    events = [
+        # Message with unknown parent_tool_use_id — should be processed normally in main
+        AssistantMessage(
+            content=[TextBlock(text="Unknown parent message")],
+            model="claude-sonnet",
+            parent_tool_use_id="unknown-id",
+        ),
+        ResultMessage(
+            subtype="result",
+            duration_ms=500,
+            duration_api_ms=400,
+            is_error=False,
+            num_turns=1,
+            session_id="sess-10",
+            total_cost_usd=0.005,
+        ),
+    ]
+
+    bridge = FakeBridge(events)
+    renderer = DiscordRenderer(main_thread)
+    await renderer.render_response(bridge, "test")
+
+    # No sub-threads created
+    assert len(parent_channel._threads) == 0
+
+    # Message should be in main thread
+    text_msgs = [m for m in main_thread._messages if m.content and "Unknown parent" in m.content]
+    assert len(text_msgs) >= 1


### PR DESCRIPTION
Sub-agents get their own Discord threads. Main thread shows summary + link.

- Task tool → creates new thread (1h auto-archive)
- Sub-agent tools/text routed via parent_tool_use_id
- Buffered streaming (typewriter) in sub-threads
- Completion updates both threads
- Fallback to inline on thread creation failure

220 tests pass. Closes #100