### PR TITLE
fix: can_use_tool permission compat + env typo detection (#103)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ CLAUDE_MODEL=sonnet
 # confirmation. Anyone who can post in a bound Discord channel will be able to
 # trigger arbitrary code execution on this host. Only enable bypassPermissions
 # if every potential message author is fully trusted with shell access.
-CLAUDE_PERMISSION_MODE=bypassPermissions
+CLAUDE_PERMISSION_MODE=default
 
 # Root directory under which `/project bind` paths must live. Optional,
 # defaults to the current user's home directory. Bindings that resolve outside

--- a/.env.example
+++ b/.env.example
@@ -4,15 +4,16 @@ DISCORD_BOT_TOKEN=your-bot-token-here
 # Claude model (sonnet, opus, haiku, or full model id). Optional, defaults to sonnet.
 CLAUDE_MODEL=sonnet
 
-# Claude permission mode (default, acceptEdits, plan, bypassPermissions).
-# Defaults to "default" which prompts for risky tool calls.
+# Claude permission mode. Options: default, acceptEdits, plan, bypassPermissions
+# NOTE: AskUserQuestion interactive prompts (buttons/select menus) only work
+# with bypassPermissions mode due to SDK/CLI protocol limitations.
 #
 # WARNING: "bypassPermissions" disables all tool-permission prompts and lets
 # Claude run any tool (including shell commands and file edits) without
 # confirmation. Anyone who can post in a bound Discord channel will be able to
 # trigger arbitrary code execution on this host. Only enable bypassPermissions
 # if every potential message author is fully trusted with shell access.
-CLAUDE_PERMISSION_MODE=default
+CLAUDE_PERMISSION_MODE=bypassPermissions
 
 # Root directory under which `/project bind` paths must live. Optional,
 # defaults to the current user's home directory. Bindings that resolve outside

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -283,6 +283,18 @@ class ClaudeBridge:
         # Always assign hooks dict (we now unconditionally register PreCompact etc.)
         hooks = _hooks_dict
 
+        use_can_use_tool = (
+            self.on_ask_user is not None
+            and self._config.claude_permission_mode == "bypassPermissions"
+        )
+
+        if self.on_ask_user is not None and not use_can_use_tool:
+            log.warning(
+                "AskUserQuestion interactive prompts disabled — "
+                "requires permission_mode='bypassPermissions' (current: '%s')",
+                self._config.claude_permission_mode,
+            )
+
         options = ClaudeCodeOptions(
             cwd=self.project_path,
             env=self._env or {},
@@ -291,10 +303,7 @@ class ClaudeBridge:
             # Only use can_use_tool when bypassing permissions.
             # In other modes, the CLI's permission system handles tool approval,
             # and our callback format is incompatible with the CLI's Zod schema.
-            can_use_tool=self._can_use_tool if (
-                self.on_ask_user is not None
-                and self._config.claude_permission_mode == "bypassPermissions"
-            ) else None,
+            can_use_tool=self._can_use_tool if use_can_use_tool else None,
             resume=self._resume_session_id,
             append_system_prompt=full_system_prompt,
             allowed_tools=self._allowed_tools,

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -288,7 +288,13 @@ class ClaudeBridge:
             env=self._env or {},
             permission_mode=self._config.claude_permission_mode,
             model=self.model,
-            can_use_tool=self._can_use_tool if self.on_ask_user else None,
+            # Only use can_use_tool when bypassing permissions.
+            # In other modes, the CLI's permission system handles tool approval,
+            # and our callback format is incompatible with the CLI's Zod schema.
+            can_use_tool=self._can_use_tool if (
+                self.on_ask_user is not None
+                and self._config.claude_permission_mode == "bypassPermissions"
+            ) else None,
             resume=self._resume_session_id,
             append_system_prompt=full_system_prompt,
             allowed_tools=self._allowed_tools,

--- a/src/clauded/config.py
+++ b/src/clauded/config.py
@@ -6,7 +6,11 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+import logging
+
 from dotenv import load_dotenv
+
+log = logging.getLogger("clauded.config")
 
 
 @dataclass(frozen=True)
@@ -34,6 +38,16 @@ def load_config() -> Config:
         projects_root = str(Path(raw_root).expanduser().resolve())
     else:
         projects_root = str(Path.home().resolve())
+
+    # Check for common env-var typos
+    typo_map = {
+        "CLAUDE_PREMISSION_MODE": "CLAUDE_PERMISSION_MODE",
+        "DISCORD_TOKEN": "DISCORD_BOT_TOKEN",
+        "CLAUDED_PROJECT_ROOT": "CLAUDED_PROJECTS_ROOT",
+    }
+    for typo, correct in typo_map.items():
+        if os.environ.get(typo):
+            log.warning("Found '%s' in env — did you mean '%s'?", typo, correct)
 
     return Config(
         discord_bot_token=token,

--- a/tests/test_claude_bridge.py
+++ b/tests/test_claude_bridge.py
@@ -228,3 +228,32 @@ async def test_send_message_generator_exit_keeps_session_active(
     # Session must still be active and client must NOT have been disconnected
     assert bridge.is_active is True
     client.disconnect.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# can_use_tool disabled when not bypassPermissions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_can_use_tool_none_when_not_bypass(monkeypatch):
+    """can_use_tool should be None when permission_mode != bypassPermissions."""
+    from clauded.config import Config
+    from clauded.session_config import SessionConfig
+    from clauded.claude_bridge import ClaudeBridge
+
+    cfg = Config(discord_bot_token="t", claude_model="sonnet",
+                 claude_permission_mode="default", projects_root="/tmp")
+    
+    captured = []
+    class FakeClient:
+        def __init__(self, options=None): captured.append(options)
+        async def connect(self, prompt=None): pass
+    
+    monkeypatch.setattr("clauded.claude_bridge.ClaudeSDKClient", FakeClient)
+    
+    sc = SessionConfig(on_ask_user=lambda x: x)  # has on_ask_user
+    bridge = ClaudeBridge("/tmp", cfg, sc)
+    await bridge.start()
+    
+    assert captured[0].can_use_tool is None  # should NOT be set in default mode

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,3 +79,13 @@ def test_projects_root_defaults_to_home(
     isolated_env.setenv("DISCORD_BOT_TOKEN", "tok-abc")
     cfg = load_config()
     assert cfg.projects_root == str(home.resolve())
+
+
+def test_typo_warning_logged(isolated_env, caplog):
+    """Common env var typos produce a warning."""
+    import logging
+    isolated_env.setenv("DISCORD_BOT_TOKEN", "tok")
+    isolated_env.setenv("CLAUDE_PREMISSION_MODE", "bypassPermissions")
+    with caplog.at_level(logging.WARNING):
+        load_config()
+    assert "did you mean" in caplog.text.lower() or "CLAUDE_PERMISSION_MODE" in caplog.text


### PR DESCRIPTION
Fixes ZodError when permission_mode != bypassPermissions. Adds env typo warnings. 222 tests pass. Closes #103