### PR TITLE
fix: 3 display issues — rolling tool log, table formatting, single subtasks thread

### DIFF
--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1164,25 +1164,41 @@ class DiscordRenderer:
 
         Discord does not render markdown tables, so we wrap them in
         code blocks where at least the column alignment is preserved.
+        Tables already inside code fences are left untouched.
         """
         lines_in = text.split("\n")
         result: list[str] = []
         in_table = False
+        in_code_fence = False
         table_lines: list[str] = []
 
         for line in lines_in:
             stripped = line.strip()
-            # Detect table rows: starts with | and ends with |
+
+            # Track existing code fences
+            if stripped.startswith("```"):
+                in_code_fence = not in_code_fence
+                if in_table and table_lines:
+                    result.append("```")
+                    result.extend(table_lines)
+                    result.append("```")
+                    in_table = False
+                    table_lines = []
+                result.append(line)
+                continue
+
+            if in_code_fence:
+                result.append(line)
+                continue
+
             if stripped.startswith("|") and stripped.endswith("|"):
                 if not in_table:
                     in_table = True
                     table_lines = []
-                # Skip separator rows like |---|---|
                 if not all(c in "|-: " for c in stripped):
                     table_lines.append(stripped)
             else:
                 if in_table:
-                    # End of table — wrap in code block
                     if table_lines:
                         result.append("```")
                         result.extend(table_lines)
@@ -1191,7 +1207,6 @@ class DiscordRenderer:
                     table_lines = []
                 result.append(line)
 
-        # Handle table at end of text
         if in_table and table_lines:
             result.append("```")
             result.extend(table_lines)

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -226,9 +226,14 @@ class DiscordRenderer:
         task_depth = 0                            # subtask nesting depth (#74)
         # Stats populated from ResultMessage
         stats: dict | None = None
+        # Rolling tool log (Issue #1: merge consecutive tool embeds)
+        tool_log_msg: discord.Message | None = None
+        tool_log_lines: list[str] = []
         # Sub-agent thread tracking: parent_tool_use_id -> thread/renderer
         subagent_threads: dict[str, discord.Thread] = {}
         subagent_renderers: dict[str, "DiscordRenderer"] = {}
+        # Single subtasks thread for all sub-agents (Issue #3)
+        subtasks_thread: discord.Thread | None = None
 
         try:
             async for event in bridge.send_message(user_text):
@@ -305,32 +310,45 @@ class DiscordRenderer:
                                         await sub_renderer._safe_send(content=sub_renderer._sub_buffer[:DISCORD_MAX_LEN])
                                     sub_renderer._sub_buffer = ""
                                     sub_renderer._sub_msg = None
-                                tool_embed = self._build_tool_embed(block)
                                 tool_id = getattr(block, "id", None)
                                 name = getattr(block, "name", "tool") or "tool"
                                 if tool_id:
                                     tool_names[tool_id] = name
-                                tmsg = await sub_renderer._safe_send(embed=tool_embed)
-                                if tmsg is not None and tool_id:
-                                    tool_msgs[tool_id] = tmsg
+                                # Rolling tool log for sub-agent
+                                if not hasattr(sub_renderer, '_tool_log_lines'):
+                                    sub_renderer._tool_log_lines = []
+                                    sub_renderer._tool_log_msg = None
+                                sub_renderer._tool_log_lines.append(f"🔄 {name}...")
+                                tool_embed = discord.Embed(
+                                    title="🔧 Tool Activity",
+                                    description="\n".join(sub_renderer._tool_log_lines[-15:]),
+                                    color=COLOR_TOOL_RUNNING,
+                                )
+                                if sub_renderer._tool_log_msg is None:
+                                    sub_renderer._tool_log_msg = await sub_renderer._safe_send(embed=tool_embed)
+                                else:
+                                    await sub_renderer._safe_edit(sub_renderer._tool_log_msg, embed=tool_embed)
                             elif isinstance(block, ToolResultBlock):
                                 tool_id = getattr(block, "tool_use_id", None)
                                 result_name = tool_names.get(tool_id, "") if tool_id else ""
                                 is_err = bool(getattr(block, "is_error", False))
-                                if tool_id and tool_id in tool_msgs:
-                                    if is_err:
-                                        result_embed = discord.Embed(
-                                            title=f"❌ {result_name or 'tool'}",
-                                            color=COLOR_TOOL_FAILURE,
-                                        )
-                                        error_text = str(block.content)[:500] if block.content else "Failed"
-                                        result_embed.description = f"```\n{error_text}\n```"
-                                    else:
-                                        result_embed = discord.Embed(
-                                            title=f"✅ {result_name or 'tool'}",
-                                            color=COLOR_TOOL_SUCCESS,
-                                        )
-                                    await sub_renderer._safe_edit(tool_msgs[tool_id], embed=result_embed)
+                                if hasattr(sub_renderer, '_tool_log_msg') and sub_renderer._tool_log_msg is not None:
+                                    status = "✅" if not is_err else "❌"
+                                    for i in range(len(sub_renderer._tool_log_lines) - 1, -1, -1):
+                                        if sub_renderer._tool_log_lines[i].startswith("🔄 " + (result_name or "")):
+                                            if is_err:
+                                                error_text = str(block.content)[:100] if block.content else "Failed"
+                                                sub_renderer._tool_log_lines[i] = f"{status} {result_name or 'tool'}: {error_text}"
+                                            else:
+                                                sub_renderer._tool_log_lines[i] = f"{status} {result_name or 'tool'}"
+                                            break
+                                    has_errors = any("❌" in l for l in sub_renderer._tool_log_lines)
+                                    tool_embed = discord.Embed(
+                                        title="🔧 Tool Activity",
+                                        description="\n".join(sub_renderer._tool_log_lines[-15:]),
+                                        color=COLOR_TOOL_FAILURE if has_errors else COLOR_TOOL_SUCCESS,
+                                    )
+                                    await sub_renderer._safe_edit(sub_renderer._tool_log_msg, embed=tool_embed)
                             elif isinstance(block, ThinkingBlock):
                                 thinking_text = block.thinking[:3900].replace("||", "\\|\\|")
                                 embed = discord.Embed(
@@ -442,36 +460,43 @@ class DiscordRenderer:
                                 continue
 
                             # --- Special tool display: Task subtask (#55, #74) ---
-                            # Creates a separate Discord thread for each sub-agent
+                            # Creates/reuses a single "Subtasks" thread for all sub-agents
                             if name in ("Task", "Agent"):
                                 task_depth += 1
                                 desc = block.input.get("description", "")[:300]
                                 prompt = block.input.get("prompt", "")[:500]
 
-                                # Try to create a sub-agent thread
+                                # Try to create or reuse a shared subtasks thread
                                 try:
-                                    parent_channel = self.target
-                                    if hasattr(parent_channel, 'parent') and parent_channel.parent:
-                                        parent_channel = parent_channel.parent
+                                    if subtasks_thread is None:
+                                        parent_channel = self.target
+                                        if hasattr(parent_channel, 'parent') and parent_channel.parent:
+                                            parent_channel = parent_channel.parent
 
-                                    thread_name = f"🔀 Subtask: {desc[:80]}" if desc else f"🔀 Subtask #{task_depth}"
-
-                                    # Create thread in the parent channel
-                                    anchor_msg = await parent_channel.send(
-                                        embed=discord.Embed(
-                                            title=thread_name,
-                                            description=f"Sub-agent working on: {desc}" if desc else "Sub-agent started",
-                                            color=COLOR_INFO,
+                                        anchor_msg = await parent_channel.send(
+                                            embed=discord.Embed(
+                                                title="🔀 Subtasks",
+                                                description="Sub-agent activity",
+                                                color=COLOR_INFO,
+                                            )
                                         )
-                                    )
-                                    sub_thread = await anchor_msg.create_thread(
-                                        name=thread_name[:100],
-                                        auto_archive_duration=60,
-                                    )
+                                        subtasks_thread = await anchor_msg.create_thread(
+                                            name="🔀 Subtasks"[:100],
+                                            auto_archive_duration=60,
+                                        )
+
+                                    sub_thread = subtasks_thread
 
                                     if tool_id:
                                         subagent_threads[tool_id] = sub_thread
                                         subagent_renderers[tool_id] = DiscordRenderer(sub_thread)
+
+                                    # Post subtask header as separator in the shared thread
+                                    sep = discord.Embed(
+                                        title=f"━━━ Subtask #{task_depth}: {desc[:80]} ━━━",
+                                        color=COLOR_INFO,
+                                    )
+                                    await sub_thread.send(embed=sep)
 
                                     # In the main thread, show compact summary with link
                                     _guild_id = getattr(self.target, 'guild', None) and self.target.guild.id
@@ -680,12 +705,17 @@ class DiscordRenderer:
                                     tool_msgs[tool_id] = tmsg
                                 continue
 
-                            # Build a colored embed for the tool execution
-                            tool_embed = self._build_tool_embed(block)
-
-                            tmsg = await self._safe_send(embed=tool_embed)
-                            if tmsg is not None and tool_id:
-                                tool_msgs[tool_id] = tmsg
+                            # Rolling tool log: merge consecutive tool embeds
+                            tool_log_lines.append(f"🔄 {name}...")
+                            tool_embed = discord.Embed(
+                                title="🔧 Tool Activity",
+                                description="\n".join(tool_log_lines[-15:]),
+                                color=COLOR_TOOL_RUNNING,
+                            )
+                            if tool_log_msg is None:
+                                tool_log_msg = await self._safe_send(embed=tool_embed)
+                            else:
+                                await self._safe_edit(tool_log_msg, embed=tool_embed)
 
                             # Show file content preview for Write/Edit tools
                             if block.name == "Write":
@@ -784,10 +814,28 @@ class DiscordRenderer:
                             if result_name == "TaskStop":
                                 continue
 
-                            if tool_id and tool_id in tool_msgs:
+                            is_err = bool(getattr(block, "is_error", False))
+                            name = tool_names.get(tool_id, "tool") if tool_id else "tool"
+                            if tool_log_msg is not None:
+                                # Update rolling tool log
+                                status = "✅" if not is_err else "❌"
+                                for i in range(len(tool_log_lines) - 1, -1, -1):
+                                    if tool_log_lines[i].startswith("🔄 " + name):
+                                        if is_err:
+                                            error_text = str(block.content)[:100] if block.content else "Failed"
+                                            tool_log_lines[i] = f"{status} {name}: {error_text}"
+                                        else:
+                                            tool_log_lines[i] = f"{status} {name}"
+                                        break
+                                has_errors = any("❌" in l for l in tool_log_lines)
+                                tool_embed = discord.Embed(
+                                    title="🔧 Tool Activity",
+                                    description="\n".join(tool_log_lines[-15:]),
+                                    color=COLOR_TOOL_FAILURE if has_errors else COLOR_TOOL_SUCCESS,
+                                )
+                                await self._safe_edit(tool_log_msg, embed=tool_embed)
+                            elif tool_id and tool_id in tool_msgs:
                                 orig_msg = tool_msgs[tool_id]
-                                name = tool_names.get(tool_id, "tool")
-                                is_err = bool(getattr(block, "is_error", False))
                                 if is_err:
                                     result_embed = discord.Embed(
                                         title=f"❌ {name}",
@@ -937,6 +985,7 @@ class DiscordRenderer:
         """Replace the cursor in ``live_msg`` and emit any overflow as new messages."""
         # E1: Process channel/thread markers before finalizing.
         buffer = await self._process_markers(buffer)
+        buffer = self._format_tables(buffer)
         if len(buffer) <= DISCORD_MAX_LEN:
             await self._safe_edit(live_msg, content=buffer)
             self._last_msg = live_msg
@@ -966,6 +1015,7 @@ class DiscordRenderer:
         # Process channel/thread management markers before sending.
         if buffer:
             buffer = await self._process_markers(buffer)
+        buffer = self._format_tables(buffer)
 
         if typewriter and live_msg is not None:
             await self._finalize_typewriter(live_msg, buffer)
@@ -1103,6 +1153,52 @@ class DiscordRenderer:
                 log.warning("Discord edit failed after backoff", exc_info=True)
         except discord.HTTPException:
             log.warning("Discord edit failed", exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Markdown table → code block conversion
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _format_tables(text: str) -> str:
+        """Convert markdown tables to code blocks for Discord.
+
+        Discord does not render markdown tables, so we wrap them in
+        code blocks where at least the column alignment is preserved.
+        """
+        lines_in = text.split("\n")
+        result: list[str] = []
+        in_table = False
+        table_lines: list[str] = []
+
+        for line in lines_in:
+            stripped = line.strip()
+            # Detect table rows: starts with | and ends with |
+            if stripped.startswith("|") and stripped.endswith("|"):
+                if not in_table:
+                    in_table = True
+                    table_lines = []
+                # Skip separator rows like |---|---|
+                if not all(c in "|-: " for c in stripped):
+                    table_lines.append(stripped)
+            else:
+                if in_table:
+                    # End of table — wrap in code block
+                    if table_lines:
+                        result.append("```")
+                        result.extend(table_lines)
+                        result.append("```")
+                    in_table = False
+                    table_lines = []
+                result.append(line)
+
+        # Handle table at end of text
+        if in_table and table_lines:
+            result.append("```")
+            result.extend(table_lines)
+            result.append("```")
+
+        return "\n".join(result)
+
 
     # ------------------------------------------------------------------
     # Smart text splitting

--- a/tests/test_smart_split.py
+++ b/tests/test_smart_split.py
@@ -163,3 +163,23 @@ def test_detect_open_fence_lang_picks_last_open_fence() -> None:
     # Two fences (closed pair) followed by a third open one with lang "rust".
     chunk = "```py\nfoo\n```\nbetween\n```rust\nbar"
     assert DiscordRenderer._detect_open_fence_lang(chunk) == "rust"
+
+
+# ---------------------------------------------------------------------------
+# _format_tables – code-fence awareness
+# ---------------------------------------------------------------------------
+
+
+def test_format_tables_inside_code_block():
+    """Tables already inside a code fence are not double-wrapped."""
+    text = "Output:\n```\n| id | name |\n|----|\n| 1  | Alice |\n```\nDone."
+    result = DiscordRenderer._format_tables(text)
+    assert result.count("```") == 2  # only the original pair, no double-wrapping
+
+
+def test_format_tables_normal():
+    """A bare markdown table is wrapped in a code block."""
+    text = "Results:\n| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |\nEnd."
+    result = DiscordRenderer._format_tables(text)
+    assert "```" in result  # table wrapped
+    assert "| Alice | 30 |" in result

--- a/tests/test_subagent_threads.py
+++ b/tests/test_subagent_threads.py
@@ -284,9 +284,12 @@ async def test_subagent_messages_routed_to_thread():
     text_msgs = [m for m in sub_thread._messages if m.content and "researching" in m.content]
     assert len(text_msgs) >= 1
 
-    # Tool embed should be in sub-thread
-    tool_embeds = [m for m in sub_thread._messages if m.embeds and "Bash" in (m.embeds[0].title or "")]
+    # Tool activity embed should be in sub-thread (rolling tool log)
+    tool_embeds = [m for m in sub_thread._messages if m.embeds and "Tool Activity" in (m.embeds[0].title or "")]
     assert len(tool_embeds) >= 1
+    # Bash should appear in the tool log description
+    tool_desc = tool_embeds[0].embeds[0].description or ""
+    assert "Bash" in tool_desc
 
     # Main thread should NOT have the sub-agent's text
     main_text = [m for m in main_thread._messages if m.content and "researching" in m.content]
@@ -516,17 +519,19 @@ async def test_multiple_subagents_get_separate_threads():
     renderer = DiscordRenderer(main_thread)
     await renderer.render_response(bridge, "multi-task")
 
-    # Two sub-threads should be created
-    assert len(parent_channel._threads) == 2
+    # All subtasks share a single thread
+    assert len(parent_channel._threads) == 1
 
-    # Each sub-thread should have its own text
-    thread_a = parent_channel._threads[0]
-    thread_b = parent_channel._threads[1]
-
-    a_text = [m for m in thread_a._messages if m.content and "Alpha" in m.content]
-    b_text = [m for m in thread_b._messages if m.content and "Beta" in m.content]
+    # Both subtask texts should be in the shared thread
+    shared_thread = parent_channel._threads[0]
+    a_text = [m for m in shared_thread._messages if m.content and "Alpha" in m.content]
+    b_text = [m for m in shared_thread._messages if m.content and "Beta" in m.content]
     assert len(a_text) >= 1
     assert len(b_text) >= 1
+
+    # Separator embeds should exist for each subtask
+    sep_embeds = [m for m in shared_thread._messages if m.embeds and "━━━" in (m.embeds[0].title or "")]
+    assert len(sep_embeds) >= 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes real-world display problems found in user testing:

1. Tool embed flood → single rolling "🔧 Tool Activity" embed (last 15 entries, edits in place)
2. Markdown tables → auto-wrapped in code blocks (skips existing code fences)
3. Scattered subtask threads → single shared "🔀 Subtasks" thread with separator embeds

224 tests pass.