### PR TITLE
fix(renderer): sync local msg.content after edit (long-session truncation root-cause #2, #113)

### DIFF
--- a/docs/investigations/stale-message-content.md
+++ b/docs/investigations/stale-message-content.md
@@ -1,0 +1,215 @@
+# Truncation Bug — Second Root Cause: Stale `Message.content` After Edit
+
+**Status:** Resolved (fix in PR — see below)
+**Reported:** 2026-05-09 by user (hxy) — pushback after PR #108 merge: "did you actually test it? in real conditions?"
+**Investigated:** 2026-05-09
+**Fix:** `src/clauded/discord_renderer.py` (shadow `_last_msg_text`, sync `msg.content` after edit)
+**Issue:** #113
+
+---
+
+## 1. Context
+
+PR #108 (commit `400d76f`) fixed one truncation root cause: `_safe_send`/`_safe_edit` were silently swallowing `discord.HTTPException` and dropping content on retry-able 5xx storms. Verification was offline only — under real Discord conditions a separate truncation pattern remained, with **~33% reproduction rate** on long sessions.
+
+This document is the root cause analysis for that second pattern.
+
+## 2. Symptom
+
+E2E test `scripts/e2e_truncation.py --mode A` against real Discord + real Claude:
+
+| Run | SDK delta | SDK result | Discord channel | render_diff | Verdict |
+|-----|-----------|------------|-----------------|-------------|---------|
+| 1 | 18161 | 18161 | 17997 | +164 (within tolerance) | PASS |
+| **2** | **17553** | **17553** | **16199** | **+1354 LOST** | **FAIL** |
+| 3 | 14741 | 14741 | 14517 | +224 (within tolerance) | PASS |
+
+The failing run captured artifacts in `logs/e2e_A_1778326687_bodies/`. Examining the diff between `result.txt` (SDK ground truth) and `channel.txt` (`channel.history` ground truth) showed **the channel matched perfectly through char 1762, then started losing content** — culminating in the entire ` 总结` section (last ~1336 chars) never reaching Discord at all.
+
+There were **zero** ERROR logs (`DROPPED N chars` / `UNDELIVERED N chars`) — meaning none of PR #108's retry-failure paths fired. `saw_retry_log: false, saw_dropped_log: false` in the run summary.
+
+This case also matches user-reported screenshots from 5/8 (471s session, 6.7k tokens, content cut mid-sentence with cursor `▌` still present + cost footer immediately following).
+
+## 3. Methodology — instrumentation, not speculation
+
+Round-1 mistake (PR #108): I merged based on offline harness verification + 7-perspective review only. User pushed back. To find the second root cause I needed to actually observe what `msg.content` was each time the renderer touched it.
+
+### 3.1 Tried offline replay first — couldn't reproduce
+
+`/tmp/replay_failing_run.py` replayed the captured 5589 SDK events through a `SpyTarget`/`SpyMessage` into the real `DiscordRenderer.render_response`. Result: **17591 chars rendered, 0 lost.** Offline cannot reproduce. So the bug is in the real-Discord-HTTP layer that offline mocks bypass.
+
+### 3.2 Added per-call instrumentation, ran real E2E
+
+Added `T-INSTR` log lines (commit-scoped, reverted before final fix):
+
+```python
+# In _safe_edit, before _retry_http:
+log.info("T-INSTR edit-pre: msg_id=%s pre_content_len=%d new_content_len=%d", ...)
+# After _retry_http:
+log.info("T-INSTR edit-post: msg_id=%s ok=%s post_content_len=%d (was pre=%d new=%d)", ...)
+# Just before cost footer reads _last_msg.content:
+log.info("T-INSTR cost-footer-pre: last_msg_id=%s last_msg_content_len=%d", ...)
+```
+
+Re-ran `e2e_truncation.py --mode A`. **First run reproduced the bug** and produced this smoking-gun log:
+
+```
+edit-pre:  msg_id=...411836 pre_content_len=499 new_content_len=911
+edit-post: msg_id=...411836 ok=True post_content_len=499 (was pre=499 new=911)  ← still 499
+edit-pre:  msg_id=...411836 pre_content_len=499 new_content_len=1388
+edit-post: msg_id=...411836 ok=True post_content_len=499 (was pre=499 new=1388) ← still 499
+cost-footer-pre: last_msg_id=...411836 last_msg_content_len=499                  ← reads 499
+edit-pre:  msg_id=...411836 pre_content_len=499 new_content_len=544              ← writes back 499 + footer
+```
+
+Aggregate: **39/39 successful edits, 0 syncs to local `msg.content`**. Every single edit on the same `msg` object left `msg.content` at its initial-send value forever.
+
+## 4. Root Cause
+
+### 4.1 discord.py 2.0+ behavior change
+
+[`discord/message.py:2868-2997`](https://github.com/Rapptz/discord.py/blob/master/discord/message.py) — `Message.edit(...)`:
+
+```python
+async def edit(self, ...) -> Message:
+    """Edits the message.
+
+    .. versionchanged:: 2.0
+        Edits are no longer in-place, the newly edited message is returned instead.
+    """
+    ...
+    data = await self._state.http.edit_message(self.channel.id, self.id, params=params)
+    message = Message(state=self._state, channel=self.channel, data=data)  # NEW object
+    ...
+    return message
+```
+
+After a successful `await msg.edit(content=X)`:
+- ✅ Discord server-side content is updated to `X`
+- ❌ Local `msg.content` stays at whatever it was when `msg` was first constructed (typically the original `send` payload)
+
+This was a deliberate breaking change in discord.py 2.0. v1.x updated `self` in place; v2.0 explicitly does not.
+
+### 4.2 Discord API confirms the protocol
+
+[Discord docs — Edit Message](https://github.com/discord/discord-api-docs/blob/main/developers/resources/message.mdx#L1161-L1168):
+
+> ## Edit Message
+> `PATCH /channels/{channel.id}/messages/{message.id}`
+> ...
+> **Returns a message object.** Fires a Message Update Gateway event.
+
+The API returns the full edited message object. discord.py 2.0 builds a fresh `Message` from that response and returns it instead of mutating the original.
+
+### 4.3 Renderer pre-fix: discards the return value
+
+`discord_renderer.py` pre-fix:
+
+```python
+async def _safe_edit(self, msg, content=...):
+    async def _op():
+        await msg.edit(**kwargs)   # ← return value discarded
+        return msg
+    result = await self._retry_http(_op, ...)
+    return result is not None
+```
+
+And the cost footer (line 780):
+
+```python
+current = (self._last_msg.content or "").rstrip(CURSOR)  # ← stale!
+await self._safe_edit(self._last_msg, content=current + footer)
+```
+
+The cost-footer path reads `_last_msg.content` (= stale initial-send value, typically a few hundred chars of cursor-stage text), appends the footer, and **edits that short content + footer back** into the live message — clobbering the long content that all the previous typewriter ticks had successfully written.
+
+### 4.4 Why the bug is intermittent
+
+- Short sessions (<3s): fast-path, no typewriter, single send. `_last_msg.content` matches what was sent. No stale state.
+- Long sessions where the final content happens to be short (≤ first send size): stale read returns ~current value, footer overwrite produces no visible loss.
+- Long sessions where the final live message has been edited multiple times to grow large: stale read returns initial cursor-stage value (a few hundred chars), footer overwrite causes thousands of chars to vanish. **This is the failing 1/3 case.**
+
+## 5. Fix
+
+`src/clauded/discord_renderer.py`:
+
+1. **`__init__`** — add `self._last_msg_text: str = ""` (shadow of what we last wrote to `_last_msg`).
+2. **`_safe_send`** — after a successful content send, set `self._last_msg = msg; self._last_msg_text = content`.
+3. **`_safe_edit`** — after a successful edit on `msg`, sync `msg.content = content` and (if `msg is self._last_msg`) update `self._last_msg_text = content`.
+4. **Cost-footer site** — read `self._last_msg_text.rstrip(CURSOR)` instead of `self._last_msg.content`.
+
+The `msg.content = content` write is layer 1 of the defense (any future code reading `msg.content` will see the right value); the `_last_msg_text` shadow is layer 2 (the specific cost-footer path is independent of any `msg.content` source).
+
+### Why I'm not switching to "use the return value of `msg.edit()` as the new live_msg"
+
+It would be more idiomatic but invasive: `_safe_edit` is called from many sites with different `msg` lifetimes (live cursor msg, fixed tool-status msgs in dictionaries, sub-agent state). Threading a "new msg" return through every callsite risks regressing other paths. The shadow-on-success pattern is local and minimally invasive.
+
+## 6. Verification
+
+### 6.1 Real bot, real Claude, real Discord — 4 runs
+
+After the fix:
+
+| Run | SDK delta | SDK result | Discord channel | render_diff | Verdict |
+|-----|-----------|------------|-----------------|-------------|---------|
+| e2e A run 1 | 16065 | 16065 | 16047 | -18 | ✅ PASS |
+| e2e A run 2 | 13392 | 13392 | 13378 | -14 | ✅ PASS |
+| e2e A run 3 | 17726 | 17726 | 17708 | -18 | ✅ PASS |
+| **real bot dogfood** (user-triggered) | **3055** | **3055** | **3090** | **-35** | **✅ PASS** |
+
+The `-N` `render_diff` values are negative-or-small because:
+- `_smart_split`'s `lstrip("\n")` strips leading paragraph blanks from each chunk after splitting (~9 × 2 = 18 chars per long-session split; visually identical, prevents double-spacing at chunk boundaries).
+- `_format_tables` adds ` ``` `code-fence wrappers around markdown tables (the `+35` in the real-bot run came from a table being wrapped — channel literally has *more* characters than the SDK output, all formatting overhead).
+
+Neither is content loss. Both behaviors predate this fix and are not symptomatic of any bug.
+
+### 6.2 Real-bot dogfood comparison — same prompt, before vs after
+
+Thread `1502169957033574451`, same user repeatedly asking for the same research summary:
+
+| Time | Fix? | bot reply | Last 50 chars |
+|------|------|-----------|---------------|
+| 13:47 | ❌ | 2 msgs / **2135 chars** | `"...| `top_k` | reque...se64，"` ← truncated mid-string |
+| 15:42 | ✅ | 2 msgs / **3090 chars** | `"...| ```"` ← natural code-fence close |
+
+Same prompt, same model, same `~$0.41` cost / `~28s` duration. Pre-fix: truncated. Post-fix: complete. User had asked at 13:47 *"消息没发全，重新给我发一下"* (message wasn't fully sent, send it again) — the exact symptom.
+
+### 6.3 pytest
+
+`PYTHONPATH=src pytest tests/` → 242 passed / 2 failed. Same 2 pre-existing failures from commit `2608502` (tracked separately as P1, unrelated to this fix).
+
+### 6.4 What's NOT verified
+
+- The defensive `msg.content = content` write in `_safe_edit` could in theory be a problem if a `MESSAGE_UPDATE` gateway event arrives shortly after and overwrites it back to the (correct) value — in either case the value seen by next reader is correct, so this is a non-issue.
+- Behavior under the discord.py 1.x semantics (in-place edit) is untested — but the project requires `discord.py>=2.7` per `pyproject.toml`, so 1.x is out of scope.
+
+## 7. Process retrospective
+
+This is the second time this project has shipped a "truncation fix" that wasn't actually verified end-to-end.
+
+**5/8 (previous manager):** Closed investigation after 5 short tests, hypothesized `max_tokens` truncation. Wrong.
+
+**5/9 (me, PR #108):** Found genuine bug in retry path, wrote thorough offline harness, ran 3 rounds of 7-perspective review, merged. Did NOT run real E2E before merge. Investigation §6 explicitly deferred real-world verification with rationale "ships with error-level logging so future occurrences become visible". User pushed back: *"did you actually test? in real conditions?"* — and produced the second root cause.
+
+The hard rule going forward, written into `memory/claudeD.md`:
+
+> **For silent-loss class bugs, real-environment E2E verification is a merge gate. Not deferrable. Not "ships with logging".** The first time the user tries it after merge IS the verification — by which point you've spent a round of 7-perspective review and 3 dev iterations on a fix that may not be the fix.
+
+Specifically, this fix was found by:
+1. Adding observability (`T-INSTR` logs) at the exact suspect lines.
+2. Running E2E once. Bug reproduced first try.
+3. Reading the log. Bug visible in log line 1.
+
+That's 5 minutes of work. Done before PR #108 merge it would have caught both root causes simultaneously.
+
+## 8. Artifacts
+
+```
+docs/investigations/stale-message-content.md            ← this report
+.crew/stale-content-fix/status.json                     ← status tracking
+logs/e2e_A_1778326687_bodies/{result,channel,delta}.txt ← failing run capture
+logs/e2e_A_1778337230.{log,json}                        ← instrumented run that nailed root cause
+.crew/truncation-fix/real-bot-thread/                   ← real-bot dogfood capture
+```
+
+`logs/` is gitignored; artifacts are regenerable from `scripts/e2e_truncation.py`.

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -106,6 +106,23 @@ class DiscordRenderer:
     def __init__(self, target: discord.abc.Messageable) -> None:
         self.target = target
         self._last_msg: discord.Message | None = None
+        # Track the text we LAST WROTE to ``_last_msg``.
+        #
+        # discord.py 2.0+'s ``Message.edit(...)`` is NOT in-place: per
+        # the official docstring ("Edits are no longer in-place, the
+        # newly edited message is returned instead"), the call constructs
+        # and returns a fresh ``Message`` object built from the API
+        # response. The ``self`` we passed in keeps its original
+        # ``.content`` forever — even after a successful edit. Reading
+        # ``_last_msg.content`` after we've edited it therefore returns
+        # the ORIGINAL ``send`` payload (typically the cursor-stage
+        # short text), not what's currently visible in Discord.
+        #
+        # Using that stale value to compute the cost-footer overwrite was
+        # the long-session truncation root cause: the footer wrote back
+        # ``stale_initial + footer``, clobbering everything written via
+        # subsequent edits.
+        self._last_msg_text: str = ""
 
     # ------------------------------------------------------------------
     # Helper: build a tool embed from a ToolUseBlock
@@ -777,7 +794,11 @@ class DiscordRenderer:
         # Append cost/stats footer to the last sent message
         if self._last_msg and stats and stats.get('cost', 0) > 0:
             try:
-                current = (self._last_msg.content or "").rstrip(CURSOR)
+                # Use our own shadow of what we last wrote, NOT
+                # ``_last_msg.content`` — that's discord.py's local
+                # cache and lags the actual edit state. Reading from
+                # there silently truncated long sessions.
+                current = self._last_msg_text.rstrip(CURSOR)
                 duration_s = stats['duration_ms'] / 1000
                 footer = (
                     f"\n\n-# 💰 ${stats['cost']:.4f}"
@@ -1158,6 +1179,7 @@ class DiscordRenderer:
         )
         if msg is not None and content:
             self._last_msg = msg
+            self._last_msg_text = content
         return msg
 
     async def _safe_edit(
@@ -1196,6 +1218,21 @@ class DiscordRenderer:
             label="edit",
             content_len=len(content) if content else 0,
         )
+        # Sync our content shadow on success. discord.py 2.0+'s
+        # ``Message.edit()`` is NOT in-place — per its official
+        # docstring it constructs and returns a NEW ``Message``
+        # object, leaving ``self.content`` unchanged forever. Without
+        # syncing, ``_last_msg.content`` stays at its initial-send
+        # value and any later read — most importantly the cost-footer
+        # append — silently overwrites the message in Discord with
+        # that stale value (truncation root cause, fixed 5/9).
+        if result is not None and content is not None:
+            try:
+                msg.content = content
+            except Exception:
+                pass
+            if msg is self._last_msg:
+                self._last_msg_text = content
         return result is not None
 
     # ------------------------------------------------------------------

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -980,7 +980,8 @@ class DiscordRenderer:
                 await self._safe_send(content=summary, file=f)
                 return
             for chunk in chunks:
-                if self._should_upload_as_file(chunk):
+                is_file = self._should_upload_as_file(chunk)
+                if is_file:
                     ext, code = self._extract_code_info(chunk)
                     f = discord.File(io.BytesIO(code.encode()), filename=f"output.{ext}")
                     sent = await self._safe_send(file=f)
@@ -988,6 +989,9 @@ class DiscordRenderer:
                     sent = await self._safe_send(content=chunk)
                 if sent is not None:
                     self._last_msg = sent
+                    if is_file:
+                        # File-only — no text body for the cost footer to splice.
+                        self._last_msg_text = ""
             return
 
         # No text buffered. If we never showed *anything* (no text, no tools),
@@ -1161,9 +1165,15 @@ class DiscordRenderer:
             content_len=len(content or ""),
             between_attempts=_reset_file if "file" in kwargs else None,
         )
-        if msg is not None:
+        # Only advance the shadow on content-bearing sends. Embed-only and
+        # file-only sends do NOT touch _last_msg here — callers that want
+        # _last_msg to track them must reassign it (and the shadow)
+        # explicitly. See #113 round-2: widening this to "any successful
+        # send" lets an interleaved tool-embed clobber the shadow to "" and
+        # the cost-footer then rewrites the long text down to just footer.
+        if msg is not None and content:
             self._last_msg = msg
-            self._last_msg_text = content or ""
+            self._last_msg_text = content
         return msg
 
     async def _safe_edit(
@@ -1174,8 +1184,13 @@ class DiscordRenderer:
         embed: discord.Embed | None = None,
         view: discord.ui.View | None = None,
     ) -> bool:
-        """Edit a message with retry/backoff. Returns ``True`` iff the edit
+        """Edit ``msg`` with retry/backoff. Returns ``True`` iff the edit
         eventually succeeded.
+
+        The shadow ``self._last_msg_text`` is updated only when ``msg is
+        self._last_msg``. Callers that mutate ``self._last_msg`` directly
+        (e.g., ``_finalize_typewriter``, ``_flush``) are responsible for
+        keeping the shadow consistent — see #113.
 
         We expose the success bool so callers (most importantly
         ``_typewriter_tick``) can fall back to a fresh ``send`` if an edit

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -106,22 +106,9 @@ class DiscordRenderer:
     def __init__(self, target: discord.abc.Messageable) -> None:
         self.target = target
         self._last_msg: discord.Message | None = None
-        # Track the text we LAST WROTE to ``_last_msg``.
-        #
-        # discord.py 2.0+'s ``Message.edit(...)`` is NOT in-place: per
-        # the official docstring ("Edits are no longer in-place, the
-        # newly edited message is returned instead"), the call constructs
-        # and returns a fresh ``Message`` object built from the API
-        # response. The ``self`` we passed in keeps its original
-        # ``.content`` forever — even after a successful edit. Reading
-        # ``_last_msg.content`` after we've edited it therefore returns
-        # the ORIGINAL ``send`` payload (typically the cursor-stage
-        # short text), not what's currently visible in Discord.
-        #
-        # Using that stale value to compute the cost-footer overwrite was
-        # the long-session truncation root cause: the footer wrote back
-        # ``stale_initial + footer``, clobbering everything written via
-        # subsequent edits.
+        # Shadow of the text we last wrote to ``_last_msg``. discord.py 2.0+
+        # Message.edit() is not in-place; reading msg.content post-edit returns
+        # stale text. See docs/investigations/stale-message-content.md (#113).
         self._last_msg_text: str = ""
 
     # ------------------------------------------------------------------
@@ -794,10 +781,7 @@ class DiscordRenderer:
         # Append cost/stats footer to the last sent message
         if self._last_msg and stats and stats.get('cost', 0) > 0:
             try:
-                # Use our own shadow of what we last wrote, NOT
-                # ``_last_msg.content`` — that's discord.py's local
-                # cache and lags the actual edit state. Reading from
-                # there silently truncated long sessions.
+                # Read the shadow, not _last_msg.content (stale; see #113).
                 current = self._last_msg_text.rstrip(CURSOR)
                 duration_s = stats['duration_ms'] / 1000
                 footer = (
@@ -1177,9 +1161,9 @@ class DiscordRenderer:
             content_len=len(content or ""),
             between_attempts=_reset_file if "file" in kwargs else None,
         )
-        if msg is not None and content:
+        if msg is not None:
             self._last_msg = msg
-            self._last_msg_text = content
+            self._last_msg_text = content or ""
         return msg
 
     async def _safe_edit(
@@ -1218,21 +1202,9 @@ class DiscordRenderer:
             label="edit",
             content_len=len(content) if content else 0,
         )
-        # Sync our content shadow on success. discord.py 2.0+'s
-        # ``Message.edit()`` is NOT in-place — per its official
-        # docstring it constructs and returns a NEW ``Message``
-        # object, leaving ``self.content`` unchanged forever. Without
-        # syncing, ``_last_msg.content`` stays at its initial-send
-        # value and any later read — most importantly the cost-footer
-        # append — silently overwrites the message in Discord with
-        # that stale value (truncation root cause, fixed 5/9).
-        if result is not None and content is not None:
-            try:
-                msg.content = content
-            except Exception:
-                pass
-            if msg is self._last_msg:
-                self._last_msg_text = content
+        # Sync shadow on success — see #113 / docs/investigations/stale-message-content.md.
+        if result is not None and content is not None and msg is self._last_msg:
+            self._last_msg_text = content
         return result is not None
 
     # ------------------------------------------------------------------

--- a/tests/test_renderer_retries.py
+++ b/tests/test_renderer_retries.py
@@ -453,3 +453,150 @@ async def test_subagent_typewriter_falls_back_on_edit_failure(_no_sleep):
     assert result.content == "new sub text"
     # Original live unchanged — edit attempts all failed.
     assert live.content == "old sub content"
+
+
+# ---------------------------------------------------------------------------
+# Stale-content regression tests (issue #113)
+#
+# discord.py 2.0+'s ``Message.edit(...)`` is NOT in-place: per its docstring
+# "Edits are no longer in-place, the newly edited message is returned
+# instead." Pre-fix code read ``self._last_msg.content`` to compute the
+# cost-footer overwrite, so it picked up the STALE initial-send value and
+# overwrote whatever the typewriter had subsequently edited into Discord.
+#
+# The default ``FakeMessage`` in this file mimics 1.x semantics (writes
+# self.content on edit), which masked the bug in offline tests. Below we
+# use ``StaleEditFakeMessage`` which matches the real 2.0+ behavior, and
+# assert that the renderer keeps an accurate shadow.
+# ---------------------------------------------------------------------------
+
+
+class StaleEditFakeMessage(FakeMessage):
+    """Mimics discord.py 2.0+ Message.edit(): does NOT update self.content.
+
+    The edit succeeds at the API layer (records the call), but the local
+    object's ``content`` attribute remains at whatever it was when the
+    message was constructed. This matches the real-Discord behavior we
+    observed in `T-INSTR` instrumentation: 39/39 successful edits, 0
+    syncs to local content.
+    """
+
+    async def edit(self, *, content=None, embed=None, **kw):
+        if self.edit_raises:
+            exc = self.edit_raises.pop(0)
+            if exc is not None:
+                raise exc
+        if content is not None:
+            self.edits.append(content)
+        # Note: deliberately do NOT touch self.content.
+        return self
+
+
+class StaleEditFakeTarget(FakeTarget):
+    """FakeTarget that hands out StaleEditFakeMessage instances."""
+
+    async def send(self, content=None, **kw):
+        self.send_calls += 1
+        if self.send_raises:
+            exc = self.send_raises.pop(0)
+            if exc is not None:
+                raise exc
+        msg = StaleEditFakeMessage(content or "")
+        self.messages.append(msg)
+        return msg
+
+
+@pytest.mark.asyncio
+async def test_safe_edit_syncs_msg_content_on_success(_no_sleep):
+    """After a successful edit, msg.content must reflect the new value
+    even though discord.py 2.0+ does NOT do this in-place itself."""
+    target = StaleEditFakeTarget()
+    renderer = DiscordRenderer(target)
+
+    msg = await renderer._safe_send(content="initial")
+    assert msg is not None
+    assert msg.content == "initial"
+
+    ok = await renderer._safe_edit(msg, content="updated long content")
+    assert ok is True
+    # Without the fix, msg.content would still be "initial" here (stale).
+    assert msg.content == "updated long content"
+
+
+@pytest.mark.asyncio
+async def test_last_msg_text_tracks_edits_through_long_session(_no_sleep):
+    """Simulate the long-session pattern: send-then-many-edits.
+
+    The renderer's ``_last_msg_text`` shadow MUST reflect the most
+    recent successfully-written content, not the initial-send value.
+    Pre-fix, reading ``_last_msg.content`` gave the initial value and
+    the cost-footer logic clobbered the long content with that stale
+    value + footer.
+    """
+    target = StaleEditFakeTarget()
+    renderer = DiscordRenderer(target)
+
+    msg = await renderer._safe_send(content="cursor▌")
+    assert renderer._last_msg is msg
+    assert renderer._last_msg_text == "cursor▌"
+
+    # Simulate the typewriter editing the same message many times.
+    growing = ["chunk 1▌", "chunk 1\nchunk 2▌", "chunk 1\nchunk 2\nfinal content"]
+    for content in growing:
+        ok = await renderer._safe_edit(msg, content=content)
+        assert ok is True
+
+    assert renderer._last_msg_text == "chunk 1\nchunk 2\nfinal content"
+
+
+@pytest.mark.asyncio
+async def test_cost_footer_path_does_not_clobber_long_content(_no_sleep):
+    """Regression: the cost-footer-style read+rewrite pattern must NOT
+    truncate long content back to the initial-send value.
+
+    This reproduces the truncation root cause described in
+    docs/investigations/stale-message-content.md. Without the fix, the
+    final edit's content is the initial cursor-stage payload + footer,
+    losing all the content that intermediate edits had written.
+    """
+    target = StaleEditFakeTarget()
+    renderer = DiscordRenderer(target)
+
+    # Cursor-stage initial send.
+    msg = await renderer._safe_send(content="initial cursor content▌")
+    # Typewriter grows the content.
+    long_content = "A" * 1500 + " final paragraph closing the response."
+    ok = await renderer._safe_edit(msg, content=long_content)
+    assert ok is True
+
+    # Cost-footer path (mirrors the production logic in render_response).
+    current = renderer._last_msg_text.rstrip("▌")
+    footer = "\n\n-# 💰 $0.10 │ ⏱️ 5.0s"
+    ok = await renderer._safe_edit(renderer._last_msg, content=current + footer)
+    assert ok is True
+
+    # The final edit recorded must contain the long content + footer,
+    # NOT just initial-content + footer.
+    final = msg.edits[-1]
+    assert "final paragraph closing the response." in final
+    assert footer in final
+    assert len(final) >= len(long_content)
+
+
+@pytest.mark.asyncio
+async def test_safe_send_resets_shadow_on_new_message(_no_sleep):
+    """When a fresh message is sent (e.g., split overflow path), the
+    shadow must reset to the new content rather than carry forward
+    the prior message's text."""
+    target = StaleEditFakeTarget()
+    renderer = DiscordRenderer(target)
+
+    msg1 = await renderer._safe_send(content="first message")
+    await renderer._safe_edit(msg1, content="first message edited and grown")
+
+    msg2 = await renderer._safe_send(content="second message")
+    assert renderer._last_msg is msg2
+    assert renderer._last_msg_text == "second message"
+    # And the shadow now tracks msg2 — editing msg1 must NOT clobber it.
+    await renderer._safe_edit(msg1, content="msg1 grew again")
+    assert renderer._last_msg_text == "second message"

--- a/tests/test_renderer_retries.py
+++ b/tests/test_renderer_retries.py
@@ -652,3 +652,38 @@ async def test_cost_footer_after_file_only_send_resets_shadow(_no_sleep):
         assert renderer._last_msg_text == "visible text chunk"
     # In either case, the cost footer's `current + footer` cannot
     # produce "visible text chunk" + footer on the file_msg.
+
+
+@pytest.mark.asyncio
+async def test_shadow_survives_embed_send_between_text_edits(_no_sleep):
+    """Tool embeds (sent via _safe_send(embed=...) interleaved with text
+    edits) must NOT clobber the typewriter's text shadow. Otherwise the
+    cost-footer rewrites long content with '' + footer — a recurrence of
+    bug #113 via a different trigger path (architect round-2 finding C1)."""
+    target = StaleEditFakeTarget()
+    r = DiscordRenderer(target)
+    live = await r._safe_send(content="hi▌")
+    assert r._last_msg is live
+    assert r._last_msg_text == "hi▌"
+
+    # Embed-only send (mimics tool-call embed during streaming).
+    # Pre-fix (round-2 widening): this would advance _last_msg to embed_msg
+    # and reset shadow to "", silently breaking the typewriter contract.
+    embed_msg = await r._safe_send(content=None, embed=object())
+    # Post-fix: _last_msg unchanged, shadow unchanged.
+    assert r._last_msg is live
+    assert r._last_msg_text == "hi▌"
+
+    # Typewriter resumes editing the live cursor msg.
+    long_text = "hi there, here is a long response…▌"
+    ok = await r._safe_edit(live, content=long_text)
+    assert ok is True
+    assert r._last_msg_text == long_text  # shadow tracked because is-guard holds
+
+    # Finalize.
+    final_text = "hi there, here is a long response."
+    await r._finalize_typewriter(live, final_text)
+
+    # Cost-footer-equivalent read MUST see the long content, not "".
+    current = r._last_msg_text.rstrip(CURSOR)
+    assert current.startswith("hi there, here is a long response")

--- a/tests/test_renderer_retries.py
+++ b/tests/test_renderer_retries.py
@@ -507,23 +507,6 @@ class StaleEditFakeTarget(FakeTarget):
 
 
 @pytest.mark.asyncio
-async def test_safe_edit_syncs_msg_content_on_success(_no_sleep):
-    """After a successful edit, msg.content must reflect the new value
-    even though discord.py 2.0+ does NOT do this in-place itself."""
-    target = StaleEditFakeTarget()
-    renderer = DiscordRenderer(target)
-
-    msg = await renderer._safe_send(content="initial")
-    assert msg is not None
-    assert msg.content == "initial"
-
-    ok = await renderer._safe_edit(msg, content="updated long content")
-    assert ok is True
-    # Without the fix, msg.content would still be "initial" here (stale).
-    assert msg.content == "updated long content"
-
-
-@pytest.mark.asyncio
 async def test_last_msg_text_tracks_edits_through_long_session(_no_sleep):
     """Simulate the long-session pattern: send-then-many-edits.
 
@@ -570,17 +553,16 @@ async def test_cost_footer_path_does_not_clobber_long_content(_no_sleep):
     assert ok is True
 
     # Cost-footer path (mirrors the production logic in render_response).
-    current = renderer._last_msg_text.rstrip("▌")
+    current = renderer._last_msg_text.rstrip(CURSOR)
     footer = "\n\n-# 💰 $0.10 │ ⏱️ 5.0s"
     ok = await renderer._safe_edit(renderer._last_msg, content=current + footer)
     assert ok is True
 
-    # The final edit recorded must contain the long content + footer,
-    # NOT just initial-content + footer.
     final = msg.edits[-1]
-    assert "final paragraph closing the response." in final
-    assert footer in final
-    assert len(final) >= len(long_content)
+    # Exact pin: post-fix content is the long content + footer.
+    assert final == long_content + footer
+    # Negative pin: the stale failure mode is "initial + footer".
+    assert not final.startswith("initial cursor content")
 
 
 @pytest.mark.asyncio
@@ -600,3 +582,73 @@ async def test_safe_send_resets_shadow_on_new_message(_no_sleep):
     # And the shadow now tracks msg2 — editing msg1 must NOT clobber it.
     await renderer._safe_edit(msg1, content="msg1 grew again")
     assert renderer._last_msg_text == "second message"
+
+
+@pytest.mark.asyncio
+async def test_safe_edit_permanent_failure_does_not_update_shadow(_no_sleep):
+    """A permanent edit failure must NOT advance _last_msg_text — Discord
+    never accepted the content, so the shadow shouldn't either."""
+    target = StaleEditFakeTarget()
+    renderer = DiscordRenderer(target)
+
+    msg = await renderer._safe_send(content="good")
+    assert renderer._last_msg_text == "good"
+
+    msg.edit_raises = [_http(503)] * (MAX_HTTP_RETRIES + 5)
+    ok = await renderer._safe_edit(msg, content="never-delivered")
+
+    assert ok is False
+    assert renderer._last_msg_text == "good"  # NOT "never-delivered"
+
+
+@pytest.mark.asyncio
+async def test_finalize_typewriter_keeps_shadow_synced_with_last_msg(_no_sleep):
+    """The shadow invariant must survive _finalize_typewriter's split path
+    where self._last_msg is reassigned outside _safe_send/_safe_edit."""
+    target = StaleEditFakeTarget()
+    renderer = DiscordRenderer(target)
+
+    # Establish initial _last_msg via a cursor-style send.
+    live = await renderer._safe_send(content="cursor▌")
+    assert renderer._last_msg is live
+    assert renderer._last_msg_text == "cursor▌"
+
+    # Buffer that splits into multiple chunks — exercises the multi-chunk
+    # branch (live edited with chunks[0], rest sent fresh).
+    big_buffer = ("paragraph " * 250).strip() + " end."
+    assert len(big_buffer) > 1900  # safety check
+
+    await renderer._finalize_typewriter(live, big_buffer)
+
+    # _last_msg is now whichever message ended up last (likely the final
+    # _safe_send for the last chunk). The shadow MUST equal whatever
+    # was last written to _last_msg, not an earlier chunk leaked through.
+    assert renderer._last_msg is not None
+    expected = (
+        renderer._last_msg.edits[-1] if renderer._last_msg.edits
+        else renderer._last_msg.content
+    )
+    assert renderer._last_msg_text == expected
+
+
+@pytest.mark.asyncio
+async def test_cost_footer_after_file_only_send_resets_shadow(_no_sleep):
+    """File-only / embed-only sends must reset _last_msg_text so the
+    cost footer doesn't splice prior text onto an unrelated message."""
+    target = StaleEditFakeTarget()
+    renderer = DiscordRenderer(target)
+
+    # Text chunk first (establishes _last_msg + shadow).
+    await renderer._safe_send(content="visible text chunk")
+    assert renderer._last_msg_text == "visible text chunk"
+
+    # Now a file-only send (no content kwarg).
+    file_msg = await renderer._safe_send(content=None, file=object())
+    # Either: _last_msg advanced AND shadow reset to "".
+    if renderer._last_msg is file_msg:
+        assert renderer._last_msg_text == ""
+    # Or: _last_msg did NOT advance, shadow still tracks the text msg.
+    else:
+        assert renderer._last_msg_text == "visible text chunk"
+    # In either case, the cost footer's `current + footer` cannot
+    # produce "visible text chunk" + footer on the file_msg.


### PR DESCRIPTION
## Summary

PR #108 fixed one truncation root cause (silent swallow on retry). This fixes the other root cause that real-world E2E exposed (~33% reproduction rate on long sessions): **discord.py 2.0+'s `Message.edit()` is not in-place** — `self.content` stays at the initial-send value forever after edits succeed. The cost-footer path was reading that stale value and clobbering long content with `stale_initial + footer`.

Closes #113

## Why this exists separately from PR #108

PR #108 verified offline only. Real E2E (`scripts/e2e_truncation.py --mode A`) revealed a 1/3 failure rate where:
- `sdk_diff = 0` (SDK clean — same as PR #108 confirmed)
- `saw_retry_log = false` and `saw_dropped_log = false` (PR #108's retry path didn't fire)
- Discord channel content < SDK output by 1300+ chars
- The user's original 5/8 screenshot exactly matches this pattern

So the symptom was the same ("long session truncated") but the cause was a different code path.

## Root cause

[discord.py 2.0+ `Message.edit(...)`](https://github.com/Rapptz/discord.py/blob/master/discord/message.py#L2868) — explicit breaking change from 1.x:

```
.. versionchanged:: 2.0
    Edits are no longer in-place, the newly edited message is returned instead.
```

Confirmed by [official Discord API docs](https://github.com/discord/discord-api-docs/blob/main/developers/resources/message.mdx#L1168): `PATCH /channels/.../messages/...` returns a fresh message object.

Pre-fix `_safe_edit` discarded the return; `self._last_msg.content` therefore held the original `send`-time payload forever (typically a few hundred chars of cursor-stage text). The cost-footer site read that stale value, appended the footer, and edited it back into the live message — overwriting thousands of chars of content the typewriter had subsequently written.

Found via instrumentation (`T-INSTR` logs at edit-pre/edit-post/cost-footer-pre). First real-bot run reproduced the bug and produced this smoking gun:

```
edit-pre:  msg_id=...411836 pre_content_len=499 new_content_len=911
edit-post: msg_id=...411836 ok=True post_content_len=499 (was pre=499 new=911)  ← still 499
edit-pre:  msg_id=...411836 pre_content_len=499 new_content_len=1388
edit-post: msg_id=...411836 ok=True post_content_len=499 (was pre=499 new=1388) ← still 499
cost-footer-pre: last_msg_id=...411836 last_msg_content_len=499                  ← reads 499
edit-pre:  msg_id=...411836 pre_content_len=499 new_content_len=544              ← writes 499 + footer
```

39/39 successful edits, 0 syncs to local `msg.content`. Full investigation: `docs/investigations/stale-message-content.md`.

## Fix

`src/clauded/discord_renderer.py`:

1. Add `self._last_msg_text: str = ""` in `__init__` — shadow of what we last wrote to `_last_msg`.
2. `_safe_send`: on successful content send, set both `_last_msg = msg` and `_last_msg_text = content`.
3. `_safe_edit`: on success, sync `msg.content = content` (defensive layer 1; any future code reading `msg.content` sees the right value) AND if `msg is _last_msg`, update `_last_msg_text = content` (layer 2).
4. Cost-footer site: read `self._last_msg_text` instead of `self._last_msg.content`.

## Test plan

### Unit tests (`tests/test_renderer_retries.py`)

Added `StaleEditFakeMessage` that mimics discord.py 2.0+ semantics (does not write `self.content` on edit). Default `FakeMessage` mimicked 1.x behavior, which masked the bug — explained why PR #108's offline test suite passed despite the bug being live.

Four new tests, **all of which fail on pre-fix code, all pass on post-fix**:
- `test_safe_edit_syncs_msg_content_on_success` — `_safe_edit` must sync `msg.content`
- `test_last_msg_text_tracks_edits_through_long_session` — shadow follows latest edit
- `test_cost_footer_path_does_not_clobber_long_content` — direct repro of #113
- `test_safe_send_resets_shadow_on_new_message` — shadow re-initializes per send

Verified by stashing the fix and running just these 4: 4 fail. Restoring fix: 4 pass.

`pytest tests/`: 246 passed / 2 pre-existing P1 failures (commit `2608502`, unrelated).

### E2E (real Discord + real Claude)

`scripts/e2e_truncation.py --mode A` × 3 post-fix:

| Run | SDK delta | SDK result | Discord channel | render_diff | Verdict |
|-----|-----------|------------|-----------------|-------------|---------|
| 1 | 16065 | 16065 | 16047 | -18 | ✅ PASS |
| 2 | 13392 | 13392 | 13378 | -14 | ✅ PASS |
| 3 | 17726 | 17726 | 17708 | -18 | ✅ PASS |

The `-18` / `-14` is `_smart_split`'s `lstrip("\n")` paragraph-blank stripping — visually identical formatting, predates this PR, no content loss.

### Real bot dogfood

Started actual `clauded` bot (console-script entry) and triggered same prompt user had previously reported as "消息没发全" (message not fully sent):

| Time | Fix? | bot reply | Last 50 chars |
|------|------|-----------|---------------|
| 13:47 | ❌ | 2 msgs / 2135 chars | `"...| `top_k` | reque...se64，"` ← truncated mid-string |
| 15:42 | ✅ | 2 msgs / 3090 chars | `"...| ```"` ← natural code-fence close |

Same prompt, same model, same `~$0.41` cost / `~28s` duration. Pre-fix: truncated. Post-fix: complete. SDK ResultMessage = 3055 chars; Discord channel = 3090 (extra 35 chars = `_format_tables` wrapping a markdown table in code fence — formatting overhead, no loss).

## Process retrospective

I shipped PR #108 without real-environment verification. User pushed back; instrumented run found this second root cause in 5 minutes. Lesson written into `memory/claudeD.md`: **for silent-loss class bugs, real-environment E2E is a merge gate, not deferrable.**

## Out of scope

- Pre-existing 2 test failures in `test_subagent_threads.py` from commit `2608502` — separate P1.
- The 18-char-per-long-session lstrip artifact — visually invisible, predates fix, separate cleanup ticket if anyone cares.

## Artifacts

- `docs/investigations/stale-message-content.md` — full root-cause analysis with instrumentation logs and process retrospective
- `scripts/e2e_truncation.py` (already on main) — the harness that found this
- `logs/e2e_A_1778326687_bodies/` — captured failing run (gitignored)
