### PR TITLE
v1.11 unbound channel fallback (#110)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,18 @@ CLAUDE_PERMISSION_MODE=default
 # from accidentally binding to e.g. `/etc` or another user's home.
 # CLAUDED_PROJECTS_ROOT=/home/youruser/projects
 
+# Opt-in: when set to 1/true/yes/on, `@bot` in an unbound channel falls back
+# to $HOME as the Claude session's cwd (with a one-time hint nudging the user
+# to /project bind). When unset (default), the message is silently ignored —
+# matching v1.0 behavior.
+#
+# WARNING: enabling this lets ANY user with channel-write permission run
+# Claude against the operator's home directory (~/.ssh, ~/.aws, etc.) without
+# the administrator-permission and projects_root checks that /project bind
+# enforces. Only enable if every potential message author is trusted with
+# read access to ~. Most operators should leave this off and require an
+# explicit /project bind per channel instead.
+# CLAUDED_ALLOW_UNBOUND_FALLBACK=1
+
 # Enable stream debug logging (logs/stream-debug.jsonl). Set to 1 to enable.
 # CLAUDED_STREAM_DEBUG=1

--- a/README.md
+++ b/README.md
@@ -126,8 +126,11 @@ cp .env.example .env
 | `CLAUDE_MODEL` | No | `sonnet` | Default Claude model (`sonnet`, `opus`, `haiku`, or full model ID) |
 | `CLAUDE_PERMISSION_MODE` | No | `default` | Permission mode: `default`, `acceptEdits`, `plan`, `bypassPermissions` |
 | `CLAUDED_PROJECTS_ROOT` | No | `~` (home dir) | Root directory for project bindings — paths outside this are rejected |
+| `CLAUDED_ALLOW_UNBOUND_FALLBACK` | No | `false` | When `1`/`true`, `@bot` in an unbound channel falls back to `$HOME` as `cwd`. When unset/`false` (default), the message is silently ignored — run `/project bind <path>` first. ⚠️ See security warning below |
 
 > ⚠️ **Security warning:** Setting `CLAUDE_PERMISSION_MODE=bypassPermissions` disables all tool-permission prompts. Claude will execute shell commands and file edits without confirmation. Only use this if every Discord user with channel access is trusted with shell access on the host machine.
+
+> ⚠️ **Security warning:** Setting `CLAUDED_ALLOW_UNBOUND_FALLBACK=1` lets *any* user with channel-write permission run Claude with `cwd=$HOME` — including reading `~/.ssh`, `~/.aws`, etc. Unlike `/project bind`, the fallback path is *not* validated against `CLAUDED_PROJECTS_ROOT` and *does not* require Discord administrator. Only enable if every potential message author is trusted with read access to the operator's home directory. The default (`false`) is the v1.0 behavior: unbound channels ignore `@bot`.
 
 ---
 

--- a/docs/prd/v1.11-unbound-fallback.md
+++ b/docs/prd/v1.11-unbound-fallback.md
@@ -1,0 +1,265 @@
+# PRD — v1.11 Unbound Channel Fallback
+
+## Status
+Draft
+
+## Overview
+
+When a Discord channel hasn't been bound to a project via `/project bind`, claudeD currently rejects most commands and the `@bot` message path with "Channel not bound" errors. This PRD adds graceful fallback: project-mutating commands continue to refuse (with a hint to `/project bind`), while the on-message path and read-only commands fall back to using `~` as `cwd`. A one-time per-channel hint surfaces the binding model to new users without nagging.
+
+## Motivation
+
+First-time users hit "Channel not bound" walls before they understand that channels need binding. The binding model is real (we want explicit project context for safety on writes), but it shouldn't block the entry experience. A user typing `@bot what's 2+2` in any channel should just work, with a quiet hint that they can scope to a project later if they want.
+
+## Requirements
+
+### R1 — Helper API
+
+R1.1. Add `ProjectManager.get_path_or_default(channel_id) -> tuple[Path, bool]`. Returns:
+- `(self.get_path(channel_id), True)` if the channel is bound
+- `(Path.home().resolve(), False)` otherwise
+
+R1.2. The fallback path is `Path.home().resolve()`, NOT the literal `Path.home()`. This applies the same `.resolve()` discipline that v1.0 commit `#11` introduced for `/tmp → /private/tmp` symlink correctness on macOS.
+
+R1.3. The helper does NOT mutate any state. The "hint already shown" tracking lives elsewhere (R3).
+
+### R2 — Command classification
+
+Three groups based on whether the command writes project-scoped state:
+
+#### Group A — Project-mutating commands: KEEP refusing, with hint
+
+These commands write to `<project>/.env`, `<project>/.claude/agents/*.md`, project-level MCP config, or otherwise tie to a specific project's filesystem. They MUST NOT auto-bind to `~` because that would silently scatter project config files into the user's home directory.
+
+**Refuse + hint**:
+- `/env set`, `/env unset` (writes `<project>/.env`)
+- `/agent create`, `/agent delete` (writes `<project>/.claude/agents/*.md`)
+- `/mcp add`, `/mcp add-url`, `/mcp remove` (project-level MCP config)
+- `/session resume` (session is project-scoped — resuming an unbound channel's session has no meaning)
+- `/session fork`, `/session worktree` (project-filesystem coupled)
+- `/plugin add` (mutates plugin dirs for a project)
+- `/review` (initiates PR review, implies "I'm working in a project")
+- `/security-review` (analyzes project source)
+- `/session settings` (writes session-scoped JSON, but session implies project)
+
+When called on an unbound channel, these reply with an ephemeral message:
+> ❌ This channel isn't bound to a project. Run `/project bind <path>` first, then retry.
+
+R2.1. The error message is unified across all Group A commands (constant in `cogs/__init__.py` or new `cogs/_unbound.py` helper).
+R2.2. Group A response is `ephemeral=True` so other channel members don't see it.
+
+#### Group B — Read-only / stateless commands: ALREADY work, unchanged
+
+These don't need project context. They operate on global session/cost/health state:
+
+- `/health`, `/cost show/total/reset`, `/ratelimit`
+- `/model`, `/effort`, `/max-turns`, `/fallback-model`, `/bare`
+- `/budget set/show/clear`
+- `/tools allow/deny/reset`
+- `/session list`, `/session info`, `/session stop`, `/session interrupt`, `/session compact`, `/session pin`, `/session name`
+- `/agent list`, `/agent use` (uses an existing agent name; no new file written)
+- `/mcp list`
+- `/notify`, `/debug`
+- `/project list`, `/project current` (read project state)
+
+R2.3. **No code change needed for Group B.** These already either don't call `is_bound`, or fall back gracefully today.
+
+#### Group C — On-message + future read-only commands: NEW fallback to `~`
+
+The main `@bot` path and any future stateless command:
+
+- `on_message` → `_handle_channel_message` → opens a Claude session
+- `/skill list` (future #109) — must inherit this policy
+
+When called on an unbound channel:
+1. Use `Path.home().resolve()` as the Claude session's `cwd`.
+2. Show a hint (R3) on the FIRST encounter only.
+3. Continue as if bound.
+
+### R3 — Hint mechanism
+
+R3.1. Storage: in-memory `Set[int]` field `_hinted_unbound_channels` on `ProjectManager`. Per bot process; resets on bot restart. (User chose option (a): once per channel × per bot process.)
+
+R3.2. API: `ProjectManager.should_hint_unbound(channel_id) -> bool`. Returns `True` exactly once per `channel_id` per process. Subsequent calls for the same `channel_id` return `False`. Implementation: check membership; if absent, add and return `True`; else return `False`. Atomic.
+
+R3.3. Hint content (verbatim):
+> 💡 This channel isn't bound to a project. I'll use your home directory (`~`) as the working directory. Run `/project bind <path>` to scope to a specific project.
+
+R3.4. Hint placement: in the **thread** auto-created for the user's `@bot` message, as the FIRST message before Claude's response begins streaming. Plain text (not embed). Public to thread (not ephemeral — ephemeral would be confusing in a thread context).
+
+R3.5. After `/project bind <path>` successfully binds the channel, any future entry in `_hinted_unbound_channels` for that channel becomes irrelevant (binding takes precedence and the on-message path takes the bound branch). No need to actively clean up the set.
+
+### R4 — Safety
+
+R4.1. `Path.home().resolve()` must be a real, accessible directory. If `Path.home()` raises (no `$HOME`, broken passwd, etc.), the fallback path must be reported as a friendly error in the thread:
+> ❌ Couldn't determine your home directory. Run `/project bind <path>` to use this bot.
+
+R4.2. **No path-escape validation needed for `~`.** It's the operator's own home. The existing `projects_root` validation in `ProjectManager.bind` is for *user-supplied paths* and doesn't apply here.
+
+R4.3. Hint must NOT leak across guilds. Channels are globally unique by ID in Discord, so the in-memory `Set[int]` is naturally per-channel-id. No multi-guild concern.
+
+## Acceptance Criteria
+
+### A — Unit tests
+
+A.1. `tests/test_project_manager.py` (extend existing):
+- `test_get_path_or_default_bound` — bound channel returns `(path, True)`
+- `test_get_path_or_default_unbound` — unbound returns `(Path.home().resolve(), False)`
+- `test_should_hint_unbound_first_call_returns_true`
+- `test_should_hint_unbound_second_call_returns_false`
+- `test_should_hint_unbound_isolated_per_channel` (different channels get independent first-hint)
+
+### B — On-message integration
+
+B.1. Send a `@bot hello` to an unbound channel:
+- Bot opens thread
+- Thread first message = the hint (verbatim per R3.3)
+- Thread second message = Claude's response, with `cwd=$HOME`
+- Verify via fake-bridge test: capture `ClaudeBridge.__init__` `project_path` arg; assert it equals `Path.home().resolve()`
+
+B.2. Send a SECOND `@bot ...` to the same unbound channel (in a new thread or the same channel):
+- Bot opens thread
+- Thread first message = Claude's response (NO hint repeated)
+- `cwd` still `$HOME`
+
+B.3. After `/project bind /some/path`, send `@bot ...`:
+- Thread first message = Claude's response
+- `cwd = /some/path` (NOT `$HOME`)
+- No hint
+- (The previous in-memory hint flag is irrelevant because the bound path takes the if-bound branch.)
+
+### C — Group A refusal
+
+C.1. On an unbound channel, run `/env set FOO bar`:
+- Reply is ephemeral
+- Reply text matches "❌ This channel isn't bound to a project. Run `/project bind <path>` first..."
+- No file is created in `~/.env` or anywhere else
+
+C.2. Same test for `/agent create`, `/mcp add`, `/session resume`, `/review`. (One representative test per command is fine; or one parametrized test.)
+
+### D — Group B unchanged
+
+D.1. On an unbound channel, run `/health`:
+- Returns the bot health embed normally (no error, no hint)
+
+D.2. Same for `/cost show`, `/model`, `/budget show`, `/tools reset`, `/session list`. (Sanity tests; these likely already pass without changes — confirm.)
+
+### E — Real-environment smoke (manager-run)
+
+After dev work merges, manager runs:
+
+E.1. Start bot. `/project bind` an empty test channel TC1 to `/Users/xuzhang/dev/AI/claudeD`. `/project bind` is the baseline.
+
+E.2. `@bot what is 2+2?` in an UNBOUND channel TC2:
+- Verify thread opens
+- Verify first thread message is the hint
+- Verify Claude responds normally with `cwd=~`
+- Verify `bot.log` has no ERROR/Traceback
+
+E.3. `@bot count files in current dir` in TC2:
+- Verify NO hint repeated
+- Verify Claude can `Bash` in `~` (i.e., the runtime cwd is actually `~`)
+
+E.4. `/env set TEST_VAR test_value` in TC2:
+- Verify ephemeral refusal with the unified message
+- Verify NO file appears in `~/.env` or anywhere
+
+E.5. `/health` in TC2:
+- Verify normal embed response
+
+## Technical Approach
+
+### Files affected
+
+1. `src/clauded/project_manager.py` — add `get_path_or_default()` + `should_hint_unbound()` + `_hinted_unbound_channels: Set[int]` field. ~25 LOC.
+
+2. `src/clauded/bot.py` — `_handle_channel_message`:
+   - Replace `if not self.project_manager.is_bound(channel.id): return` with the fallback flow.
+   - Use `get_path_or_default()` to get `(project_path, is_bound)`.
+   - When `not is_bound`, after creating the thread, call `should_hint_unbound()` and post the hint as the first message in the thread (before constructing the bridge / streaming).
+   - Pass `project_path` to `ClaudeBridge` as before; the bridge doesn't care whether it's `$HOME` or a project path.
+   - **Same change in `_handle_thread_message`**: a thread inside an unbound channel inherits the channel's parent fallback. (The thread's "parent_id" check `not is_bound(parent_id)` becomes `get_path_or_default(parent_id)`.)
+   - ~30 LOC change.
+
+3. `src/clauded/cogs/_unbound.py` (NEW, ~25 LOC) — small helper:
+   ```python
+   UNBOUND_REFUSE_MESSAGE = (
+       "❌ This channel isn't bound to a project. "
+       "Run `/project bind <path>` first, then retry."
+   )
+
+   async def reject_if_unbound(interaction: discord.Interaction, bot) -> bool:
+       """Return True if the interaction's channel is unbound (and reply was sent).
+       Caller should `return` immediately after a True result."""
+       channel_id = interaction.channel.parent_id if isinstance(
+           interaction.channel, discord.Thread
+       ) else interaction.channel.id
+       if not bot.project_manager.is_bound(channel_id):
+           if not interaction.response.is_done():
+               await interaction.response.send_message(
+                   UNBOUND_REFUSE_MESSAGE, ephemeral=True
+               )
+           else:
+               await interaction.followup.send(
+                   UNBOUND_REFUSE_MESSAGE, ephemeral=True
+               )
+           return True
+       return False
+   ```
+
+4. **Group A cogs**: each command in `cogs/agent.py` (create/delete), `cogs/mcp.py` (add/add-url/remove), `cogs/ops.py` (review, plugin add), `cogs/session.py` (resume, fork, worktree, security-review, settings) gets a check at the top:
+   ```python
+   if await reject_if_unbound(interaction, bot):
+       return
+   ```
+   Plus `cogs/project.py:149,167,311` already has this pattern with custom messages — unify them to use `UNBOUND_REFUSE_MESSAGE` for consistency.
+
+5. **`/env` cog** — checking the existing structure, this seems to live in `bot.py` or a separate module. Search and apply the same pattern.
+
+### Why this design (key decisions log)
+
+- **Q1 = (a)** strict for project-mutating commands — `/review` included. User chose stricter than issue body's "(b) auto-bind for read-only". Manager interpretation: writes go to filesystem, never silently to `~`; reads can fall back.
+- **Q2 = (a)** in-memory Set — claudeD is single-user, restart frequency is low, no need for persistence. Implementation simplicity wins.
+- **Q3 = (ii + I)** thread-internal plain text — keeps channel surface clean, hint co-located with Claude session for easy reference.
+
+## Testing Strategy
+
+### Unit tests
+
+- `tests/test_project_manager.py` — 5 tests (R1 helper + R3 hint state)
+- `tests/test_unbound_handler.py` (new, ~80 LOC) — `reject_if_unbound` helper tests + parametrized over Group A commands
+
+### Integration tests
+
+- `tests/test_bot_unbound_message.py` (new, ~120 LOC) — fake bridge + capture-paths tests for B.1, B.2, B.3 acceptance criteria.
+
+### Real-environment smoke
+
+- Manager-run procedure E1-E5 above, before merge.
+
+## Out of Scope
+
+- **Persistent hint state** (Q2 option b) — single-user bot, restart hint is fine.
+- **Time-window throttle** (Q2 option c) — 1h window subjective, complicates testing.
+- **Per-guild default project** (issue body out-of-scope) — separate future epic.
+- **Auto-detection of project root** — too magical; manual `/project bind` keeps the model explicit.
+- **Hint customization** (operator can change message) — over-engineering.
+- **Migration of `cogs/project.py` custom unbound messages**: optional simplification — they already work, can be unified to `UNBOUND_REFUSE_MESSAGE` as a tidy pass.
+
+## Open Questions
+
+None remaining. Manager will self-decide implementation details (test fixture style, exact wording of log messages, which file `_unbound.py` lives in).
+
+## Subtask breakdown (for Step 2)
+
+1. **Helper APIs** (S, ~25 LOC source + ~50 LOC test) — `get_path_or_default`, `should_hint_unbound`, and tests.
+
+2. **`reject_if_unbound` helper** (S, ~25 LOC source + ~30 LOC test) — `cogs/_unbound.py`.
+
+3. **Group A cog updates** (M, ~50 LOC across ~10 cog command sites) — apply `reject_if_unbound` at the top of each Group A command. Includes unifying the existing 3 sites in `cogs/project.py`.
+
+4. **on_message fallback** (M, ~40 LOC + ~80 LOC test) — `_handle_channel_message` and `_handle_thread_message` use `get_path_or_default`, post hint when unbound and `should_hint_unbound`.
+
+5. **Real-env smoke** (S procedure, manager-run) — E1-E5 above.
+
+These can be developed in parallel after subtask 1 lands (others depend on `get_path_or_default` / `should_hint_unbound` symbols).

--- a/docs/prd/v1.11-unbound-fallback.md
+++ b/docs/prd/v1.11-unbound-fallback.md
@@ -94,9 +94,17 @@ R3.5. After `/project bind <path>` successfully binds the channel, any future en
 R4.1. `Path.home().resolve()` must be a real, accessible directory. If `Path.home()` raises (no `$HOME`, broken passwd, etc.), the fallback path must be reported as a friendly error in the thread:
 > ❌ Couldn't determine your home directory. Run `/project bind <path>` to use this bot.
 
-R4.2. **No path-escape validation needed for `~`.** It's the operator's own home. The existing `projects_root` validation in `ProjectManager.bind` is for *user-supplied paths* and doesn't apply here.
+The error message MUST NOT interpolate the resolved path or the underlying exception text — both can leak operator filesystem layout to Discord users. Detail is logged at `log.warning` for operator visibility.
 
-R4.3. Hint must NOT leak across guilds. Channels are globally unique by ID in Discord, so the in-memory `Set[int]` is naturally per-channel-id. No multi-guild concern.
+R4.2. **The fallback is opt-in.** Default `Config.allow_unbound_fallback = False` (env `CLAUDED_ALLOW_UNBOUND_FALLBACK`, accepts `1`/`true`/`yes`/`on`). When `False`, an `@bot` mention in an unbound channel is silently ignored — restoring v1.0 behavior. When `True`, the on-message handlers (`_handle_channel_message` and `_handle_thread_message`) fall back to `$HOME` per R3.
+
+Why opt-in: `/project bind` requires `Permissions(administrator=True)` and validates the resolved path under `projects_root`. The on-message fallback has neither check — anyone with channel-write permission could `@bot read ~/.ssh/id_rsa` etc. Operators that want the convenient fallback explicitly opt in; the default is the v1.0 ignore-unbound posture, which is privilege-equivalent to "no on-message behavior at all" for unbound channels.
+
+R4.3. **No path-escape validation needed for `~` once the operator opts in.** It's the operator's own home; they signed off when flipping the flag. The existing `projects_root` validation in `ProjectManager.bind` is for *user-supplied paths* via `/project bind` and continues to apply there.
+
+R4.4. Hint must NOT leak across guilds. Channels are globally unique by ID in Discord, so the in-memory `Set[int]` is naturally per-channel-id. No multi-guild concern.
+
+R4.5. **Group A invariant — defense in depth.** Project-mutating `ProjectManager` methods (`set_system_prompt`, `set_budget`, `set_env`, `remove_env`, `add_extra_dir`, `remove_extra_dir`, `add_mcp_server`, `remove_mcp_server`, `set_channel_mode`) call a private `_assert_bound(channel_id)` first and raise `ValueError` on `not is_bound`. Cog-level `reject_if_unbound` is the user-facing guard; this raise is the programming-error backstop.
 
 ## Acceptance Criteria
 

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -194,7 +194,12 @@ class ClaudedBot(commands.Bot):
     # ------------------------------------------------------------------
 
     async def _handle_channel_message(self, message: discord.Message) -> None:
-        """Channel (non-thread) message: open a new thread + session."""
+        """Channel (non-thread) message: open a new thread + session.
+
+        If the channel is bound, scope the session to that project path.
+        Otherwise (v1.11, #110) fall back to the operator's home directory
+        and surface a one-time hint nudging the user to ``/project bind``.
+        """
         # Only trigger if bot is mentioned
         # Accept real @mention, role mention, or text containing bot name
         bot_mentioned = self.user and self.user.id in [m.id for m in message.mentions]
@@ -204,20 +209,42 @@ class ClaudedBot(commands.Bot):
             return
 
         channel = message.channel
-        if not self.project_manager.is_bound(channel.id):
-            return  # Channel isn't wired up; ignore.
+        # v1.11 #110: bound channels keep their stored path; unbound
+        # channels fall back to ``$HOME`` so the bot is usable immediately
+        # without a prior ``/project bind``.
+        project_path_obj, is_bound = self.project_manager.get_path_or_default(channel.id)
 
-        project_path = self.project_manager.get_path(channel.id)
-        if project_path is None:
-            log.warning("Channel %s reports bound but has no path", channel.id)
-            return
+        # Safety guard for a broken $HOME (R4.1). ``Path.home()`` itself
+        # raises ``RuntimeError`` if ``$HOME`` is unset and there's no
+        # passwd entry; ``is_dir()`` covers the "set but doesn't exist"
+        # case. Only check on the unbound path — bound paths are validated
+        # at bind time.
+        if not is_bound:
+            try:
+                home_ok = project_path_obj.is_dir()
+            except (OSError, RuntimeError) as exc:
+                home_ok = False
+                home_err: Exception = exc
+            else:
+                home_err = OSError(f"home directory does not exist: {project_path_obj}")
+            if not home_ok:
+                try:
+                    await message.reply(
+                        f"❌ Couldn't determine your home directory ({home_err}). "
+                        "Run `/project bind <path>` to use this bot."
+                    )
+                except discord.HTTPException:
+                    log.debug("Could not surface broken-home error to channel")
+                return
+
+        project_path = str(project_path_obj)
 
         # #87: support forum channel mode
         channel_mode = self.project_manager.get_channel_mode(channel.id)
         is_forum = channel_mode == "forum" and isinstance(channel, discord.ForumChannel)
 
         if not is_forum and not isinstance(channel, discord.TextChannel):
-            log.warning("Bound channel %s is not a TextChannel or ForumChannel; skipping", channel.id)
+            log.warning("Channel %s is not a TextChannel or ForumChannel; skipping", channel.id)
             return
 
         # Strip the bot mention from the message content
@@ -256,6 +283,20 @@ class ClaudedBot(commands.Bot):
             except discord.HTTPException:
                 log.debug("Could not surface thread-creation error to channel")
             return
+
+        # v1.11 #110: post the one-time unbound hint as the FIRST thread
+        # message, before the bridge starts streaming, so the user sees it
+        # immediately. ``should_hint_unbound`` is atomic and resets only on
+        # bot restart, per PRD R3.
+        if not is_bound and self.project_manager.should_hint_unbound(channel.id):
+            try:
+                await thread.send(
+                    "💡 This channel isn't bound to a project. I'll use your "
+                    "home directory (`~`) as the working directory. Run "
+                    "`/project bind <path>` to scope to a specific project."
+                )
+            except discord.HTTPException:
+                log.debug("Could not post unbound-fallback hint to thread")
 
         # Acquire the per-thread lock *before* creating the session so a
         # concurrent thread message that Discord delivers out of order can't
@@ -361,14 +402,37 @@ class ClaudedBot(commands.Bot):
     async def _handle_thread_message(
         self, message: discord.Message, parent_id: int
     ) -> None:
-        """Thread message: route to the existing/new session for that thread."""
-        if not self.project_manager.is_bound(parent_id):
-            return  # Parent channel isn't bound; ignore.
+        """Thread message: route to the existing/new session for that thread.
 
-        project_path = self.project_manager.get_path(parent_id)
-        if project_path is None:
-            log.warning("Parent channel %s bound but has no path", parent_id)
-            return
+        Uses the same bound/$HOME fallback as :meth:`_handle_channel_message`
+        for the parent channel. We deliberately do NOT post the hint here —
+        it already fired when the thread was first opened (or will fire
+        once for the parent channel id if a thread persists across a bot
+        restart and the user posts in it before mentioning the bot in the
+        parent channel).
+        """
+        # v1.11 #110: bound parent → bound path; unbound → $HOME fallback.
+        project_path_obj, is_bound = self.project_manager.get_path_or_default(parent_id)
+
+        if not is_bound:
+            try:
+                home_ok = project_path_obj.is_dir()
+            except (OSError, RuntimeError) as exc:
+                home_ok = False
+                home_err: Exception = exc
+            else:
+                home_err = OSError(f"home directory does not exist: {project_path_obj}")
+            if not home_ok:
+                try:
+                    await message.reply(
+                        f"❌ Couldn't determine your home directory ({home_err}). "
+                        "Run `/project bind <path>` to use this bot."
+                    )
+                except discord.HTTPException:
+                    log.debug("Could not surface broken-home error to thread")
+                return
+
+        project_path = str(project_path_obj)
 
         thread_id = message.channel.id
         # Acquire the per-thread lock for the entire send/render cycle so

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -29,6 +29,7 @@ from .session_config import SessionConfig
 from .session_store import SessionStore
 from .cost_tracker import CostTracker
 from .agent_manager import AgentManager
+from .cogs._unbound import UNBOUND_HINT_MESSAGE
 
 # Re-export SystemPromptModal so existing ``from clauded.bot import
 # SystemPromptModal`` continues to work (tests rely on this).
@@ -70,6 +71,42 @@ def _build_intents_safe() -> discord.Intents:
     intents.messages = True
     intents.guilds = True
     return intents
+
+
+# Generic, path-free error: never interpolate ``project_path_obj`` (which
+# is the operator's home dir) into a message Discord users will see.
+_BROKEN_HOME_MESSAGE = (
+    "❌ Couldn't determine your home directory. "
+    "Run `/project bind <path>` to use this bot."
+)
+
+
+async def _resolve_path_or_friendly_error(
+    project_manager: ProjectManager,
+    channel_id: int,
+    reply: "callable",
+) -> tuple[Path, bool] | None:
+    """Resolve ``(path, is_bound)`` for a channel, replying on broken-home.
+
+    Returns the tuple on success. On a broken ``$HOME`` (the only case the
+    fallback can fail), sends a generic error via ``reply``, logs detail
+    at warning, and returns ``None``. Bound paths are validated at bind
+    time so are assumed OK.
+    """
+    project_path_obj, is_bound = project_manager.get_path_or_default(channel_id)
+    if is_bound:
+        return project_path_obj, True
+    # ``Path.home()``-raise is already caught inside ``get_path_or_default``;
+    # what's left is the "set but doesn't exist" case, which ``is_dir()``
+    # reports as False (not a raise). One simple guard suffices.
+    if project_path_obj.is_dir():
+        return project_path_obj, False
+    log.warning("Unbound fallback failed: %s is not a directory", project_path_obj)
+    try:
+        await reply(_BROKEN_HOME_MESSAGE)
+    except discord.HTTPException:
+        log.debug("Could not surface broken-home error")
+    return None
 
 
 class ClaudedBot(commands.Bot):
@@ -197,8 +234,10 @@ class ClaudedBot(commands.Bot):
         """Channel (non-thread) message: open a new thread + session.
 
         If the channel is bound, scope the session to that project path.
-        Otherwise (v1.11, #110) fall back to the operator's home directory
-        and surface a one-time hint nudging the user to ``/project bind``.
+        Otherwise: when ``Config.allow_unbound_fallback`` is True (opt-in),
+        fall back to the operator's home directory and surface a one-time
+        hint nudging the user to ``/project bind``. When False (default,
+        v1.0 behavior), silently ignore the message.
         """
         # Only trigger if bot is mentioned
         # Accept real @mention, role mention, or text containing bot name
@@ -209,34 +248,21 @@ class ClaudedBot(commands.Bot):
             return
 
         channel = message.channel
-        # v1.11 #110: bound channels keep their stored path; unbound
-        # channels fall back to ``$HOME`` so the bot is usable immediately
-        # without a prior ``/project bind``.
-        project_path_obj, is_bound = self.project_manager.get_path_or_default(channel.id)
+        # SECURITY (sec-1): unbound fallback is off by default. v1.0 behavior
+        # is to silently ignore @bot in unbound channels. Operators opt in via
+        # CLAUDED_ALLOW_UNBOUND_FALLBACK=1 to enable the $HOME fallback.
+        if (
+            not self.project_manager.is_bound(channel.id)
+            and not self.config.allow_unbound_fallback
+        ):
+            return
 
-        # Safety guard for a broken $HOME (R4.1). ``Path.home()`` itself
-        # raises ``RuntimeError`` if ``$HOME`` is unset and there's no
-        # passwd entry; ``is_dir()`` covers the "set but doesn't exist"
-        # case. Only check on the unbound path — bound paths are validated
-        # at bind time.
-        if not is_bound:
-            try:
-                home_ok = project_path_obj.is_dir()
-            except (OSError, RuntimeError) as exc:
-                home_ok = False
-                home_err: Exception = exc
-            else:
-                home_err = OSError(f"home directory does not exist: {project_path_obj}")
-            if not home_ok:
-                try:
-                    await message.reply(
-                        f"❌ Couldn't determine your home directory ({home_err}). "
-                        "Run `/project bind <path>` to use this bot."
-                    )
-                except discord.HTTPException:
-                    log.debug("Could not surface broken-home error to channel")
-                return
-
+        resolved = await _resolve_path_or_friendly_error(
+            self.project_manager, channel.id, message.reply
+        )
+        if resolved is None:
+            return
+        project_path_obj, is_bound = resolved
         project_path = str(project_path_obj)
 
         # #87: support forum channel mode
@@ -284,17 +310,10 @@ class ClaudedBot(commands.Bot):
                 log.debug("Could not surface thread-creation error to channel")
             return
 
-        # v1.11 #110: post the one-time unbound hint as the FIRST thread
-        # message, before the bridge starts streaming, so the user sees it
-        # immediately. ``should_hint_unbound`` is atomic and resets only on
-        # bot restart, per PRD R3.
+        # First-time unbound hint, posted before the bridge starts streaming.
         if not is_bound and self.project_manager.should_hint_unbound(channel.id):
             try:
-                await thread.send(
-                    "💡 This channel isn't bound to a project. I'll use your "
-                    "home directory (`~`) as the working directory. Run "
-                    "`/project bind <path>` to scope to a specific project."
-                )
+                await thread.send(UNBOUND_HINT_MESSAGE)
             except discord.HTTPException:
                 log.debug("Could not post unbound-fallback hint to thread")
 
@@ -404,34 +423,25 @@ class ClaudedBot(commands.Bot):
     ) -> None:
         """Thread message: route to the existing/new session for that thread.
 
-        Uses the same bound/$HOME fallback as :meth:`_handle_channel_message`
-        for the parent channel. We deliberately do NOT post the hint here —
-        it already fired when the thread was first opened (or will fire
-        once for the parent channel id if a thread persists across a bot
-        restart and the user posts in it before mentioning the bot in the
-        parent channel).
+        Inherits the parent channel's bound state. The hint (if any) is the
+        channel handler's job; threads never post it themselves. When the
+        parent is unbound and the operator has not opted in via
+        ``Config.allow_unbound_fallback``, the message is silently ignored
+        (v1.0 behavior).
         """
-        # v1.11 #110: bound parent → bound path; unbound → $HOME fallback.
-        project_path_obj, is_bound = self.project_manager.get_path_or_default(parent_id)
+        # SECURITY (sec-1): mirror channel handler's gate.
+        if (
+            not self.project_manager.is_bound(parent_id)
+            and not self.config.allow_unbound_fallback
+        ):
+            return
 
-        if not is_bound:
-            try:
-                home_ok = project_path_obj.is_dir()
-            except (OSError, RuntimeError) as exc:
-                home_ok = False
-                home_err: Exception = exc
-            else:
-                home_err = OSError(f"home directory does not exist: {project_path_obj}")
-            if not home_ok:
-                try:
-                    await message.reply(
-                        f"❌ Couldn't determine your home directory ({home_err}). "
-                        "Run `/project bind <path>` to use this bot."
-                    )
-                except discord.HTTPException:
-                    log.debug("Could not surface broken-home error to thread")
-                return
-
+        resolved = await _resolve_path_or_friendly_error(
+            self.project_manager, parent_id, message.reply
+        )
+        if resolved is None:
+            return
+        project_path_obj, is_bound = resolved
         project_path = str(project_path_obj)
 
         thread_id = message.channel.id

--- a/src/clauded/cogs/_unbound.py
+++ b/src/clauded/cogs/_unbound.py
@@ -1,20 +1,4 @@
-"""Unified "channel not bound" refusal for Group A (project-mutating) commands.
-
-See ``docs/prd/v1.11-unbound-fallback.md`` (R2) for the classification of
-commands and rationale. Group A commands write project-scoped state and
-MUST refuse on unbound channels rather than silently scattering files into
-``~``.
-
-This module exists so the message text and the parent-thread fallback logic
-live in exactly one place, and so callers across cogs can add a single guard:
-
-    from clauded.cogs._unbound import reject_if_unbound
-
-    async def my_command(interaction):
-        if await reject_if_unbound(interaction, bot):
-            return
-        ...
-"""
+"""Unified unbound-channel refusal + hint string for Group A commands."""
 
 from __future__ import annotations
 
@@ -26,27 +10,39 @@ UNBOUND_REFUSE_MESSAGE = (
     "Run `/project bind <path>` first, then retry."
 )
 
+UNBOUND_HINT_MESSAGE = (
+    "💡 This channel isn't bound to a project. "
+    "I'll use your home directory (`~`) as the working directory. "
+    "Run `/project bind <path>` to scope to a specific project."
+)
+
+NO_CHANNEL_MESSAGE = "❌ This command must be run in a channel."
+
 
 async def reject_if_unbound(interaction: discord.Interaction, bot) -> bool:
-    """Return ``True`` if the interaction's channel is unbound and a refusal
-    reply has been sent. Caller MUST ``return`` immediately after a ``True``
-    result — the response has already been sent to Discord.
-
-    Threads inherit their parent channel's bound state, so we resolve the
-    parent ``channel_id`` for ``discord.Thread`` instances before checking
-    ``ProjectManager.is_bound``.
-    """
+    """Refuse Group A commands on unbound channels. Returns True iff refusal sent."""
     ch = interaction.channel
-    channel_id = ch.parent_id if isinstance(ch, discord.Thread) else ch.id
+    if ch is None:
+        # DM, cache miss, or permission gap — fall back to interaction.channel_id.
+        channel_id = interaction.channel_id
+    elif isinstance(ch, discord.Thread):
+        # Threads inherit the parent channel's bound state.
+        channel_id = ch.parent_id or interaction.channel_id
+    else:
+        channel_id = ch.id
+
+    sender = (
+        interaction.followup.send
+        if interaction.response.is_done()
+        else interaction.response.send_message
+    )
+
+    if channel_id is None:
+        await sender(NO_CHANNEL_MESSAGE, ephemeral=True)
+        return True
+
     if bot.project_manager.is_bound(channel_id):
         return False
 
-    if not interaction.response.is_done():
-        await interaction.response.send_message(
-            UNBOUND_REFUSE_MESSAGE, ephemeral=True
-        )
-    else:
-        await interaction.followup.send(
-            UNBOUND_REFUSE_MESSAGE, ephemeral=True
-        )
+    await sender(UNBOUND_REFUSE_MESSAGE, ephemeral=True)
     return True

--- a/src/clauded/cogs/_unbound.py
+++ b/src/clauded/cogs/_unbound.py
@@ -1,0 +1,52 @@
+"""Unified "channel not bound" refusal for Group A (project-mutating) commands.
+
+See ``docs/prd/v1.11-unbound-fallback.md`` (R2) for the classification of
+commands and rationale. Group A commands write project-scoped state and
+MUST refuse on unbound channels rather than silently scattering files into
+``~``.
+
+This module exists so the message text and the parent-thread fallback logic
+live in exactly one place, and so callers across cogs can add a single guard:
+
+    from clauded.cogs._unbound import reject_if_unbound
+
+    async def my_command(interaction):
+        if await reject_if_unbound(interaction, bot):
+            return
+        ...
+"""
+
+from __future__ import annotations
+
+import discord
+
+
+UNBOUND_REFUSE_MESSAGE = (
+    "❌ This channel isn't bound to a project. "
+    "Run `/project bind <path>` first, then retry."
+)
+
+
+async def reject_if_unbound(interaction: discord.Interaction, bot) -> bool:
+    """Return ``True`` if the interaction's channel is unbound and a refusal
+    reply has been sent. Caller MUST ``return`` immediately after a ``True``
+    result — the response has already been sent to Discord.
+
+    Threads inherit their parent channel's bound state, so we resolve the
+    parent ``channel_id`` for ``discord.Thread`` instances before checking
+    ``ProjectManager.is_bound``.
+    """
+    ch = interaction.channel
+    channel_id = ch.parent_id if isinstance(ch, discord.Thread) else ch.id
+    if bot.project_manager.is_bound(channel_id):
+        return False
+
+    if not interaction.response.is_done():
+        await interaction.response.send_message(
+            UNBOUND_REFUSE_MESSAGE, ephemeral=True
+        )
+    else:
+        await interaction.followup.send(
+            UNBOUND_REFUSE_MESSAGE, ephemeral=True
+        )
+    return True

--- a/src/clauded/cogs/agent.py
+++ b/src/clauded/cogs/agent.py
@@ -7,6 +7,7 @@ import logging
 import discord
 from discord import app_commands
 
+from ._unbound import reject_if_unbound
 from ..discord_renderer import COLOR_INFO
 
 log = logging.getLogger("clauded.bot")
@@ -27,6 +28,8 @@ async def agent_create(
     bot = interaction.client
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    if await reject_if_unbound(interaction, bot):
         return
     bot.agent_manager.create(name, prompt, description)
     embed = discord.Embed(
@@ -92,6 +95,8 @@ async def agent_delete(interaction: discord.Interaction, name: str) -> None:
     bot = interaction.client
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    if await reject_if_unbound(interaction, bot):
         return
     if bot.agent_manager.delete(name):
         embed = discord.Embed(

--- a/src/clauded/cogs/mcp.py
+++ b/src/clauded/cogs/mcp.py
@@ -7,6 +7,7 @@ import logging
 import discord
 from discord import app_commands
 
+from ._unbound import reject_if_unbound
 from ..discord_renderer import COLOR_INFO
 
 log = logging.getLogger("clauded.bot")
@@ -29,6 +30,8 @@ async def mcp_add(
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
+    if await reject_if_unbound(interaction, bot):
+        return
     channel_id = interaction.channel_id
     parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
     config: dict = {"type": "stdio", "command": command}
@@ -50,6 +53,8 @@ async def mcp_add_url(interaction: discord.Interaction, name: str, url: str) -> 
     bot = interaction.client
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    if await reject_if_unbound(interaction, bot):
         return
     channel_id = interaction.channel_id
     parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
@@ -96,6 +101,8 @@ async def mcp_remove(interaction: discord.Interaction, name: str) -> None:
     bot = interaction.client
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    if await reject_if_unbound(interaction, bot):
         return
     channel_id = interaction.channel_id
     parent_id = getattr(interaction.channel, "parent_id", None) or channel_id

--- a/src/clauded/cogs/ops.py
+++ b/src/clauded/cogs/ops.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import discord
 from discord import app_commands
 
+from ._unbound import reject_if_unbound
 from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE
 from ..interaction_handler import InteractionHandler
 from ..session_config import SessionConfig
@@ -137,15 +138,12 @@ async def review_pr(interaction: discord.Interaction, pr: str) -> None:
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
+    if await reject_if_unbound(interaction, bot):
+        return
     await interaction.response.defer()
     channel = interaction.channel
     parent_id = getattr(channel, "parent_id", None) or channel.id
     project_path = bot.project_manager.get_path(parent_id)
-    if not project_path:
-        await interaction.followup.send(
-            embed=discord.Embed(title="❌ Channel not bound", color=COLOR_TOOL_FAILURE)
-        )
-        return
     if not isinstance(channel, discord.TextChannel):
         await interaction.followup.send(
             embed=discord.Embed(title="❌ Use this in a text channel", color=COLOR_TOOL_FAILURE),
@@ -218,6 +216,8 @@ async def plugin_add(interaction: discord.Interaction, path: str) -> None:
     bot = interaction.client
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    if await reject_if_unbound(interaction, bot):
         return
 
     resolved = Path(path).expanduser().resolve()

--- a/src/clauded/cogs/project.py
+++ b/src/clauded/cogs/project.py
@@ -8,8 +8,9 @@ from pathlib import Path
 import discord
 from discord import app_commands
 
-from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE
+from ..discord_renderer import COLOR_INFO
 from ..project_manager import ProjectManager
+from ._unbound import reject_if_unbound
 
 log = logging.getLogger("clauded.bot")
 
@@ -146,8 +147,7 @@ async def project_system_prompt(interaction: discord.Interaction) -> None:
         await interaction.response.send_message("No channel context.", ephemeral=True)
         return
 
-    if not bot.project_manager.is_bound(channel_id):
-        await interaction.response.send_message("Channel not bound. Use /project bind first.", ephemeral=True)
+    if await reject_if_unbound(interaction, bot):
         return
 
     modal = SystemPromptModal(channel_id, bot.project_manager)
@@ -164,8 +164,7 @@ async def project_add_dir(interaction: discord.Interaction, path: str) -> None:
     if channel_id is None:
         await interaction.response.send_message("No channel context.", ephemeral=True)
         return
-    if not bot.project_manager.is_bound(channel_id):
-        await interaction.response.send_message("Channel not bound. Use /project bind first.", ephemeral=True)
+    if await reject_if_unbound(interaction, bot):
         return
     try:
         resolved = bot.project_manager.add_extra_dir(channel_id, path)
@@ -306,11 +305,10 @@ async def env_set(interaction: discord.Interaction, key: str, value: str) -> Non
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
+    if await reject_if_unbound(interaction, bot):
+        return
     channel_id = interaction.channel_id
     parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
-    if not bot.project_manager.is_bound(parent_id):
-        await interaction.response.send_message("Channel not bound. Use /project bind first.", ephemeral=True)
-        return
     bot.project_manager.set_env(parent_id, key, value)
     embed = discord.Embed(
         title="✅ Environment Variable Set",
@@ -351,6 +349,8 @@ async def env_remove(interaction: discord.Interaction, key: str) -> None:
     bot = interaction.client
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    if await reject_if_unbound(interaction, bot):
         return
     channel_id = interaction.channel_id
     parent_id = getattr(interaction.channel, "parent_id", None) or channel_id

--- a/src/clauded/cogs/project.py
+++ b/src/clauded/cogs/project.py
@@ -150,7 +150,10 @@ async def project_system_prompt(interaction: discord.Interaction) -> None:
     if await reject_if_unbound(interaction, bot):
         return
 
-    modal = SystemPromptModal(channel_id, bot.project_manager)
+    # Threads inherit the parent channel's binding; resolve to parent so the
+    # prompt attaches to the bound row, not the (unbound) thread id.
+    parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
+    modal = SystemPromptModal(parent_id, bot.project_manager)
     await interaction.response.send_modal(modal)
 
 
@@ -166,8 +169,11 @@ async def project_add_dir(interaction: discord.Interaction, path: str) -> None:
         return
     if await reject_if_unbound(interaction, bot):
         return
+    # Threads inherit the parent channel's binding; resolve to parent so
+    # the extra dir attaches to the bound row, not the (unbound) thread id.
+    parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
     try:
-        resolved = bot.project_manager.add_extra_dir(channel_id, path)
+        resolved = bot.project_manager.add_extra_dir(parent_id, path)
     except ValueError as exc:
         await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
         return

--- a/src/clauded/cogs/session.py
+++ b/src/clauded/cogs/session.py
@@ -7,6 +7,7 @@ import logging
 import discord
 from discord import app_commands
 
+from ._unbound import reject_if_unbound
 from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE
 from ..interaction_handler import InteractionHandler
 from ..session_config import SessionConfig
@@ -105,6 +106,8 @@ async def session_resume(interaction: discord.Interaction) -> None:
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
+    if await reject_if_unbound(interaction, bot):
+        return
     thread_id = interaction.channel_id
     if thread_id is None:
         await interaction.response.send_message("No thread context.", ephemeral=True)
@@ -196,6 +199,8 @@ async def session_fork(interaction: discord.Interaction) -> None:
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
+    if await reject_if_unbound(interaction, bot):
+        return
     thread_id = interaction.channel_id
     if thread_id is None:
         await interaction.response.send_message("Use this command inside a thread.", ephemeral=True)
@@ -229,6 +234,8 @@ async def session_worktree(interaction: discord.Interaction, name: str) -> None:
     bot = interaction.client
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    if await reject_if_unbound(interaction, bot):
         return
     bridge = await bot._recreate_session(interaction, worktree=name)
     if bridge:
@@ -280,6 +287,8 @@ async def session_security_review(interaction: discord.Interaction) -> None:
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
+    if await reject_if_unbound(interaction, bot):
+        return
     thread_id = interaction.channel_id
     if thread_id is None:
         await interaction.response.send_message("Use this in a thread.", ephemeral=True)
@@ -309,6 +318,8 @@ async def session_settings(interaction: discord.Interaction, json_str: str) -> N
     bot = interaction.client
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    if await reject_if_unbound(interaction, bot):
         return
     bridge = await bot._recreate_session(interaction, settings=json_str)
     if bridge:

--- a/src/clauded/config.py
+++ b/src/clauded/config.py
@@ -21,6 +21,12 @@ class Config:
     claude_model: str
     claude_permission_mode: str
     projects_root: str
+    # SECURITY: when False (default), an unbound channel's @bot message is
+    # silently ignored — restoring v1.0 behavior. When True, the on-message
+    # handler falls back to ``$HOME`` as cwd. Toggling on grants any user
+    # with channel-write permission shell access to the operator's home,
+    # so this stays opt-in. See PRD R4.2/R4.3.
+    allow_unbound_fallback: bool = False
 
 
 def load_config() -> Config:
@@ -57,4 +63,8 @@ def load_config() -> Config:
             or "default"
         ),
         projects_root=projects_root,
+        allow_unbound_fallback=(
+            os.environ.get("CLAUDED_ALLOW_UNBOUND_FALLBACK", "").strip().lower()
+            in ("1", "true", "yes", "on")
+        ),
     )

--- a/src/clauded/project_manager.py
+++ b/src/clauded/project_manager.py
@@ -11,7 +11,6 @@ import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Set, Tuple
 
 log = logging.getLogger("clauded.project_manager")
 
@@ -32,12 +31,11 @@ class ProjectManager:
         root = projects_root if projects_root is not None else str(Path.home())
         self.projects_root: Path = Path(root).expanduser().resolve()
         self._path = Path(self.path)
-        self._projects: Dict[str, Dict[str, str]] = {}
-        self._guild_roots: Dict[str, str] = {}
+        self._projects: dict[str, dict[str, str]] = {}
+        self._guild_roots: dict[str, str] = {}
         # Channels that have already been shown the "unbound, falling back to
-        # ~" hint this process. In-memory only — a bot restart re-arms the
-        # one-shot hint, which is the desired behavior per PRD R3.1.
-        self._hinted_unbound_channels: Set[int] = set()
+        # ~" hint this process. In-memory only — bot restart re-arms the hint.
+        self._hinted_unbound_channels: set[int] = set()
         self._load()
         self._load_guild_roots()
 
@@ -146,38 +144,37 @@ class ProjectManager:
         """Return True if ``channel_id`` has a binding."""
         return str(channel_id) in self._projects
 
-    # ------------------------------------------------------------------
-    # Unbound-channel fallback (v1.11, #110)
-    # ------------------------------------------------------------------
-    def get_path_or_default(self, channel_id: int) -> Tuple[Path, bool]:
-        """Return ``(path, is_bound)`` for ``channel_id``.
+    def _assert_bound(self, channel_id: int) -> None:
+        """Defense in depth: refuse mutating ops on unbound channels.
 
-        - When the channel is bound, returns ``(Path(bound_path), True)``.
-        - When unbound, returns ``(Path.home().resolve(), False)``.
-
-        The ``.resolve()`` on the home-directory fallback is intentional —
-        macOS ships ``/tmp -> /private/tmp`` and similar symlinked layouts
-        that the v1.0 `#11` fix taught us must be canonicalized at the
-        binding boundary. Applying ``.resolve()`` to ``Path.home()`` here
-        keeps the unbound path subject to the same canonicalization
-        discipline (e.g. ``/Users/x`` vs ``/private/Users/x``) so the cwd
-        we hand to Claude matches whatever it would receive after a
-        ``/project bind``.
+        Cog-level ``reject_if_unbound`` is the user-facing guard; this raises
+        a programming-error ``ValueError`` if a caller bypasses it.
         """
+        if not self.is_bound(channel_id):
+            raise ValueError(
+                f"channel {channel_id} is not bound; cannot mutate project state"
+            )
+
+    # ------------------------------------------------------------------
+    # Unbound-channel fallback
+    # ------------------------------------------------------------------
+    def get_path_or_default(self, channel_id: int) -> tuple[Path, bool]:
+        """Return ``(path, is_bound)`` — bound path or ``$HOME`` fallback."""
         if self.is_bound(channel_id):
             p = self.get_path(channel_id)
-            assert p is not None  # is_bound guarantees this
-            return Path(p), True
-        return Path.home().resolve(), False
+            if p is not None:
+                return Path(p), True
+            # Partial entry (no path key) — treat as unbound.
+        try:
+            return Path.home().resolve(), False
+        except (RuntimeError, OSError):
+            # ``Path.home()`` raises when ``$HOME`` is unset and there's no
+            # passwd entry. Return a sentinel that ``Path.is_dir()`` reports
+            # False for, so the caller's broken-home guard fires cleanly.
+            return Path("/nonexistent"), False
 
     def should_hint_unbound(self, channel_id: int) -> bool:
-        """Return True the FIRST time we should nudge ``channel_id`` about
-        ``/project bind``; False on every subsequent call.
-
-        Atomic: the membership check and insertion happen together, so two
-        concurrent callers can't both receive ``True``. State is in-memory
-        only and resets on bot restart (PRD R3.1).
-        """
+        """Return True only the first time we should nudge ``channel_id`` about /project bind."""
         if channel_id in self._hinted_unbound_channels:
             return False
         self._hinted_unbound_channels.add(channel_id)
@@ -188,6 +185,7 @@ class ProjectManager:
     # ------------------------------------------------------------------
     def set_system_prompt(self, channel_id: int, prompt: str) -> None:
         """Store a system prompt for the given channel binding."""
+        self._assert_bound(channel_id)
         key = str(channel_id)
         entry = self._projects.get(key)
         if entry is None:
@@ -216,6 +214,7 @@ class ProjectManager:
     # ------------------------------------------------------------------
     def set_budget(self, channel_id: int, amount: float) -> None:
         """Store a max budget (USD) for the given channel binding."""
+        self._assert_bound(channel_id)
         key = str(channel_id)
         entry = self._projects.get(key)
         if entry is None:
@@ -245,6 +244,7 @@ class ProjectManager:
     # ------------------------------------------------------------------
     def add_extra_dir(self, channel_id: int, path: str) -> str:
         """Add an extra directory. Validates and stores. Returns resolved path."""
+        self._assert_bound(channel_id)
         raw_parts = Path(path).expanduser().parts
         if any(part == ".." for part in raw_parts):
             raise ValueError("Path may not contain '..' segments.")
@@ -275,6 +275,7 @@ class ProjectManager:
 
     def remove_extra_dir(self, channel_id: int, path: str) -> bool:
         """Remove an extra directory. Returns True if removed."""
+        self._assert_bound(channel_id)
         key = str(channel_id)
         entry = self._projects.get(key, {})
         dirs = entry.get("extra_dirs", [])
@@ -297,6 +298,7 @@ class ProjectManager:
         ``{"type": "stdio", "command": "npx", "args": [...]}`` or
         ``{"type": "http", "url": "https://..."}``
         """
+        self._assert_bound(channel_id)
         key = str(channel_id)
         entry = self._projects.get(key, {})
         mcps = entry.get("mcp_servers", {})
@@ -311,6 +313,7 @@ class ProjectManager:
 
     def remove_mcp_server(self, channel_id: int, name: str) -> bool:
         """Remove an MCP server by name. Returns True if it existed."""
+        self._assert_bound(channel_id)
         key = str(channel_id)
         entry = self._projects.get(key, {})
         mcps = entry.get("mcp_servers", {})
@@ -326,6 +329,7 @@ class ProjectManager:
     # ------------------------------------------------------------------
     def set_env(self, channel_id: int, key: str, value: str) -> None:
         """Store an environment variable for the given channel binding."""
+        self._assert_bound(channel_id)
         k = str(channel_id)
         entry = self._projects.get(k, {})
         env = entry.get("env", {})
@@ -341,6 +345,7 @@ class ProjectManager:
 
     def remove_env(self, channel_id: int, key: str) -> bool:
         """Remove an environment variable. Returns True if removed."""
+        self._assert_bound(channel_id)
         k = str(channel_id)
         entry = self._projects.get(k, {})
         env = entry.get("env", {})
@@ -358,6 +363,7 @@ class ProjectManager:
         """Set channel mode: 'thread' (default) or 'forum'."""
         if mode not in ("thread", "forum"):
             raise ValueError(f"Invalid mode: {mode!r}. Must be 'thread' or 'forum'.")
+        self._assert_bound(channel_id)
         key = str(channel_id)
         entry = self._projects.setdefault(key, {})
         entry["channel_mode"] = mode

--- a/src/clauded/project_manager.py
+++ b/src/clauded/project_manager.py
@@ -11,7 +11,7 @@ import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Set, Tuple
 
 log = logging.getLogger("clauded.project_manager")
 
@@ -34,6 +34,10 @@ class ProjectManager:
         self._path = Path(self.path)
         self._projects: Dict[str, Dict[str, str]] = {}
         self._guild_roots: Dict[str, str] = {}
+        # Channels that have already been shown the "unbound, falling back to
+        # ~" hint this process. In-memory only — a bot restart re-arms the
+        # one-shot hint, which is the desired behavior per PRD R3.1.
+        self._hinted_unbound_channels: Set[int] = set()
         self._load()
         self._load_guild_roots()
 
@@ -141,6 +145,43 @@ class ProjectManager:
     def is_bound(self, channel_id: int) -> bool:
         """Return True if ``channel_id`` has a binding."""
         return str(channel_id) in self._projects
+
+    # ------------------------------------------------------------------
+    # Unbound-channel fallback (v1.11, #110)
+    # ------------------------------------------------------------------
+    def get_path_or_default(self, channel_id: int) -> Tuple[Path, bool]:
+        """Return ``(path, is_bound)`` for ``channel_id``.
+
+        - When the channel is bound, returns ``(Path(bound_path), True)``.
+        - When unbound, returns ``(Path.home().resolve(), False)``.
+
+        The ``.resolve()`` on the home-directory fallback is intentional —
+        macOS ships ``/tmp -> /private/tmp`` and similar symlinked layouts
+        that the v1.0 `#11` fix taught us must be canonicalized at the
+        binding boundary. Applying ``.resolve()`` to ``Path.home()`` here
+        keeps the unbound path subject to the same canonicalization
+        discipline (e.g. ``/Users/x`` vs ``/private/Users/x``) so the cwd
+        we hand to Claude matches whatever it would receive after a
+        ``/project bind``.
+        """
+        if self.is_bound(channel_id):
+            p = self.get_path(channel_id)
+            assert p is not None  # is_bound guarantees this
+            return Path(p), True
+        return Path.home().resolve(), False
+
+    def should_hint_unbound(self, channel_id: int) -> bool:
+        """Return True the FIRST time we should nudge ``channel_id`` about
+        ``/project bind``; False on every subsequent call.
+
+        Atomic: the membership check and insertion happen together, so two
+        concurrent callers can't both receive ``True``. State is in-memory
+        only and resets on bot restart (PRD R3.1).
+        """
+        if channel_id in self._hinted_unbound_channels:
+            return False
+        self._hinted_unbound_channels.add(channel_id)
+        return True
 
     # ------------------------------------------------------------------
     # System prompt

--- a/tests/test_bot_unbound_message.py
+++ b/tests/test_bot_unbound_message.py
@@ -1,0 +1,386 @@
+"""Tests for the v1.11 unbound-channel fallback in ``ClaudedBot``.
+
+The on-message handlers (``_handle_channel_message`` /
+``_handle_thread_message``) used to early-return when the channel had
+no ``/project bind``. v1.11 (#110) changes that: unbound channels fall
+back to the operator's home directory and surface a one-shot hint about
+``/project bind`` as the first thread message.
+
+These tests drive the handlers directly with fake Discord objects, and
+monkeypatch ``SessionManager.create_session`` + ``DiscordRenderer`` so
+the handler's bridge/render side effects don't actually try to talk to
+Claude.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from clauded.bot import ClaudedBot
+from clauded.config import Config
+from clauded.cost_tracker import CostTracker
+from clauded.project_manager import ProjectManager
+from clauded.session_manager import SessionManager
+
+
+# ---------------------------------------------------------------------------
+# Fake Discord plumbing
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeAuthor:
+    id: int = 999
+    bot: bool = False
+    name: str = "alice"
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@dataclass
+class FakeUser:
+    id: int = 42
+    name: str = "bot"
+
+
+class FakeReaction:
+    pass
+
+
+class FakeThread:
+    """Minimal stand-in for a created Discord thread."""
+
+    def __init__(self, thread_id: int, name: str = "session") -> None:
+        self.id = thread_id
+        self.name = name
+        self.parent_id: int | None = None
+        self.messages: list[dict[str, Any]] = []
+
+    async def send(self, content: str | None = None, **kwargs: Any) -> Any:
+        self.messages.append({"content": content, **kwargs})
+        return MagicMock()
+
+
+class FakeChannel:
+    """Stand-in for ``discord.TextChannel`` (the parent of the thread)."""
+
+    # Marker that ``isinstance(self, discord.TextChannel)`` returns True
+    # via the test setup below.
+    def __init__(self, channel_id: int) -> None:
+        self.id = channel_id
+        self.parent_id: int | None = None
+        self.sent: list[Any] = []
+
+    async def send(self, content: str | None = None, **kwargs: Any) -> Any:
+        self.sent.append({"content": content, **kwargs})
+        return MagicMock()
+
+
+class FakeMessage:
+    """Stand-in for ``discord.Message``."""
+
+    def __init__(
+        self,
+        *,
+        channel: Any,
+        content: str,
+        bot_user_id: int,
+        author: FakeAuthor | None = None,
+    ) -> None:
+        self.channel = channel
+        self.content = content
+        # Pretend the bot was @mentioned so ``_handle_channel_message``
+        # passes the gate.
+        self.mentions = [MagicMock(id=bot_user_id)]
+        self.role_mentions: list[Any] = []
+        self.author = author or FakeAuthor()
+        self.attachments: list[Any] = []
+        self.replies: list[str] = []
+        self._created_thread: FakeThread | None = None
+
+    async def reply(self, content: str, **kwargs: Any) -> Any:
+        self.replies.append(content)
+        return MagicMock()
+
+    async def create_thread(self, *, name: str, **kwargs: Any) -> FakeThread:
+        thread = FakeThread(thread_id=hash(name) & 0xFFFF, name=name)
+        thread.parent_id = self.channel.id
+        self._created_thread = thread
+        return thread
+
+    async def add_reaction(self, _emoji: str) -> None:
+        return None
+
+    async def remove_reaction(self, _emoji: str, _user: Any) -> None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Bot fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Config:
+    return Config(
+        discord_bot_token="tok",
+        claude_model="sonnet",
+        claude_permission_mode="default",
+        projects_root=str(tmp_path),
+    )
+
+
+@pytest.fixture
+def bot(cfg: Config, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ClaudedBot:
+    """Build a ``ClaudedBot`` without going through ``commands.Bot.__init__``.
+
+    Discord's commands.Bot constructor wants a running event loop and an
+    actual token; for unit tests we just need the attributes the handlers
+    touch.
+    """
+    # Steer ProjectManager at a temp data dir so we don't pollute repo data/.
+    pm = ProjectManager(data_dir=str(tmp_path / "data"), projects_root=str(tmp_path))
+
+    bot = ClaudedBot.__new__(ClaudedBot)
+    bot.config = cfg
+    bot.project_manager = pm
+    bot.session_manager = SessionManager()
+    bot.cost_tracker = CostTracker()
+    bot.agent_manager = MagicMock()
+    bot._start_time = 0.0
+    bot._claude_version = "test"
+    bot._debug_logging = False
+    bot._pre_tool_notifications = False
+    bot._notify_enabled = {}
+    # Bot identity used by the mention check
+    bot._connection = MagicMock()  # placeholder; tests don't talk to it
+    fake_user = FakeUser(id=42, name="bot")
+    # ``self.user`` is a property on commands.Bot; set it directly.
+    monkeypatch.setattr(ClaudedBot, "user", property(lambda self: fake_user))
+
+    # Make ``isinstance(channel, discord.TextChannel)`` succeed for FakeChannel.
+    monkeypatch.setattr(discord, "TextChannel", FakeChannel)
+    # ForumChannel check uses ``channel_mode == "forum"``, which our fixture
+    # never sets, so the actual class never matters. Patch it to a sentinel
+    # so the isinstance() check is well-defined.
+    class _Forum:  # noqa: D401
+        pass
+
+    monkeypatch.setattr(discord, "ForumChannel", _Forum)
+
+    return bot
+
+
+@pytest.fixture
+def captured_sessions(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Capture every ``SessionManager.create_session`` call's project_path.
+
+    Returns a list that the test inspects; each entry holds the args the
+    handler passed in. The fake bridge is just enough to satisfy the
+    handler's ``bridge.total_cost`` access.
+    """
+    captured: list[dict[str, Any]] = []
+
+    async def _fake_create(
+        self: SessionManager,
+        thread_id: int,
+        project_path: str,
+        config: Config,
+        session_config: Any = None,
+    ) -> Any:
+        bridge = MagicMock()
+        bridge.total_cost = 0.0
+        bridge.is_active = True
+        # ``save_session_state`` skips when session_id is falsy — keep it None
+        # so the test doesn't hit SessionStore's JSON encoder with mocks.
+        bridge.session_id = None
+        captured.append(
+            {
+                "thread_id": thread_id,
+                "project_path": project_path,
+                "session_config": session_config,
+            }
+        )
+        # Register so ``get_session`` returns it (used by thread handler).
+        self._sessions[thread_id] = bridge
+        return bridge
+
+    monkeypatch.setattr(SessionManager, "create_session", _fake_create)
+
+    # Skip the actual rendering — the handler's renderer call would try to
+    # iterate the (mock) bridge's ``send_message``. We don't care; the test
+    # only inspects what was captured before render.
+    async def _noop_render(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401
+        return None
+
+    monkeypatch.setattr(ClaudedBot, "_render_with_retry", _noop_render)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unbound_channel_first_message_falls_back_to_home_with_hint(
+    bot: ClaudedBot, captured_sessions: list[dict[str, Any]]
+) -> None:
+    """First @bot in an unbound channel: bridge cwd=$HOME + hint posted."""
+    channel = FakeChannel(channel_id=1001)
+    msg = FakeMessage(channel=channel, content="<@42> hello", bot_user_id=42)
+
+    await bot._handle_channel_message(msg)
+
+    assert captured_sessions, "Expected create_session to be called"
+    assert captured_sessions[0]["project_path"] == str(Path.home().resolve())
+
+    thread = msg._created_thread
+    assert thread is not None, "Thread should have been created"
+    # Hint must be the first message posted in the thread, before anything
+    # the bridge would emit.
+    assert thread.messages, "Hint message expected on the thread"
+    first = thread.messages[0]["content"]
+    assert "isn't bound to a project" in first
+    assert "/project bind" in first
+    assert "home directory" in first
+
+
+@pytest.mark.asyncio
+async def test_unbound_channel_second_message_no_hint_repeated(
+    bot: ClaudedBot, captured_sessions: list[dict[str, Any]]
+) -> None:
+    """Second @bot in same unbound channel: cwd=$HOME, no hint repeated."""
+    channel = FakeChannel(channel_id=1002)
+
+    msg1 = FakeMessage(channel=channel, content="<@42> first", bot_user_id=42)
+    await bot._handle_channel_message(msg1)
+    msg2 = FakeMessage(channel=channel, content="<@42> second", bot_user_id=42)
+    await bot._handle_channel_message(msg2)
+
+    assert len(captured_sessions) == 2
+    assert all(
+        c["project_path"] == str(Path.home().resolve()) for c in captured_sessions
+    )
+
+    thread2 = msg2._created_thread
+    assert thread2 is not None
+    # Second invocation must NOT post the hint into its (separate) thread.
+    for m in thread2.messages:
+        assert "isn't bound to a project" not in (m["content"] or "")
+
+
+@pytest.mark.asyncio
+async def test_bound_channel_uses_bound_path_no_hint(
+    bot: ClaudedBot,
+    captured_sessions: list[dict[str, Any]],
+    tmp_path: Path,
+) -> None:
+    """Bound channel: bridge gets bound path; no hint posted."""
+    proj = tmp_path / "myproj"
+    proj.mkdir()
+    bot.project_manager.bind(2001, str(proj))
+
+    channel = FakeChannel(channel_id=2001)
+    msg = FakeMessage(channel=channel, content="<@42> hi", bot_user_id=42)
+
+    await bot._handle_channel_message(msg)
+
+    assert captured_sessions
+    assert captured_sessions[0]["project_path"] == str(proj.resolve())
+
+    thread = msg._created_thread
+    assert thread is not None
+    for m in thread.messages:
+        assert "isn't bound to a project" not in (m["content"] or "")
+
+
+@pytest.mark.asyncio
+async def test_post_bind_no_hint_even_if_previously_unbound(
+    bot: ClaudedBot,
+    captured_sessions: list[dict[str, Any]],
+    tmp_path: Path,
+) -> None:
+    """Unbound → fired hint → /project bind → next call uses bound, no hint."""
+    channel = FakeChannel(channel_id=3001)
+
+    # First message: unbound. Hint fires.
+    msg1 = FakeMessage(channel=channel, content="<@42> first", bot_user_id=42)
+    await bot._handle_channel_message(msg1)
+    thread1 = msg1._created_thread
+    assert thread1 is not None
+    assert any(
+        "isn't bound to a project" in (m["content"] or "") for m in thread1.messages
+    )
+
+    # Now bind.
+    proj = tmp_path / "later"
+    proj.mkdir()
+    bot.project_manager.bind(3001, str(proj))
+
+    # Second message: bound. cwd=bound, no hint in this thread.
+    msg2 = FakeMessage(channel=channel, content="<@42> second", bot_user_id=42)
+    await bot._handle_channel_message(msg2)
+    thread2 = msg2._created_thread
+    assert thread2 is not None
+    for m in thread2.messages:
+        assert "isn't bound to a project" not in (m["content"] or "")
+    assert captured_sessions[-1]["project_path"] == str(proj.resolve())
+
+
+@pytest.mark.asyncio
+async def test_handle_thread_message_inherits_parent_fallback(
+    bot: ClaudedBot, captured_sessions: list[dict[str, Any]]
+) -> None:
+    """Thread message inside unbound parent: bridge cwd=$HOME, no hint here."""
+    parent_channel = FakeChannel(channel_id=4001)
+    thread = FakeChannel(channel_id=4002)  # treat thread as a channel-like obj
+    thread.parent_id = parent_channel.id
+
+    # Sanity-check that the test-level fake thread satisfies what the
+    # handler reads from ``message.channel``.
+    msg = FakeMessage(channel=thread, content="follow-up", bot_user_id=42)
+    await bot._handle_thread_message(msg, parent_id=parent_channel.id)
+
+    assert captured_sessions
+    assert captured_sessions[0]["project_path"] == str(Path.home().resolve())
+    # The thread handler does NOT post the hint — it's the channel handler's job.
+    assert thread.sent == []
+
+
+@pytest.mark.asyncio
+async def test_broken_home_dir_friendly_error(
+    bot: ClaudedBot,
+    captured_sessions: list[dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If $HOME isn't a directory, reply with a friendly error; no session."""
+    bogus = Path("/this/path/does/not/exist/clauded-test")
+
+    def fake_get_path_or_default(channel_id: int):
+        return bogus, False
+
+    monkeypatch.setattr(
+        bot.project_manager, "get_path_or_default", fake_get_path_or_default
+    )
+
+    channel = FakeChannel(channel_id=5001)
+    msg = FakeMessage(channel=channel, content="<@42> hi", bot_user_id=42)
+
+    await bot._handle_channel_message(msg)
+
+    # No bridge created.
+    assert captured_sessions == []
+    # No thread created.
+    assert msg._created_thread is None
+    # Friendly error replied.
+    assert msg.replies, "A reply should have been sent for the broken home"
+    assert "home directory" in msg.replies[0]
+    assert "/project bind" in msg.replies[0]

--- a/tests/test_bot_unbound_message.py
+++ b/tests/test_bot_unbound_message.py
@@ -23,6 +23,7 @@ import discord
 import pytest
 
 from clauded.bot import ClaudedBot
+from clauded.cogs._unbound import UNBOUND_HINT_MESSAGE
 from clauded.config import Config
 from clauded.cost_tracker import CostTracker
 from clauded.project_manager import ProjectManager
@@ -134,6 +135,8 @@ def cfg(tmp_path: Path) -> Config:
         claude_model="sonnet",
         claude_permission_mode="default",
         projects_root=str(tmp_path),
+        # These tests exercise the v1.11 unbound fallback path; enable it.
+        allow_unbound_fallback=True,
     )
 
 
@@ -248,9 +251,10 @@ async def test_unbound_channel_first_message_falls_back_to_home_with_hint(
     # the bridge would emit.
     assert thread.messages, "Hint message expected on the thread"
     first = thread.messages[0]["content"]
-    assert "isn't bound to a project" in first
-    assert "/project bind" in first
-    assert "home directory" in first
+    # tester-2: pin to the exported constant — no substring drift, no
+    # accidental wording divergence between cog and bot module.
+    assert first.startswith("💡"), f"Hint must lead with the lightbulb: {first!r}"
+    assert first == UNBOUND_HINT_MESSAGE
 
 
 @pytest.mark.asyncio
@@ -382,5 +386,8 @@ async def test_broken_home_dir_friendly_error(
     assert msg._created_thread is None
     # Friendly error replied.
     assert msg.replies, "A reply should have been sent for the broken home"
-    assert "home directory" in msg.replies[0]
-    assert "/project bind" in msg.replies[0]
+    reply = msg.replies[0]
+    assert "home directory" in reply
+    assert "/project bind" in reply
+    # sec-2: error must NOT leak the operator's home path or any other path.
+    assert str(bogus) not in reply, "broken-home reply leaked the path"

--- a/tests/test_features_68_73.py
+++ b/tests/test_features_68_73.py
@@ -110,7 +110,10 @@ class TestSystemPromptModal:
         """Modal pre-fills prompt_input.default with existing system prompt."""
         from clauded.bot import SystemPromptModal
 
-        pm = ProjectManager(data_dir=str(tmp_path / "data"), projects_root="/tmp")
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        pm = ProjectManager(data_dir=str(tmp_path / "data"), projects_root=str(tmp_path))
+        pm.bind(42, str(proj))
         pm.set_system_prompt(42, "Be helpful and concise.")
         modal = SystemPromptModal(42, pm)
         assert modal.prompt_input.default == "Be helpful and concise."
@@ -359,9 +362,23 @@ class TestPostToolUseHook:
 
 
 class TestProjectManagerEnv:
+    @staticmethod
+    def _make_bound_pm(tmp_path, channel_id: int = 100) -> ProjectManager:
+        """Helper: create a ProjectManager with ``channel_id`` already bound
+        to a real directory under the configured root. Required because
+        v1.11 arch-2 forbids ``set_env``/``remove_env`` on unbound channels.
+        """
+        proj = tmp_path / f"proj-{channel_id}"
+        proj.mkdir()
+        pm = ProjectManager(
+            data_dir=str(tmp_path / "data"), projects_root=str(tmp_path)
+        )
+        pm.bind(channel_id, str(proj))
+        return pm
+
     def test_set_and_get_env(self, tmp_path) -> None:
         """set_env stores a variable retrievable via get_env."""
-        pm = ProjectManager(data_dir=str(tmp_path / "data"), projects_root="/tmp")
+        pm = self._make_bound_pm(tmp_path, 100)
         pm.set_env(100, "API_KEY", "secret123")
         env = pm.get_env(100)
         assert env == {"API_KEY": "secret123"}
@@ -373,7 +390,7 @@ class TestProjectManagerEnv:
 
     def test_set_env_multiple(self, tmp_path) -> None:
         """Multiple env vars can be set."""
-        pm = ProjectManager(data_dir=str(tmp_path / "data"), projects_root="/tmp")
+        pm = self._make_bound_pm(tmp_path, 100)
         pm.set_env(100, "KEY1", "val1")
         pm.set_env(100, "KEY2", "val2")
         env = pm.get_env(100)
@@ -381,28 +398,30 @@ class TestProjectManagerEnv:
 
     def test_set_env_overwrites(self, tmp_path) -> None:
         """Setting same key overwrites the value."""
-        pm = ProjectManager(data_dir=str(tmp_path / "data"), projects_root="/tmp")
+        pm = self._make_bound_pm(tmp_path, 100)
         pm.set_env(100, "KEY", "old")
         pm.set_env(100, "KEY", "new")
         assert pm.get_env(100)["KEY"] == "new"
 
     def test_remove_env(self, tmp_path) -> None:
         """remove_env removes the variable and returns True."""
-        pm = ProjectManager(data_dir=str(tmp_path / "data"), projects_root="/tmp")
+        pm = self._make_bound_pm(tmp_path, 100)
         pm.set_env(100, "KEY", "val")
         assert pm.remove_env(100, "KEY") is True
         assert pm.get_env(100) == {}
 
     def test_remove_env_not_found(self, tmp_path) -> None:
         """remove_env returns False if key doesn't exist."""
-        pm = ProjectManager(data_dir=str(tmp_path / "data"), projects_root="/tmp")
+        pm = self._make_bound_pm(tmp_path, 100)
         assert pm.remove_env(100, "MISSING") is False
 
     def test_env_persists(self, tmp_path) -> None:
         """Env vars survive a round-trip through save/load."""
-        pm1 = ProjectManager(data_dir=str(tmp_path / "data"), projects_root="/tmp")
+        pm1 = self._make_bound_pm(tmp_path, 200)
         pm1.set_env(200, "TOKEN", "abc")
-        pm2 = ProjectManager(data_dir=str(tmp_path / "data"), projects_root="/tmp")
+        pm2 = ProjectManager(
+            data_dir=str(tmp_path / "data"), projects_root=str(tmp_path)
+        )
         assert pm2.get_env(200) == {"TOKEN": "abc"}
 
 

--- a/tests/test_features_87_91.py
+++ b/tests/test_features_87_91.py
@@ -40,31 +40,52 @@ class TestChannelMode:
     def test_default_mode_is_thread(self, manager: ProjectManager) -> None:
         assert manager.get_channel_mode(999) == "thread"
 
-    def test_set_mode_to_forum(self, manager: ProjectManager) -> None:
+    def test_set_mode_to_forum(
+        self, manager: ProjectManager, projects_root: Path
+    ) -> None:
+        proj = projects_root / "p"
+        proj.mkdir()
+        manager.bind(100, str(proj))
         manager.set_channel_mode(100, "forum")
         assert manager.get_channel_mode(100) == "forum"
 
-    def test_set_mode_to_thread(self, manager: ProjectManager) -> None:
+    def test_set_mode_to_thread(
+        self, manager: ProjectManager, projects_root: Path
+    ) -> None:
+        proj = projects_root / "p"
+        proj.mkdir()
+        manager.bind(100, str(proj))
         manager.set_channel_mode(100, "forum")
         manager.set_channel_mode(100, "thread")
         assert manager.get_channel_mode(100) == "thread"
 
-    def test_set_mode_invalid_raises(self, manager: ProjectManager) -> None:
+    def test_set_mode_invalid_raises(
+        self, manager: ProjectManager, projects_root: Path
+    ) -> None:
+        proj = projects_root / "p"
+        proj.mkdir()
+        manager.bind(100, str(proj))
         with pytest.raises(ValueError, match="Invalid mode"):
             manager.set_channel_mode(100, "invalid")
 
     def test_mode_persists(
         self, data_dir: Path, projects_root: Path
     ) -> None:
+        proj = projects_root / "p"
+        proj.mkdir()
         pm1 = ProjectManager(data_dir=str(data_dir), projects_root=str(projects_root))
+        pm1.bind(200, str(proj))
         pm1.set_channel_mode(200, "forum")
 
         pm2 = ProjectManager(data_dir=str(data_dir), projects_root=str(projects_root))
         assert pm2.get_channel_mode(200) == "forum"
 
     def test_mode_saved_in_projects_json(
-        self, manager: ProjectManager, data_dir: Path
+        self, manager: ProjectManager, data_dir: Path, projects_root: Path
     ) -> None:
+        proj = projects_root / "p"
+        proj.mkdir()
+        manager.bind(300, str(proj))
         manager.set_channel_mode(300, "forum")
         payload = json.loads((data_dir / "projects.json").read_text())
         assert payload["300"]["channel_mode"] == "forum"
@@ -80,12 +101,14 @@ class TestChannelMode:
         assert manager.get_project(400) == str(proj.resolve())
         assert manager.get_channel_mode(400) == "forum"
 
-    def test_mode_on_unbound_channel(self, manager: ProjectManager) -> None:
-        """Setting mode on unbound channel creates a minimal entry."""
-        manager.set_channel_mode(500, "forum")
-        assert manager.get_channel_mode(500) == "forum"
-        # But no path is bound
-        assert manager.get_project(500) is None
+    def test_mode_on_unbound_channel_raises(
+        self, manager: ProjectManager
+    ) -> None:
+        """Mutating channel state on an unbound channel must raise (arch-2)."""
+        with pytest.raises(ValueError, match="not bound"):
+            manager.set_channel_mode(500, "forum")
+        # And reading a never-set mode falls back to the default.
+        assert manager.get_channel_mode(500) == "thread"
 
 
 # ===========================================================================

--- a/tests/test_group_a_unbound.py
+++ b/tests/test_group_a_unbound.py
@@ -1,0 +1,190 @@
+"""Parametrized tests verifying Group A commands call ``reject_if_unbound``.
+
+PRD: ``docs/prd/v1.11-unbound-fallback.md`` Acceptance Criterion C.
+Issue: #127.
+
+The contract under test:
+    On an unbound channel, a Group A command MUST send the unified ephemeral
+    refusal message AND skip its underlying side-effect (no agent created, no
+    MCP server registered, no session spawned, ...).
+
+We pick one representative command per cog file. The helper itself is covered
+by ``tests/test_unbound_handler.py`` (#126); here we just verify each cog
+correctly applies the guard.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import discord
+
+from clauded.bot import ClaudedBot
+from clauded.cogs._unbound import UNBOUND_REFUSE_MESSAGE
+from clauded.cogs.agent import agent_create
+from clauded.cogs.mcp import mcp_add
+from clauded.cogs.ops import review_pr
+from clauded.cogs.project import env_set
+from clauded.cogs.session import session_resume
+
+
+def _make_interaction(*, channel_id: int = 1234) -> MagicMock:
+    """Build a discord.Interaction stub whose channel is a bound TextChannel
+    by default. Tests mutate ``bot.project_manager.is_bound`` to flip state.
+    """
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = channel_id
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = channel
+    interaction.channel_id = channel_id
+    interaction.guild_id = 7777
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock(
+        side_effect=lambda *a, **kw: interaction.response.is_done.configure_mock(
+            return_value=True
+        )
+    )
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_bot(*, is_bound: bool) -> MagicMock:
+    bot = MagicMock(spec=ClaudedBot)
+    bot.project_manager = MagicMock()
+    bot.project_manager.is_bound = MagicMock(return_value=is_bound)
+    bot.project_manager.add_mcp_server = MagicMock()
+    bot.project_manager.set_env = MagicMock()
+    bot.project_manager.get_path = MagicMock(return_value=None)
+    bot.project_manager.get_stored_session = MagicMock(return_value=None)
+    bot.agent_manager = MagicMock()
+    bot.agent_manager.create = MagicMock()
+    return bot
+
+
+# (cog_name, callback, kwargs_for_call, sentinel_check)
+# sentinel_check: callable(bot) → asserts the side-effect helper was NOT invoked.
+GROUP_A_CASES = [
+    (
+        "agent_create",
+        agent_create.callback,
+        {"name": "tester", "prompt": "hi", "description": ""},
+        lambda bot: bot.agent_manager.create.assert_not_called(),
+    ),
+    (
+        "mcp_add",
+        mcp_add.callback,
+        {"name": "srv", "command": "/bin/true", "args": ""},
+        lambda bot: bot.project_manager.add_mcp_server.assert_not_called(),
+    ),
+    (
+        "review_pr",
+        review_pr.callback,
+        {"pr": "42"},
+        # /review never calls add_mcp_server; the meaningful no-side-effect
+        # check is "we didn't call get_path" because reject_if_unbound returns
+        # before that line.
+        lambda bot: bot.project_manager.get_path.assert_not_called(),
+    ),
+    (
+        "session_resume",
+        session_resume.callback,
+        {},
+        lambda bot: bot.project_manager.get_stored_session.assert_not_called(),
+    ),
+    (
+        "env_set",
+        env_set.callback,
+        {"key": "FOO", "value": "bar"},
+        lambda bot: bot.project_manager.set_env.assert_not_called(),
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name,callback,kwargs,no_side_effect", GROUP_A_CASES, ids=[c[0] for c in GROUP_A_CASES]
+)
+async def test_group_a_refuses_on_unbound(
+    name: str, callback, kwargs: dict, no_side_effect
+) -> None:
+    """Each Group A command, when run on an unbound channel, replies with the
+    unified ephemeral refusal and DOES NOT invoke its side-effect helper.
+    """
+    interaction = _make_interaction()
+    bot = _make_bot(is_bound=False)
+    interaction.client = bot
+
+    await callback(interaction, **kwargs)
+
+    no_side_effect(bot)
+
+    # Refusal message must have gone out — either via response or followup
+    # depending on whether the command deferred first. Helper unit tests cover
+    # the routing logic; here we just check ONE of them carries the message.
+    response_calls = [
+        ca.args + tuple(ca.kwargs.values())
+        for ca in interaction.response.send_message.await_args_list
+    ]
+    followup_calls = [
+        ca.args + tuple(ca.kwargs.values())
+        for ca in interaction.followup.send.await_args_list
+    ]
+    refusal_seen = any(
+        UNBOUND_REFUSE_MESSAGE in str(c) for c in response_calls + followup_calls
+    )
+    assert refusal_seen, (
+        f"{name} did not send UNBOUND_REFUSE_MESSAGE. "
+        f"response={response_calls} followup={followup_calls}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name,callback,kwargs,no_side_effect", GROUP_A_CASES, ids=[c[0] for c in GROUP_A_CASES]
+)
+async def test_group_a_passes_through_on_bound(
+    name: str, callback, kwargs: dict, no_side_effect
+) -> None:
+    """Each Group A command, when run on a bound channel, does NOT send the
+    unified refusal. (The command may still bail for other reasons — e.g.,
+    ``/session resume`` returning ``No saved session to resume.`` — but the
+    bound check itself must pass through.)
+    """
+    interaction = _make_interaction()
+    bot = _make_bot(is_bound=True)
+    interaction.client = bot
+
+    # Stub out anything that would otherwise blow up in the body. We only
+    # care that the FIRST gate (reject_if_unbound) didn't fire.
+    bot._recreate_session = AsyncMock(return_value=None)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_lock = MagicMock(return_value=AsyncMock())
+    bot.session_manager.create_session = AsyncMock(return_value=None)
+
+    try:
+        await callback(interaction, **kwargs)
+    except Exception:
+        # Some commands fail downstream because of incomplete mocks; that's
+        # fine — we only assert the helper didn't reject.
+        pass
+
+    response_calls = [
+        ca.args + tuple(ca.kwargs.values())
+        for ca in interaction.response.send_message.await_args_list
+    ]
+    followup_calls = [
+        ca.args + tuple(ca.kwargs.values())
+        for ca in interaction.followup.send.await_args_list
+    ]
+    refusal_seen = any(
+        UNBOUND_REFUSE_MESSAGE in str(c) for c in response_calls + followup_calls
+    )
+    assert not refusal_seen, (
+        f"{name} sent UNBOUND_REFUSE_MESSAGE on a BOUND channel. "
+        f"response={response_calls} followup={followup_calls}"
+    )

--- a/tests/test_group_a_unbound.py
+++ b/tests/test_group_a_unbound.py
@@ -1,16 +1,8 @@
 """Parametrized tests verifying Group A commands call ``reject_if_unbound``.
 
-PRD: ``docs/prd/v1.11-unbound-fallback.md`` Acceptance Criterion C.
-Issue: #127.
-
-The contract under test:
-    On an unbound channel, a Group A command MUST send the unified ephemeral
-    refusal message AND skip its underlying side-effect (no agent created, no
-    MCP server registered, no session spawned, ...).
-
-We pick one representative command per cog file. The helper itself is covered
-by ``tests/test_unbound_handler.py`` (#126); here we just verify each cog
-correctly applies the guard.
+Each Group A command MUST, on an unbound channel, send the unified
+ephemeral refusal AND skip its underlying side-effect (no agent created,
+no MCP server registered, no session spawned, ...).
 """
 
 from __future__ import annotations
@@ -23,16 +15,22 @@ import discord
 
 from clauded.bot import ClaudedBot
 from clauded.cogs._unbound import UNBOUND_REFUSE_MESSAGE
-from clauded.cogs.agent import agent_create
-from clauded.cogs.mcp import mcp_add
-from clauded.cogs.ops import review_pr
-from clauded.cogs.project import env_set
-from clauded.cogs.session import session_resume
+from clauded.cogs.agent import agent_create, agent_delete
+from clauded.cogs.mcp import mcp_add, mcp_add_url, mcp_remove
+from clauded.cogs.ops import plugin_add, review_pr
+from clauded.cogs.project import env_remove, env_set, project_add_dir
+from clauded.cogs.session import (
+    session_fork,
+    session_resume,
+    session_security_review,
+    session_settings,
+    session_worktree,
+)
 
 
 def _make_interaction(*, channel_id: int = 1234) -> MagicMock:
-    """Build a discord.Interaction stub whose channel is a bound TextChannel
-    by default. Tests mutate ``bot.project_manager.is_bound`` to flip state.
+    """Build a discord.Interaction stub. Tests mutate ``bot.project_manager.is_bound``
+    to flip channel state.
     """
     channel = MagicMock(spec=discord.TextChannel)
     channel.id = channel_id
@@ -58,17 +56,25 @@ def _make_bot(*, is_bound: bool) -> MagicMock:
     bot.project_manager = MagicMock()
     bot.project_manager.is_bound = MagicMock(return_value=is_bound)
     bot.project_manager.add_mcp_server = MagicMock()
+    bot.project_manager.remove_mcp_server = MagicMock(return_value=True)
     bot.project_manager.set_env = MagicMock()
+    bot.project_manager.remove_env = MagicMock(return_value=True)
+    bot.project_manager.add_extra_dir = MagicMock(return_value="/tmp/x")
     bot.project_manager.get_path = MagicMock(return_value=None)
     bot.project_manager.get_stored_session = MagicMock(return_value=None)
     bot.agent_manager = MagicMock()
     bot.agent_manager.create = MagicMock()
+    bot.agent_manager.delete = MagicMock(return_value=True)
+    bot._recreate_session = AsyncMock(return_value=None)
     return bot
 
 
 # (cog_name, callback, kwargs_for_call, sentinel_check)
-# sentinel_check: callable(bot) → asserts the side-effect helper was NOT invoked.
+# sentinel_check: callable(bot) → asserts the side-effect helper was NOT
+# invoked. Each entry covers a distinct (cog × subcommand) site so we
+# catch a future copy-paste site that forgets the guard.
 GROUP_A_CASES = [
+    # cogs/agent.py
     (
         "agent_create",
         agent_create.callback,
@@ -76,11 +82,31 @@ GROUP_A_CASES = [
         lambda bot: bot.agent_manager.create.assert_not_called(),
     ),
     (
+        "agent_delete",
+        agent_delete.callback,
+        {"name": "tester"},
+        lambda bot: bot.agent_manager.delete.assert_not_called(),
+    ),
+    # cogs/mcp.py
+    (
         "mcp_add",
         mcp_add.callback,
         {"name": "srv", "command": "/bin/true", "args": ""},
         lambda bot: bot.project_manager.add_mcp_server.assert_not_called(),
     ),
+    (
+        "mcp_add_url",
+        mcp_add_url.callback,
+        {"name": "srv", "url": "https://example.com/mcp"},
+        lambda bot: bot.project_manager.add_mcp_server.assert_not_called(),
+    ),
+    (
+        "mcp_remove",
+        mcp_remove.callback,
+        {"name": "srv"},
+        lambda bot: bot.project_manager.remove_mcp_server.assert_not_called(),
+    ),
+    # cogs/ops.py
     (
         "review_pr",
         review_pr.callback,
@@ -91,16 +117,60 @@ GROUP_A_CASES = [
         lambda bot: bot.project_manager.get_path.assert_not_called(),
     ),
     (
+        "plugin_add",
+        plugin_add.callback,
+        {"path": "/tmp"},
+        lambda bot: bot._recreate_session.assert_not_called(),
+    ),
+    # cogs/session.py
+    (
         "session_resume",
         session_resume.callback,
         {},
         lambda bot: bot.project_manager.get_stored_session.assert_not_called(),
     ),
     (
+        "session_fork",
+        session_fork.callback,
+        {},
+        lambda bot: bot._recreate_session.assert_not_called(),
+    ),
+    (
+        "session_worktree",
+        session_worktree.callback,
+        {"name": "feat"},
+        lambda bot: bot._recreate_session.assert_not_called(),
+    ),
+    (
+        "session_security_review",
+        session_security_review.callback,
+        {},
+        lambda bot: bot._recreate_session.assert_not_called(),
+    ),
+    (
+        "session_settings",
+        session_settings.callback,
+        {"json_str": "{}"},
+        lambda bot: bot._recreate_session.assert_not_called(),
+    ),
+    # cogs/project.py
+    (
         "env_set",
         env_set.callback,
         {"key": "FOO", "value": "bar"},
         lambda bot: bot.project_manager.set_env.assert_not_called(),
+    ),
+    (
+        "env_remove",
+        env_remove.callback,
+        {"key": "FOO"},
+        lambda bot: bot.project_manager.remove_env.assert_not_called(),
+    ),
+    (
+        "project_add_dir",
+        project_add_dir.callback,
+        {"path": "/tmp"},
+        lambda bot: bot.project_manager.add_extra_dir.assert_not_called(),
     ),
 ]
 
@@ -123,9 +193,6 @@ async def test_group_a_refuses_on_unbound(
 
     no_side_effect(bot)
 
-    # Refusal message must have gone out — either via response or followup
-    # depending on whether the command deferred first. Helper unit tests cover
-    # the routing logic; here we just check ONE of them carries the message.
     response_calls = [
         ca.args + tuple(ca.kwargs.values())
         for ca in interaction.response.send_message.await_args_list
@@ -151,26 +218,25 @@ async def test_group_a_passes_through_on_bound(
     name: str, callback, kwargs: dict, no_side_effect
 ) -> None:
     """Each Group A command, when run on a bound channel, does NOT send the
-    unified refusal. (The command may still bail for other reasons — e.g.,
-    ``/session resume`` returning ``No saved session to resume.`` — but the
-    bound check itself must pass through.)
+    unified refusal. We also positively assert that ``is_bound`` was
+    consulted, which proves the gate executed (and didn't reject) instead
+    of being silently bypassed by a future refactor.
     """
     interaction = _make_interaction()
     bot = _make_bot(is_bound=True)
     interaction.client = bot
 
-    # Stub out anything that would otherwise blow up in the body. We only
-    # care that the FIRST gate (reject_if_unbound) didn't fire.
-    bot._recreate_session = AsyncMock(return_value=None)
     bot.session_manager = MagicMock()
     bot.session_manager.get_lock = MagicMock(return_value=AsyncMock())
     bot.session_manager.create_session = AsyncMock(return_value=None)
+    bot.session_manager.stop_session = AsyncMock(return_value=True)
+    bot.session_manager.get_session = MagicMock(return_value=None)
 
     try:
         await callback(interaction, **kwargs)
     except Exception:
-        # Some commands fail downstream because of incomplete mocks; that's
-        # fine — we only assert the helper didn't reject.
+        # Some commands fail downstream because of incomplete mocks; the
+        # gate's outcome was already captured above.
         pass
 
     response_calls = [
@@ -188,3 +254,5 @@ async def test_group_a_passes_through_on_bound(
         f"{name} sent UNBOUND_REFUSE_MESSAGE on a BOUND channel. "
         f"response={response_calls} followup={followup_calls}"
     )
+
+    bot.project_manager.is_bound.assert_called()

--- a/tests/test_project_cog_thread_parent.py
+++ b/tests/test_project_cog_thread_parent.py
@@ -1,0 +1,118 @@
+"""Integration tests for eng-2: ``/project system-prompt`` + ``/project add-dir``
+must resolve to the parent channel id when run inside a thread.
+
+Threads inherit their parent's bound state; if the cog passed
+``interaction.channel_id`` (the thread id) instead of ``parent_id`` to
+``set_system_prompt`` / ``add_extra_dir``, state would attach to a row
+that's never read back, silently losing data.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from clauded.bot import ClaudedBot
+from clauded.cogs.project import project_add_dir, project_system_prompt
+from clauded.project_manager import ProjectManager
+
+
+@pytest.fixture
+def projects_root(tmp_path: Path) -> Path:
+    root = tmp_path / "projects"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def pm(tmp_path: Path, projects_root: Path) -> ProjectManager:
+    return ProjectManager(
+        data_dir=str(tmp_path / "data"), projects_root=str(projects_root)
+    )
+
+
+def _make_thread_interaction(
+    *, thread_id: int, parent_id: int
+) -> MagicMock:
+    """Build an Interaction whose channel is a thread (so the cog must
+    consult ``parent_id``).
+    """
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = thread_id
+    thread.parent_id = parent_id
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = thread
+    interaction.channel_id = thread_id
+    interaction.guild_id = 7777
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.send_message = AsyncMock()
+    interaction.response.send_modal = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_bot(pm: ProjectManager) -> MagicMock:
+    bot = MagicMock(spec=ClaudedBot)
+    bot.project_manager = pm
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_project_add_dir_in_thread_attaches_to_parent(
+    pm: ProjectManager, projects_root: Path
+) -> None:
+    """``/project add-dir`` from inside a thread must call
+    ``add_extra_dir`` with the parent channel id, not the thread id.
+    """
+    parent_id, thread_id = 5001, 5002
+    proj = projects_root / "p"
+    proj.mkdir()
+    pm.bind(parent_id, str(proj))
+
+    extra = projects_root / "extra"
+    extra.mkdir()
+
+    interaction = _make_thread_interaction(
+        thread_id=thread_id, parent_id=parent_id
+    )
+    bot = _make_bot(pm)
+    interaction.client = bot
+
+    await project_add_dir.callback(interaction, path=str(extra))
+
+    # The extra dir must show up under the PARENT row, not the thread row.
+    assert str(extra.resolve()) in pm.get_extra_dirs(parent_id)
+    assert pm.get_extra_dirs(thread_id) == []
+
+
+@pytest.mark.asyncio
+async def test_project_system_prompt_modal_targets_parent(
+    pm: ProjectManager, projects_root: Path
+) -> None:
+    """``/project system-prompt`` from inside a thread must hand the modal
+    a ``channel_id`` equal to the parent. We catch the modal as it's
+    dispatched and inspect its private channel_id field.
+    """
+    parent_id, thread_id = 6001, 6002
+    proj = projects_root / "p"
+    proj.mkdir()
+    pm.bind(parent_id, str(proj))
+
+    interaction = _make_thread_interaction(
+        thread_id=thread_id, parent_id=parent_id
+    )
+    bot = _make_bot(pm)
+    interaction.client = bot
+
+    await project_system_prompt.callback(interaction)
+
+    # send_modal received a SystemPromptModal scoped to parent_id.
+    interaction.response.send_modal.assert_awaited_once()
+    sent_modal = interaction.response.send_modal.await_args.args[0]
+    # The modal stores the id as ``_channel_id`` (cogs/project.py).
+    assert sent_modal._channel_id == parent_id

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -452,3 +452,55 @@ def test_add_extra_dir_outside_root_raises(tmp_path):
     pm.bind(1, str(root))  # need a binding first
     with pytest.raises(ValueError, match="outside"):
         pm.add_extra_dir(1, str(outside))
+
+
+# ---------------------------------------------------------------------------
+# Unbound-channel fallback helpers (v1.11, #110)
+# ---------------------------------------------------------------------------
+
+
+def test_get_path_or_default_bound(
+    manager: ProjectManager, projects_root: Path
+) -> None:
+    """A bound channel returns ``(bound_path, True)``."""
+    proj = projects_root / "p"
+    proj.mkdir()
+    manager.bind(100, str(proj))
+
+    path, is_bound = manager.get_path_or_default(100)
+    assert is_bound is True
+    assert path == proj.resolve()
+
+
+def test_get_path_or_default_unbound(manager: ProjectManager) -> None:
+    """An unbound channel returns ``(Path.home().resolve(), False)``."""
+    path, is_bound = manager.get_path_or_default(101)
+    assert is_bound is False
+    assert path == Path.home().resolve()
+
+
+def test_should_hint_unbound_first_call_returns_true(
+    manager: ProjectManager,
+) -> None:
+    """First call for a channel returns True."""
+    assert manager.should_hint_unbound(200) is True
+
+
+def test_should_hint_unbound_second_call_returns_false(
+    manager: ProjectManager,
+) -> None:
+    """Subsequent calls for the same channel return False."""
+    assert manager.should_hint_unbound(201) is True
+    assert manager.should_hint_unbound(201) is False
+    assert manager.should_hint_unbound(201) is False
+
+
+def test_should_hint_unbound_isolated_per_channel(
+    manager: ProjectManager,
+) -> None:
+    """Different channel ids each get their own first-hint."""
+    assert manager.should_hint_unbound(300) is True
+    assert manager.should_hint_unbound(301) is True
+    # And each is now suppressed independently.
+    assert manager.should_hint_unbound(300) is False
+    assert manager.should_hint_unbound(301) is False

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -504,3 +504,152 @@ def test_should_hint_unbound_isolated_per_channel(
     # And each is now suppressed independently.
     assert manager.should_hint_unbound(300) is False
     assert manager.should_hint_unbound(301) is False
+
+
+# ---------------------------------------------------------------------------
+# tester-1: defensive partial-entry handling in get_path_or_default
+# ---------------------------------------------------------------------------
+
+
+def test_get_path_or_default_partial_entry_falls_through_to_home(
+    manager: ProjectManager,
+) -> None:
+    """``is_bound`` returns True for an entry without a ``path`` key (e.g.
+    a stale projects.json from a partial write). The helper must fall
+    through to the unbound branch instead of returning ``None``-shaped
+    garbage that downstream code asserts on.
+    """
+    # Simulate a partial entry directly — corresponds to a JSON file
+    # written before/around a v1.0 crash that left the row without "path".
+    manager._projects["999"] = {"system_prompt": "stale"}
+    assert manager.is_bound(999) is True
+    assert manager.get_path(999) is None  # the trap
+
+    path, is_bound = manager.get_path_or_default(999)
+    assert is_bound is False, "partial entry must be treated as unbound"
+    assert path == Path.home().resolve()
+
+
+# ---------------------------------------------------------------------------
+# sec-3 / tester-1: Path.home() raise is caught
+# ---------------------------------------------------------------------------
+
+
+def test_get_path_or_default_no_home(
+    manager: ProjectManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``Path.home()`` raises ``RuntimeError`` when ``$HOME`` is unset and
+    there's no passwd entry. ``get_path_or_default`` must catch that and
+    return a sentinel path that ``is_dir()`` reports False for, so the
+    bot's broken-home guard fires cleanly instead of bubbling a stack
+    trace into the on-message handler.
+    """
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("HOME not set")
+
+    monkeypatch.setattr(Path, "home", _raise)
+
+    path, is_bound = manager.get_path_or_default(8888)
+    assert is_bound is False
+    assert path.is_dir() is False, "sentinel must report not-a-directory"
+
+
+def test_get_path_or_default_home_oserror(
+    manager: ProjectManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``Path.home().resolve()`` can raise ``OSError`` on broken filesystems.
+    The helper must catch that too — same sentinel.
+    """
+    def _raise(*_args, **_kwargs):
+        raise OSError("EIO")
+
+    # OSError on the very ``Path.home()`` call exercises the OSError leg of
+    # the except clause without needing to fake a Path subclass.
+    monkeypatch.setattr(Path, "home", _raise)
+
+    path, is_bound = manager.get_path_or_default(8889)
+    assert is_bound is False
+    assert path.is_dir() is False
+
+
+# ---------------------------------------------------------------------------
+# arch-2: _assert_bound invariant in project-mutating methods
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bound_manager(
+    manager: ProjectManager, projects_root: Path
+) -> tuple[ProjectManager, int]:
+    """Manager with channel id 7000 already bound to a real directory."""
+    proj = projects_root / "boundproj"
+    proj.mkdir()
+    manager.bind(7000, str(proj))
+    return manager, 7000
+
+
+@pytest.mark.parametrize(
+    "method_name,args",
+    [
+        ("set_system_prompt", ("hi there",)),
+        ("set_budget", (1.50,)),
+        ("set_env", ("FOO", "bar")),
+        ("remove_env", ("FOO",)),
+        ("add_mcp_server", ("srv", {"type": "stdio", "command": "/bin/true"})),
+        ("remove_mcp_server", ("srv",)),
+        ("set_channel_mode", ("forum",)),
+        ("remove_extra_dir", ("/tmp/x",)),
+    ],
+)
+def test_mutators_raise_on_unbound_channel(
+    manager: ProjectManager, method_name: str, args: tuple
+) -> None:
+    """Every project-mutating method must raise ``ValueError`` containing
+    "not bound" when called against an unbound channel id. This is the
+    arch-2 defense-in-depth invariant — even if a future cog forgets the
+    user-facing ``reject_if_unbound`` guard, the manager refuses to write.
+    """
+    fn = getattr(manager, method_name)
+    with pytest.raises(ValueError, match="not bound"):
+        fn(123456789, *args)
+    # And nothing was written.
+    assert "123456789" not in manager._projects
+
+
+def test_add_extra_dir_raises_on_unbound_channel(
+    manager: ProjectManager, projects_root: Path
+) -> None:
+    """``add_extra_dir`` is parametrized separately because its second
+    arg must be a real directory; the others' inputs are all literals.
+    """
+    target = projects_root / "extra"
+    target.mkdir()
+    with pytest.raises(ValueError, match="not bound"):
+        manager.add_extra_dir(987654321, str(target))
+    assert "987654321" not in manager._projects
+
+
+def test_mutators_succeed_on_bound_channel(
+    bound_manager: tuple[ProjectManager, int], projects_root: Path
+) -> None:
+    """Sanity: arch-2 doesn't break the happy path. Each mutator must
+    succeed on a channel that's been bound.
+    """
+    pm, ch = bound_manager
+    pm.set_system_prompt(ch, "hi")
+    assert pm.get_system_prompt(ch) == "hi"
+    pm.set_budget(ch, 0.50)
+    assert pm.get_budget(ch) == pytest.approx(0.50)
+    pm.set_env(ch, "K", "v")
+    assert pm.get_env(ch) == {"K": "v"}
+    assert pm.remove_env(ch, "K") is True
+    pm.add_mcp_server(ch, "srv", {"type": "stdio", "command": "/bin/true"})
+    assert "srv" in pm.get_mcp_servers(ch)
+    assert pm.remove_mcp_server(ch, "srv") is True
+    pm.set_channel_mode(ch, "forum")
+    assert pm.get_channel_mode(ch) == "forum"
+    extra = projects_root / "another"
+    extra.mkdir()
+    pm.add_extra_dir(ch, str(extra))
+    assert str(extra.resolve()) in pm.get_extra_dirs(ch)
+    assert pm.remove_extra_dir(ch, str(extra)) is True

--- a/tests/test_unbound_handler.py
+++ b/tests/test_unbound_handler.py
@@ -12,11 +12,15 @@ import pytest
 
 import discord
 
-from clauded.cogs._unbound import UNBOUND_REFUSE_MESSAGE, reject_if_unbound
+from clauded.cogs._unbound import (
+    NO_CHANNEL_MESSAGE,
+    UNBOUND_REFUSE_MESSAGE,
+    reject_if_unbound,
+)
 
 
 def _make_interaction(
-    *, channel: object, response_done: bool = False
+    *, channel: object, response_done: bool = False, channel_id: int | None = 1234
 ) -> MagicMock:
     """Build a minimal ``discord.Interaction`` mock with awaitable response
     methods. ``channel`` is attached directly so ``isinstance`` checks against
@@ -24,6 +28,7 @@ def _make_interaction(
     """
     interaction = MagicMock(spec=discord.Interaction)
     interaction.channel = channel
+    interaction.channel_id = channel_id
     interaction.response = MagicMock()
     interaction.response.is_done = MagicMock(return_value=response_done)
     interaction.response.send_message = AsyncMock()
@@ -107,3 +112,60 @@ async def test_reject_if_unbound_uses_followup_when_response_done() -> None:
     interaction.followup.send.assert_awaited_once_with(
         UNBOUND_REFUSE_MESSAGE, ephemeral=True
     )
+
+
+# ---------------------------------------------------------------------------
+# eng-1: defensive None-check for ``interaction.channel``
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reject_if_unbound_when_channel_is_none_falls_back_to_channel_id() -> None:
+    """DM / cache miss → ``interaction.channel`` is None. Helper must NOT
+    crash with AttributeError; it should consult ``interaction.channel_id``
+    instead.
+    """
+    interaction = _make_interaction(channel=None, channel_id=5555)
+    bot = _make_bot(is_bound=False)
+
+    result = await reject_if_unbound(interaction, bot)
+
+    assert result is True
+    bot.project_manager.is_bound.assert_called_once_with(5555)
+    interaction.response.send_message.assert_awaited_once_with(
+        UNBOUND_REFUSE_MESSAGE, ephemeral=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_reject_if_unbound_when_channel_and_channel_id_are_both_none() -> None:
+    """When BOTH ``channel`` and ``channel_id`` are None (DM with no cache),
+    refuse with the no-channel message — and never query ``is_bound``.
+    """
+    interaction = _make_interaction(channel=None, channel_id=None)
+    bot = _make_bot(is_bound=False)
+
+    result = await reject_if_unbound(interaction, bot)
+
+    assert result is True
+    bot.project_manager.is_bound.assert_not_called()
+    interaction.response.send_message.assert_awaited_once_with(
+        NO_CHANNEL_MESSAGE, ephemeral=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_reject_if_unbound_thread_with_no_parent_id_falls_back_to_channel_id() -> None:
+    """A discord.Thread whose ``parent_id`` is None (rare race) should fall
+    back to ``interaction.channel_id`` rather than blow up.
+    """
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = 6000
+    thread.parent_id = None
+    interaction = _make_interaction(channel=thread, channel_id=6001)
+    bot = _make_bot(is_bound=False)
+
+    result = await reject_if_unbound(interaction, bot)
+
+    assert result is True
+    bot.project_manager.is_bound.assert_called_once_with(6001)

--- a/tests/test_unbound_handler.py
+++ b/tests/test_unbound_handler.py
@@ -1,0 +1,109 @@
+"""Tests for ``cogs._unbound.reject_if_unbound`` helper.
+
+PRD: ``docs/prd/v1.11-unbound-fallback.md`` R2.
+Issue: #126.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import discord
+
+from clauded.cogs._unbound import UNBOUND_REFUSE_MESSAGE, reject_if_unbound
+
+
+def _make_interaction(
+    *, channel: object, response_done: bool = False
+) -> MagicMock:
+    """Build a minimal ``discord.Interaction`` mock with awaitable response
+    methods. ``channel`` is attached directly so ``isinstance`` checks against
+    real discord types still work when ``spec=`` is used by the caller.
+    """
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = channel
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=response_done)
+    interaction.response.send_message = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_bot(*, is_bound: bool) -> MagicMock:
+    bot = MagicMock()
+    bot.project_manager = MagicMock()
+    bot.project_manager.is_bound = MagicMock(return_value=is_bound)
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_reject_if_unbound_returns_false_when_bound() -> None:
+    """Bound top-level channel → returns False, no message sent."""
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = 1111
+    interaction = _make_interaction(channel=channel)
+    bot = _make_bot(is_bound=True)
+
+    result = await reject_if_unbound(interaction, bot)
+
+    assert result is False
+    bot.project_manager.is_bound.assert_called_once_with(1111)
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reject_if_unbound_returns_true_when_unbound_top_channel() -> None:
+    """Unbound top-level channel → True + ephemeral refusal via response."""
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = 2222
+    interaction = _make_interaction(channel=channel, response_done=False)
+    bot = _make_bot(is_bound=False)
+
+    result = await reject_if_unbound(interaction, bot)
+
+    assert result is True
+    bot.project_manager.is_bound.assert_called_once_with(2222)
+    interaction.response.send_message.assert_awaited_once_with(
+        UNBOUND_REFUSE_MESSAGE, ephemeral=True
+    )
+    interaction.followup.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reject_if_unbound_returns_true_when_unbound_thread() -> None:
+    """Thread inherits parent channel's bound state → looks up parent_id."""
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = 9999  # thread id should NOT be used
+    thread.parent_id = 3333  # parent channel id IS the lookup key
+    interaction = _make_interaction(channel=thread, response_done=False)
+    bot = _make_bot(is_bound=False)
+
+    result = await reject_if_unbound(interaction, bot)
+
+    assert result is True
+    bot.project_manager.is_bound.assert_called_once_with(3333)
+    interaction.response.send_message.assert_awaited_once_with(
+        UNBOUND_REFUSE_MESSAGE, ephemeral=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_reject_if_unbound_uses_followup_when_response_done() -> None:
+    """If response was already sent (deferred / first message went out), use
+    ``followup.send`` instead of ``response.send_message``."""
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = 4444
+    interaction = _make_interaction(channel=channel, response_done=True)
+    bot = _make_bot(is_bound=False)
+
+    result = await reject_if_unbound(interaction, bot)
+
+    assert result is True
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_awaited_once_with(
+        UNBOUND_REFUSE_MESSAGE, ephemeral=True
+    )


### PR DESCRIPTION
## Summary

Closes #110. Subtasks #125-#129.

When user @bot's an unbound Discord channel, claudeD now:
- Group A (project-mutating commands like `/env set`, `/agent create`, `/mcp add`, `/review`): refuse with unified ephemeral message hinting at `/project bind`.
- Group B (read-only like `/health`, `/cost`, `/model`): unchanged, work as before.
- Group C (on-message + future read commands): fallback to `$HOME` as cwd, post one-time hint to thread.

## Test plan

- pytest baseline: **298 passed / 2 pre-existing P1** (273 → 298, +25 new tests).
- Real-env smoke (#129): manager-run before merge.

## Design decisions (DDD with user)

| Q | Locked |
|---|---|
| Q1 command classification | (a) strict — writes refuse + hint, reads + on_message → $HOME, /review refuses |
| Q2 hint frequency | (a) once per channel × per bot process (in-memory Set) |
| Q3 hint placement + form | (ii+I) thread-internal plain text first message |

## Subtasks

- #125 helpers (`get_path_or_default`, `should_hint_unbound`) — `f54946c`
- #126 `reject_if_unbound` helper — `8b032e4`
- #127 apply to ~13 Group A commands — `e426826`
- #128 on_message + thread fallback — `d98a38a`
- #129 real-env smoke (manager-run, pre-merge gate)

## PRD

`docs/prd/v1.11-unbound-fallback.md` (commit `279a4af`)