### PR TITLE
v1.12 table rendering: PNG + Copy button (#112)

### DIFF
--- a/docs/prd/v1.12-table-rendering.md
+++ b/docs/prd/v1.12-table-rendering.md
@@ -24,7 +24,7 @@ DDD findings (round 2, after live demos sent to test channel):
 
 ### R1 — `_format_tables` rewrite
 
-R1.1. The current `_format_tables(text: str) -> str` static method in `src/clauded/discord_renderer.py:1230` returns plain markdown with tables fenced in `` ``` ``. Replace with a method that **detects tables**, **extracts them as structured data**, and **returns the surrounding text only**, separately producing a list of (table_data, png_bytes, markdown_source) tuples for callers to send.
+R1.1. The current `_format_tables(text: str) -> str` static method in `src/clauded/discord_renderer.py:1445` returns plain markdown with tables fenced in `` ``` ``. Replace with a method that **detects tables**, **extracts them as structured data**, and **returns the surrounding text only**, separately producing a list of (table_data, png_bytes, markdown_source) tuples for callers to send.
 
 R1.2. New signature:
 ```python

--- a/docs/prd/v1.12-table-rendering.md
+++ b/docs/prd/v1.12-table-rendering.md
@@ -1,0 +1,222 @@
+# PRD — v1.12 Markdown Table Rendering (PNG + Copy Button)
+
+## Status
+Draft
+
+## Overview
+
+Replace the current `_format_tables` behavior (wraps tables in `` ``` `` code fences, mobile word-wrap breaks alignment) with **PNG attachment + Copy-as-text button**. One PNG image, one persistent Button — small enough to render fast, big enough to scroll horizontally on mobile, text-source still copyable.
+
+## Motivation
+
+User reported: "明显不对，反正我要正确的表格显示" (5/8). Verified in real Discord:
+
+- Desktop `` ``` `` table: usable, but takes screen real estate.
+- **Mobile `` ``` `` table: CJK + emoji + long paths hard-wrap → all column alignment lost.**
+
+DDD findings (round 2, after live demos sent to test channel):
+- Components V2 Container/Section (issue body's "elevated B" alternative) shown to user — feedback: "挤一起" on mobile, still cannot horizontally scroll wide tables.
+- PNG attachment shown to user — feedback: works, mobile pinch+pan reveals full width.
+- Hybrid PNG + V2 dual-send rejected: doubles message count, V2 hits 40-component cap on large tables, ordering fragility.
+- **Final decision (c5)**: single PNG + Copy-as-text button. User-confirmed via live demo (Discord msg `1503234678134538421`).
+
+## Requirements
+
+### R1 — `_format_tables` rewrite
+
+R1.1. The current `_format_tables(text: str) -> str` static method in `src/clauded/discord_renderer.py:1230` returns plain markdown with tables fenced in `` ``` ``. Replace with a method that **detects tables**, **extracts them as structured data**, and **returns the surrounding text only**, separately producing a list of (table_data, png_bytes, markdown_source) tuples for callers to send.
+
+R1.2. New signature:
+```python
+def _extract_and_render_tables(text: str) -> tuple[str, list[TableRender]]:
+    """Returns (text_with_tables_replaced_by_placeholder, table_renders).
+    Each placeholder in text marks where to insert a PNG attachment."""
+```
+Where `TableRender` is a small dataclass:
+```python
+@dataclass
+class TableRender:
+    headers: list[str]
+    rows: list[list[str]]
+    png_bytes: bytes
+    markdown_source: str   # the original markdown table source for the Copy button
+    placeholder: str       # e.g. "\n[TABLE_PNG_0]\n" — inserted into text where the table was
+```
+
+R1.3. Tables nested inside `` ``` `` code fences must remain untouched (preserve current behavior, tested in `test_smart_split.py:169-184`).
+
+R1.4. Single-column tables (`| Header |`) and header-only tables (no data rows) → treat as non-tables (re-emit verbatim — they're rare and PNG would be silly).
+
+### R2 — Renderer integration
+
+R2.1. `_finalize_typewriter` and `_flush` (currently call `_format_tables` at lines 938 + 967) must:
+   1. Call `_extract_and_render_tables(buffer)` → `(stripped_text, renders)`
+   2. Smart-split + send the `stripped_text` per existing logic
+   3. For each `render` in `renders`: send a follow-up message with the PNG attachment + a `CopyTableTextView` persistent view containing the markdown source
+
+R2.2. Order is: text-segments-up-to-table-1 → png[0] + button → text-segments-between-1-and-2 → png[1] + button → ... → text-after-last-table.
+
+R2.3. If `buffer` contains no tables, `_extract_and_render_tables` returns `(buffer, [])` and existing behavior is preserved.
+
+### R3 — Persistent Copy button
+
+R3.1. New class `CopyTableTextView(discord.ui.View)` in `src/clauded/cogs/_table_view.py` (or new module):
+```python
+class CopyTableTextView(ui.View):
+    def __init__(self):
+        super().__init__(timeout=None)
+
+    @ui.button(label="📋 Copy as text", style=discord.ButtonStyle.secondary, custom_id="copy_table_text")
+    async def copy(self, interaction, button):
+        # Resolve markdown source via interaction.message.attachments[0] sidecar
+        # OR via a separate persistent store keyed by message_id
+        ...
+```
+
+R3.2. **Persistence challenge**: the markdown source can't live in the View instance because Views don't serialize. Options:
+- **(a)** Embed markdown as a `.md` sidecar file attached to the message; button reads `interaction.message.attachments[1].read()` and replies ephemeral with its content (or as a file if >1900 chars).
+- **(b)** Store mapping `message_id → markdown` in `data/table_sources.json`, persistent across bot restarts.
+
+Manager pick: **(a)** — zero new persistent state, attaches the source-of-truth inline with the PNG. Discord shows the `.md` as a downloadable file too, which is a bonus.
+
+R3.3. `bot.py` startup registers `self.add_view(CopyTableTextView())` so the button responds after bot restart.
+
+### R4 — PNG renderer
+
+R4.1. New module `src/clauded/table_png.py` (~150 LOC):
+```python
+def render_table_png(headers: list[str], rows: list[list[str]]) -> bytes:
+    """Render a table to PNG bytes. Dark Discord theme, blurple accent.
+    Cell text stripped of markdown backticks for display."""
+```
+
+R4.2. Pillow + system fonts. **No bundled fonts** (user opted out of 25MB Noto bundle). Font resolution order:
+1. `/System/Library/Fonts/PingFang.ttc` (macOS CJK) → for CJK
+2. `/System/Library/Fonts/Menlo.ttc` (macOS) → for mono/code
+3. `Arial Unicode.ttf` → for fallback
+4. `ImageFont.load_default()` → ugly but never crashes
+
+R4.3. Display formatting:
+- Strip ` `` ` backticks from cell content (PNG doesn't render markdown — show plain code-like text in mono font).
+- Wide cells get truncated with `…` if longer than ~120 chars; full content remains in the `.md` sidecar for copy.
+
+R4.4. Performance budget: ≤200ms per PNG (Pillow direct draw, ~692×200 → ~20KB for 6×7 table — verified in demo).
+
+### R5 — Dependency declaration
+
+R5.1. Add `Pillow>=10` to `pyproject.toml` dependencies. ~3MB wheel — small.
+
+R5.2. **No `wcwidth` dep** (issue body suggested it; we don't need it because Pillow's `font.getbbox(text)` measures actual rendered width including CJK / emoji glyphs correctly).
+
+R5.3. **No bundled fonts.** Mac dev box uses system fonts. Linux deploy hardening is out of scope (separate issue).
+
+### R6 — Edge cases
+
+R6.1. Malformed table (missing separator row): re-emit verbatim text, don't crash.
+R6.2. Table inside ` ``` ` code fence: leave alone.
+R6.3. Multiple tables separated by paragraphs: each renders to its own PNG + button.
+R6.4. Empty body cells: render as empty cell (whitespace), no crash.
+R6.5. Cell with `<br>` HTML line break: replace with `\n`, draw multiline cell (cell height grows).
+R6.6. Markdown link `[name](url)` in cell: render as `name (url)` text in PNG; markdown source preserves link syntax for copy.
+
+## Acceptance Criteria
+
+### A — Unit tests
+
+- `tests/test_table_render.py` — new file:
+  - `test_simple_table_extracted_and_png_rendered` — 3-col×3-row ASCII → 1 TableRender, headers + rows correct, png_bytes is valid PNG (`PIL.Image.open(BytesIO).format == "PNG"`)
+  - `test_table_inside_code_fence_left_alone` — `` ``` ``\n| x |\n`` ``` `` → no TableRender, text unchanged
+  - `test_malformed_table_not_extracted` — table without separator row → no TableRender
+  - `test_multiple_tables_each_rendered` — 2 tables separated by paragraph → 2 TableRender entries in order
+  - `test_single_column_table_not_treated_as_table` — `| Header |` lines → no extraction
+  - `test_cjk_emoji_table_renders_without_crash` — CJK + emoji cells → PNG produced, no exception (visual correctness checked manually)
+  - `test_markdown_source_preserved_for_copy` — markdown_source field equals the original table verbatim
+
+### B — Integration
+
+- `tests/test_renderer_tables.py` — drives `_flush` / `_finalize_typewriter` against a fake target, asserts:
+  - Text-before-table sent as content message
+  - PNG + view sent as follow-up
+  - `CopyTableTextView` registered with `discord.ui.Button(custom_id="copy_table_text")`
+  - Tables nested in code fences NOT replaced by PNGs (preserve existing test_smart_split coverage)
+
+### C — Copy button roundtrip
+
+- `tests/test_copy_table_view.py`:
+  - Mock interaction with attached `.md` sidecar file → `view.copy` reads it and `response.send_message(content="```\n<md>\n```", ephemeral=True)` was called
+  - `.md` sidecar > 1900 chars → `view.copy` sends as `discord.File` instead
+
+### D — Real-environment smoke (manager-run)
+
+- Bot starts with `bot.add_view(CopyTableTextView())` registered
+- Send Claude session prompt that elicits a markdown table response
+- Verify: PNG + button appear in Discord; button click returns markdown ephemeral; copy-paste from ephemeral produces working markdown
+- Restart bot; click same old button → still works (persistent view)
+
+### E — Pillow fallback / Linux
+
+- If Pillow import fails → log warning, fall back to current `_format_tables` (code-fence wrap)
+- If system fonts not found → use `ImageFont.load_default()`, log warning
+- Bot must NOT crash on table rendering under any environment
+
+## Technical Approach
+
+### File changes
+
+| File | Change | LOC |
+|---|---|---|
+| `src/clauded/table_png.py` (new) | `render_table_png(headers, rows) -> bytes` | ~150 |
+| `src/clauded/cogs/_table_view.py` (new) | `CopyTableTextView` persistent view | ~40 |
+| `src/clauded/discord_renderer.py` | Replace `_format_tables`; rewrite caller integration | ~60 net |
+| `src/clauded/bot.py` | `add_view(CopyTableTextView())` at startup | +2 |
+| `pyproject.toml` | Add `Pillow>=10` dependency | +1 |
+| `tests/test_table_render.py` (new) | A-criteria tests | ~120 |
+| `tests/test_renderer_tables.py` (new) | B-criteria tests | ~80 |
+| `tests/test_copy_table_view.py` (new) | C-criteria tests | ~60 |
+
+Estimated 1.5-2 person-days including review rounds.
+
+### Implementation order
+
+1. **Subtask 1** — `table_png.py` renderer (R4) + unit tests (A.1, A.6). Independent.
+2. **Subtask 2** — `_extract_and_render_tables` in `discord_renderer.py` (R1) + unit tests (A.2-A.5, A.7). Independent.
+3. **Subtask 3** — `CopyTableTextView` (R3) + sidecar `.md` attachment logic + unit tests (C). Depends on nothing.
+4. **Subtask 4** — Integration in `_finalize_typewriter` + `_flush` (R2) + bot startup `add_view` (R3.3) + integration tests (B). Depends on 1, 2, 3.
+5. **Subtask 5** — Pillow fallback (R6.6, E) — defensive guards. Depends on 4.
+6. **Subtask 6** — Manager-run real-env smoke (D).
+
+Subtasks 1, 2, 3 can run in parallel via git worktrees.
+
+## Out of Scope
+
+- Bundled Noto/Liberation fonts (25MB) — Linux deploy hardening is separate issue.
+- `wcwidth` dependency (Pillow's `font.getbbox` already handles glyph widths correctly).
+- Auto-decision between PNG / V2 / vertical listing — single PNG path for ALL tables.
+- Persistent `data/table_sources.json` — sidecar `.md` attachment avoids new persistent state.
+- Custom user theme / accent color override — not requested.
+- Markdown nested in cells beyond inline `` `code` ``, links, `<br>` — won't support nested tables, complex HTML.
+
+## Open Questions
+
+None. All design decisions resolved via live Discord demos with user.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Pillow missing or fonts not found | E acceptance: graceful fallback to current `_format_tables` |
+| User's Discord client too old to render Buttons | Button click ignored = `interaction failed`; PNG still readable. Mobile clients all support Buttons since 2022. |
+| `.md` sidecar attachment count: Discord cap = 10 attachments/message; a message with multiple tables would exceed it | If buffer has >5 tables: only first 5 get PNGs+buttons; rest fall back to `` ``` `` text (rare in practice; document in acceptance) |
+| PNG width on phone: ultra-wide tables (12 cols × 200 chars total) may render at 2000+ px | Pillow naturally allows horizontal pan on Discord mobile; if width > 4000 px, scale down with antialiasing (Pillow `thumbnail`) |
+| Persistent view memory leak: `bot.add_view(CopyTableTextView())` registers one view that handles all clicks | View is stateless (reads source from `interaction.message.attachments`); single registration is enough |
+
+## Subtask Issue Breakdown
+
+For Step 2 dispatch — each subtask gets its own GitHub issue.
+
+1. **#sub1** — `src/clauded/table_png.py` PNG renderer + 7 unit tests. Size S/M.
+2. **#sub2** — `_extract_and_render_tables` in `discord_renderer.py` + 6 unit tests. Size S/M.
+3. **#sub3** — `CopyTableTextView` persistent view + sidecar `.md` attachment + 3 unit tests. Size S.
+4. **#sub4** — Renderer integration (`_finalize_typewriter` / `_flush` / `bot.py add_view`) + 4 integration tests. Size M. Depends on #sub1, #sub2, #sub3.
+5. **#sub5** — Pillow fallback + Linux/font hardening + 2 defensive tests. Size S. Depends on #sub4.
+6. **#sub6** — Real-environment smoke (manager-run). Size S procedure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "discord.py>=2.4,<3.0",
     "claude-agent-sdk==0.1.80",
     "python-dotenv>=1.0",
+    "Pillow>=10",
 ]
 
 [project.optional-dependencies]

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -141,11 +141,18 @@ class ClaudedBot(commands.Bot):
             self._claude_version = "unknown"
         self._cleanup_task.start()
 
-        # v1.12 / #134 / PRD R3.3: register the persistent Copy-as-text
-        # button view. One stateless instance handles every PNG-table
-        # button click in the process — the markdown source lives in the
-        # ``.md`` sidecar attached to the message, not in the view.
-        # Required so the button keeps working after a bot restart.
+        # PRD R3.3 — register the persistent Copy-as-text button view so
+        # the button keeps working after a bot restart.
+        #
+        # Why both registrations:
+        # - This ``add_view(CopyTableTextView())`` at startup registers a
+        #   global handler for ``custom_id="copy_table_text"`` so clicks
+        #   are dispatched even on messages whose original view object is
+        #   long gone (post-restart).
+        # - ``DiscordRenderer._send_table_renders`` also instantiates a
+        #   fresh ``CopyTableTextView()`` on each PNG send, because
+        #   discord.py needs a view object on the initial send to inject
+        #   the button components into the Discord message.
         self.add_view(CopyTableTextView())
 
         # ----- Import command objects from cog modules -----

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -316,14 +316,37 @@ class ClaudedBot(commands.Bot):
             except discord.HTTPException:
                 log.debug("Could not surface thread-permission error to channel")
             return
-        except discord.HTTPException:
-            log.exception("Failed to create thread for channel=%s", channel.id)
-            try:
-                if not is_forum:
-                    await channel.send("❌ Failed to create a thread for this message.")
-            except discord.HTTPException:
-                log.debug("Could not surface thread-creation error to channel")
-            return
+        except discord.HTTPException as e:
+            # Discord gateway can duplicate MESSAGE_CREATE → on_message runs
+            # twice → the second ``message.create_thread`` raises 160004
+            # ("a thread has already been created for this message"). The
+            # winning race already created the thread; we just need to
+            # re-fetch the message to see it and reuse it. Forum-channel
+            # thread creation goes through a different path and isn't
+            # subject to this race, so we only handle 160004 here.
+            if getattr(e, "code", None) == 160004 and not is_forum:
+                try:
+                    message = await channel.fetch_message(message.id)
+                except discord.HTTPException:
+                    log.exception("Could not refetch after thread-race")
+                    return
+                if message.thread is not None:
+                    log.info(
+                        "Thread-race: reusing existing thread %d",
+                        message.thread.id,
+                    )
+                    thread = message.thread
+                else:
+                    log.warning("160004 reported but message.thread is None")
+                    return
+            else:
+                log.exception("Failed to create thread for channel=%s", channel.id)
+                try:
+                    if not is_forum:
+                        await channel.send("❌ Failed to create a thread for this message.")
+                except discord.HTTPException:
+                    log.debug("Could not surface thread-creation error to channel")
+                return
 
         # First-time unbound hint, posted before the bridge starts streaming.
         if not is_bound and self.project_manager.should_hint_unbound(channel.id):

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -30,6 +30,7 @@ from .session_store import SessionStore
 from .cost_tracker import CostTracker
 from .agent_manager import AgentManager
 from .cogs._unbound import UNBOUND_HINT_MESSAGE
+from .cogs._table_view import CopyTableTextView
 
 # Re-export SystemPromptModal so existing ``from clauded.bot import
 # SystemPromptModal`` continues to work (tests rely on this).
@@ -139,6 +140,13 @@ class ClaudedBot(commands.Bot):
         except Exception:
             self._claude_version = "unknown"
         self._cleanup_task.start()
+
+        # v1.12 / #134 / PRD R3.3: register the persistent Copy-as-text
+        # button view. One stateless instance handles every PNG-table
+        # button click in the process — the markdown source lives in the
+        # ``.md`` sidecar attached to the message, not in the view.
+        # Required so the button keeps working after a bot restart.
+        self.add_view(CopyTableTextView())
 
         # ----- Import command objects from cog modules -----
         from .cogs.project import project_group, env_group

--- a/src/clauded/cogs/_table_view.py
+++ b/src/clauded/cogs/_table_view.py
@@ -1,0 +1,67 @@
+"""Persistent Discord UI view: copy-as-text button for rendered table PNGs (#112, #133).
+
+The view is stateless and persistent (``timeout=None`` + stable ``custom_id``).
+Markdown source for the table is carried as a ``.md`` sidecar attachment on the
+parent message, so the view can be re-registered after a bot restart via
+``bot.add_view(CopyTableTextView())`` without needing any external store.
+"""
+
+from __future__ import annotations
+
+import io
+
+import discord
+from discord import ui
+
+
+class CopyTableTextView(ui.View):
+    """Persistent view exposing a single 'Copy as text' button.
+
+    The button reads the markdown source from the ``.md`` sidecar attachment
+    of ``interaction.message`` and replies ephemerally with its contents
+    (inline code-fenced for short tables, file attachment for long ones).
+    """
+
+    def __init__(self) -> None:
+        super().__init__(timeout=None)  # persistent across bot restarts
+
+    @ui.button(
+        label="📋 Copy as text",
+        style=discord.ButtonStyle.secondary,
+        custom_id="copy_table_text",  # stable id required for persistence
+    )
+    async def copy(
+        self,
+        interaction: discord.Interaction,
+        button: ui.Button,
+    ) -> None:
+        md_attachment = next(
+            (
+                a
+                for a in interaction.message.attachments
+                if a.filename.endswith(".md")
+            ),
+            None,
+        )
+        if md_attachment is None:
+            await interaction.response.send_message(
+                "❌ Couldn't find markdown source attachment.",
+                ephemeral=True,
+            )
+            return
+
+        content_bytes = await md_attachment.read()
+        text = content_bytes.decode("utf-8", errors="replace")
+
+        if len(text) <= 1900:
+            await interaction.response.send_message(
+                f"```\n{text}\n```",
+                ephemeral=True,
+            )
+        else:
+            f = discord.File(io.BytesIO(content_bytes), filename="table.md")
+            await interaction.response.send_message(
+                "Markdown source attached:",
+                file=f,
+                ephemeral=True,
+            )

--- a/src/clauded/cogs/_table_view.py
+++ b/src/clauded/cogs/_table_view.py
@@ -35,11 +35,16 @@ class CopyTableTextView(ui.View):
         interaction: discord.Interaction,
         button: ui.Button,
     ) -> None:
+        # Filename must start with ``table_`` AND end with ``.md`` — this
+        # prevents collision with the long-upload fallback message which is
+        # named ``claude-response.md`` (review I7). Without the prefix
+        # guard, a Copy button on a multi-attachment message could fire
+        # against the wrong sidecar.
         md_attachment = next(
             (
                 a
                 for a in interaction.message.attachments
-                if a.filename.endswith(".md")
+                if a.filename.startswith("table_") and a.filename.endswith(".md")
             ),
             None,
         )

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1520,11 +1520,25 @@ class DiscordRenderer:
     ) -> tuple[str, list[TableRender]]:
         """Extract markdown tables, render to PNG, return placeholders.
 
-        Walks ``text`` line-by-line. Each *well-formed* markdown table
-        (header row + ``|---|---|`` separator + ≥1 data row, ≥2 columns,
-        not inside a ``` code fence) is replaced in the returned text with
-        a unique placeholder ``\\n[TABLE_PNG_N]\\n`` and yields a
-        :class:`TableRender` carrying:
+        Walks ``text`` line-by-line. Each *well-formed* markdown table is
+        replaced in the returned text with a unique placeholder
+        ``\\n[TABLE_PNG_N]\\n`` and yields a :class:`TableRender` carrying
+        headers/rows/png_bytes/markdown_source.
+
+        Two table shapes are accepted (≥2 columns, not inside a ``` code
+        fence, ≥1 data row in both cases):
+
+        1. **Strict GFM**: header + ``|---|---|`` separator + data rows.
+        2. **Relaxed (no separator)**: header followed directly by data
+           rows where the first data row has the same cell count as the
+           header. Claude's SDK frequently emits tables without a
+           separator row, so the relaxed shape catches production output
+           that the strict matcher would otherwise drop into the legacy
+           code-fence fallback path. On the relaxed path a synthetic
+           ``|---|...|`` line is spliced into ``markdown_source`` only
+           (so the ``.md`` sidecar stays GFM-valid); the PNG renderer
+           and the verbatim-fallback paths see exactly the original
+           input lines.
 
         - ``headers`` / ``rows`` — parsed cell strings (pipe-stripped, trimmed)
         - ``png_bytes`` — output of :func:`table_png.render_table_png`
@@ -1544,7 +1558,8 @@ class DiscordRenderer:
         - Tables inside ``` code fences → left verbatim, no TableRender.
         - Single-column tables (``| Header |``) → re-emitted verbatim.
         - Header-only tables (separator present but no data rows) → verbatim.
-        - Malformed tables (no separator row after the header) → verbatim.
+        - Header line with no following ``|...|`` line → verbatim.
+        - Header + non-separator next row with mismatched cell count → verbatim.
         - PNG render failure (Pillow error, oversize → ``ValueError``) →
           original lines re-emitted verbatim, error logged (review C2).
 
@@ -1604,22 +1619,48 @@ class DiscordRenderer:
                 i += 1
                 continue
 
-            # Candidate header. Need a separator on the next non-empty line.
+            # Candidate header. Two accepted shapes:
+            #   1. Strict GFM: header + ``|---|---|`` separator + ≥1 row.
+            #   2. Relaxed: header followed directly by another ``|...|``
+            #      row with matching cell count (Claude SDK frequently emits
+            #      tables without a separator row). On the relaxed path we
+            #      synthesize a ``|---|...|`` separator solely for
+            #      ``markdown_source`` so the ``.md`` sidecar stays
+            #      GFM-valid; the PNG renderer only ever sees headers+rows.
             header_line = line
             header_stripped = stripped
             j = i + 1
-            if j >= n or not _is_table_line(lines_in[j].strip()) \
-                    or not _is_separator_line(lines_in[j].strip()):
-                # Malformed (no separator) — emit verbatim.
+
+            if j >= n or not _is_table_line(lines_in[j].strip()):
+                # No next table-shaped line — not a table.
                 result.append(header_line)
                 i += 1
                 continue
 
-            sep_line = lines_in[j]
+            next_stripped = lines_in[j].strip()
+            sep_synthesized = False
+            if _is_separator_line(next_stripped):
+                # Strict path — separator row consumes lines_in[j].
+                sep_line = lines_in[j]
+                k = j + 1
+            else:
+                # Relaxed path — no separator row. Require matching cell
+                # count between header and the candidate first data row;
+                # otherwise this is not a table and we fall back verbatim.
+                header_cells = len(_split_cells(header_stripped))
+                next_cells = len(_split_cells(next_stripped))
+                if header_cells != next_cells:
+                    result.append(header_line)
+                    i += 1
+                    continue
+                # Synthesize a GFM separator for ``markdown_source`` only.
+                sep_line = "|" + "|".join(["---"] * header_cells) + "|"
+                sep_synthesized = True
+                # First data row is lines_in[j] — do NOT skip it.
+                k = j
 
             # Collect contiguous data rows.
             data_lines: list[str] = []
-            k = j + 1
             while k < n:
                 ds = lines_in[k].strip()
                 if not _is_table_line(ds) or _is_separator_line(ds):
@@ -1631,9 +1672,13 @@ class DiscordRenderer:
             rows = [_split_cells(dl.strip()) for dl in data_lines]
 
             # PRD R1.4 — single-column / header-only → emit verbatim.
+            # Only emit ``sep_line`` if it actually came from the input
+            # (strict path); the relaxed path synthesizes it for the
+            # markdown_source sidecar only and must not leak into output.
             if len(headers) < 2 or not rows:
                 result.append(header_line)
-                result.append(sep_line)
+                if not sep_synthesized:
+                    result.append(sep_line)
                 for dl in data_lines:
                     result.append(dl)
                 i = k
@@ -1651,7 +1696,8 @@ class DiscordRenderer:
                     len(renders),
                 )
                 result.append(header_line)
-                result.append(sep_line)
+                if not sep_synthesized:
+                    result.append(sep_line)
                 result.extend(data_lines)
                 i = k
                 continue

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -32,6 +32,7 @@ import io
 import logging
 import time
 import uuid
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Awaitable, Callable
 
 import discord
@@ -48,11 +49,51 @@ from .claude_bridge import (
 )
 from claude_agent_sdk.types import StreamEvent
 from .stream_logger import log_event as _log_stream
+from .table_png import render_table_png
 
 if TYPE_CHECKING:
     from .claude_bridge import ClaudeBridge
 
 log = logging.getLogger("clauded.discord_renderer")
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TableRender:
+    """A markdown table extracted from a renderer buffer for PNG attachment.
+
+    Produced by :meth:`DiscordRenderer._extract_and_render_tables`. Each
+    instance carries the parsed structure plus the rendered PNG bytes and the
+    original markdown source (kept verbatim for the Copy-as-text button).
+
+    Fields
+    ------
+    headers
+        Cell text of the table's header row, one per column.
+    rows
+        Body rows (each a list of cell strings, length matching ``headers``).
+    png_bytes
+        Result of :func:`table_png.render_table_png` — ready to attach to a
+        Discord message via :class:`discord.File`.
+    markdown_source
+        Original markdown table text exactly as it appeared in the input
+        buffer (verbatim, including any leading/trailing whitespace per line).
+        This is the source-of-truth surfaced by the Copy button (#133).
+    placeholder
+        Token inserted into the surrounding text where the table used to be,
+        e.g. ``"\\n[TABLE_PNG_0]\\n"``. Callers (#134) split on these to
+        interleave text messages with PNG follow-ups.
+    """
+
+    headers: list[str]
+    rows: list[list[str]]
+    png_bytes: bytes
+    markdown_source: str
+    placeholder: str
 
 # ---------------------------------------------------------------------------
 # Color scheme for embeds
@@ -1223,12 +1264,17 @@ class DiscordRenderer:
         return result is not None
 
     # ------------------------------------------------------------------
-    # Markdown table → code block conversion
+    # Markdown table → code block conversion (legacy) / PNG extraction
     # ------------------------------------------------------------------
 
     @staticmethod
     def _format_tables(text: str) -> str:
-        """Convert markdown tables to code blocks for Discord.
+        """Legacy: wrap markdown tables in code-fence blocks for Discord.
+
+        Kept intact for backward compatibility during the incremental
+        v1.12 PNG migration (#112). Subtask #134 will switch callers to
+        :meth:`_extract_and_render_tables` and this method may then be
+        removed.
 
         Discord does not render markdown tables, so we wrap them in
         code blocks where at least the column alignment is preserved.
@@ -1281,6 +1327,130 @@ class DiscordRenderer:
             result.append("```")
 
         return "\n".join(result)
+
+    @staticmethod
+    def _extract_and_render_tables(text: str) -> tuple[str, list[TableRender]]:
+        """Extract markdown tables, render to PNG, return placeholders.
+
+        Walks ``text`` line-by-line. Each *well-formed* markdown table
+        (header row + ``|---|---|`` separator + ≥1 data row, ≥2 columns,
+        not inside a ``` code fence) is replaced in the returned text with
+        a unique placeholder ``\\n[TABLE_PNG_N]\\n`` and yields a
+        :class:`TableRender` carrying:
+
+        - ``headers`` / ``rows`` — parsed cell strings (pipe-stripped, trimmed)
+        - ``png_bytes`` — output of :func:`table_png.render_table_png`
+        - ``markdown_source`` — original verbatim block of lines that formed
+          the table (for the Copy-as-text button in #133)
+        - ``placeholder`` — the same token inserted into the returned text
+
+        Returns ``(text_with_placeholders, [TableRender, ...])``. If no
+        tables are found, returns ``(text, [])`` unchanged.
+
+        Edge cases (per PRD R1.4 / R6):
+
+        - Tables inside ``` code fences → left verbatim, no TableRender.
+        - Single-column tables (``| Header |``) → re-emitted verbatim.
+        - Header-only tables (separator present but no data rows) → verbatim.
+        - Malformed tables (no separator row after the header) → verbatim.
+        """
+        lines_in = text.split("\n")
+        result: list[str] = []
+        renders: list[TableRender] = []
+        in_code_fence = False
+        i = 0
+        n = len(lines_in)
+
+        def _is_table_line(s: str) -> bool:
+            return s.startswith("|") and s.endswith("|")
+
+        def _is_separator_line(s: str) -> bool:
+            # e.g. ``|---|---|`` or ``| :--- | ---: |`` — only ``|``, ``-``,
+            # ``:`` and spaces, and at least one ``-``.
+            inner = s.strip("|").strip()
+            if not inner or "-" not in inner:
+                return False
+            return all(c in "|-: " for c in s)
+
+        def _split_cells(s: str) -> list[str]:
+            # Strip leading/trailing pipes, then split. Empty cells preserved.
+            body = s
+            if body.startswith("|"):
+                body = body[1:]
+            if body.endswith("|"):
+                body = body[:-1]
+            return [c.strip() for c in body.split("|")]
+
+        while i < n:
+            line = lines_in[i]
+            stripped = line.strip()
+
+            # Track code fences first — anything inside is opaque.
+            if stripped.startswith("```"):
+                in_code_fence = not in_code_fence
+                result.append(line)
+                i += 1
+                continue
+
+            if in_code_fence or not _is_table_line(stripped):
+                result.append(line)
+                i += 1
+                continue
+
+            # Candidate header. Need a separator on the next non-empty line.
+            header_line = line
+            header_stripped = stripped
+            j = i + 1
+            if j >= n or not _is_table_line(lines_in[j].strip()) \
+                    or not _is_separator_line(lines_in[j].strip()):
+                # Malformed (no separator) — emit verbatim.
+                result.append(header_line)
+                i += 1
+                continue
+
+            sep_line = lines_in[j]
+
+            # Collect contiguous data rows.
+            data_lines: list[str] = []
+            k = j + 1
+            while k < n:
+                ds = lines_in[k].strip()
+                if not _is_table_line(ds) or _is_separator_line(ds):
+                    break
+                data_lines.append(lines_in[k])
+                k += 1
+
+            headers = _split_cells(header_stripped)
+            rows = [_split_cells(dl.strip()) for dl in data_lines]
+
+            # PRD R1.4 — single-column / header-only → emit verbatim.
+            if len(headers) < 2 or not rows:
+                result.append(header_line)
+                result.append(sep_line)
+                for dl in data_lines:
+                    result.append(dl)
+                i = k
+                continue
+
+            # Well-formed table — render PNG, replace with placeholder.
+            png = render_table_png(headers, rows)
+            markdown_source = "\n".join(
+                [header_line, sep_line, *data_lines]
+            )
+            placeholder = f"\n[TABLE_PNG_{len(renders)}]\n"
+            renders.append(
+                TableRender(
+                    headers=headers,
+                    rows=rows,
+                    png_bytes=png,
+                    markdown_source=markdown_source,
+                    placeholder=placeholder,
+                )
+            )
+            result.append(placeholder)
+            i = k
+
+        return "\n".join(result), renders
 
 
     # ------------------------------------------------------------------

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -49,13 +49,24 @@ from .claude_bridge import (
 )
 from claude_agent_sdk.types import StreamEvent
 from .stream_logger import log_event as _log_stream
-from .table_png import render_table_png
 from .cogs._table_view import CopyTableTextView
 
 if TYPE_CHECKING:
     from .claude_bridge import ClaudeBridge
 
 log = logging.getLogger("clauded.discord_renderer")
+
+# Pillow defensive fallback (#135 / PRD R6 + acceptance E).
+# If Pillow (or .table_png's other deps) cannot be imported, fall back to the
+# legacy code-fence wrap in ``DiscordRenderer._format_tables`` rather than
+# crashing the renderer. ``PILLOW_AVAILABLE`` is consulted at the top of
+# :meth:`DiscordRenderer._extract_and_render_tables` for a fast-fail.
+try:
+    from .table_png import render_table_png, MAX_COLS, MAX_ROWS, MAX_TABLE_PIXELS
+    PILLOW_AVAILABLE = True
+except ImportError:
+    PILLOW_AVAILABLE = False
+    log.warning("Pillow not installed; tables fall back to code-fence rendering")
 
 
 # ---------------------------------------------------------------------------
@@ -1542,6 +1553,14 @@ class DiscordRenderer:
         endswith("|")``; Claude sometimes emits ``Name | Score`` form
         (review I5).
         """
+        # Pillow defensive fallback (#135 / PRD R6 + acceptance E).
+        # If the import at module load failed, we never had a working PNG
+        # path — return the legacy code-fence formatting and an empty
+        # render list. Caller branches on ``not renders`` and continues
+        # down its no-table path (no PNG follow-ups will be attempted).
+        if not PILLOW_AVAILABLE:
+            return DiscordRenderer._format_tables(text), []
+
         lines_in = text.split("\n")
         result: list[str] = []
         renders: list[TableRender] = []

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1426,6 +1426,17 @@ class DiscordRenderer:
         """
         kwargs: dict = {}
         if content is not None:
+            # v1.12 bug D — Discord rejects ``content=""`` with HTTP 400
+            # code 50006 "Cannot send an empty message". This bites the
+            # streaming-cursor cleanup path in ``_finalize_typewriter``
+            # where the buffer is entirely a table placeholder and the
+            # pre-table segment is empty. Substitute a single space so
+            # the edit succeeds and the user no longer sees the leaked
+            # raw markdown table text alongside the PNG follow-up
+            # (Bug C symptom in the v1.12 smoke run).
+            if not content.strip():
+                log.debug("_safe_edit: empty content; substituting space to avoid Discord 50006")
+                content = " "
             kwargs["content"] = content
         if embed is not None:
             kwargs["embed"] = embed
@@ -1579,12 +1590,26 @@ class DiscordRenderer:
         lines_in = text.split("\n")
         result: list[str] = []
         renders: list[TableRender] = []
-        in_code_fence = False
+        # v1.12 bug D — fence depth tracker per CommonMark §4.5. A fence
+        # opens with N≥3 consecutive backticks and only closes on a line
+        # whose backtick run length is ≥N. Tracking just a bool with
+        # ``startswith("```")`` mis-parsed quad-backtick outer fences:
+        # the inner ``\u0060\u0060\u0060`` line was treated as a fence
+        # toggle and the markdown table inside leaked back out to PNG
+        # extraction, violating PRD R5 (code fences preserved verbatim).
+        fence_count = 0  # 0 ⇒ not in a fence; otherwise the opener's backtick run
         i = 0
         n = len(lines_in)
 
         def _is_table_line(s: str) -> bool:
             return s.startswith("|") and s.endswith("|")
+
+        def _leading_backtick_run(s: str) -> int:
+            """Return the count of leading backticks on ``s`` (already stripped)."""
+            j = 0
+            while j < len(s) and s[j] == "`":
+                j += 1
+            return j
 
         def _is_separator_line(s: str) -> bool:
             # e.g. ``|---|---|`` or ``| :--- | ---: |`` — only ``|``, ``-``,
@@ -1608,13 +1633,27 @@ class DiscordRenderer:
             stripped = line.strip()
 
             # Track code fences first — anything inside is opaque.
-            if stripped.startswith("```"):
-                in_code_fence = not in_code_fence
+            # CommonMark §4.5: a fence opens with N≥3 consecutive backticks
+            # at line start; it only closes on a line whose backtick run
+            # length is ≥N (so a ``\u0060\u0060\u0060\u0060`` outer fence
+            # is NOT closed by an inner ``\u0060\u0060\u0060``). v1.12
+            # bug D — see comment block above.
+            ticks = _leading_backtick_run(stripped)
+            if fence_count == 0:
+                if ticks >= 3:
+                    fence_count = ticks
+                    result.append(line)
+                    i += 1
+                    continue
+            else:
+                # Currently inside a fence — only a ≥fence_count run closes it.
+                if ticks >= fence_count:
+                    fence_count = 0
                 result.append(line)
                 i += 1
                 continue
 
-            if in_code_fence or not _is_table_line(stripped):
+            if not _is_table_line(stripped):
                 result.append(line)
                 i += 1
                 continue

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1426,17 +1426,21 @@ class DiscordRenderer:
         """
         kwargs: dict = {}
         if content is not None:
-            # v1.12 bug D — Discord rejects ``content=""`` with HTTP 400
-            # code 50006 "Cannot send an empty message". This bites the
-            # streaming-cursor cleanup path in ``_finalize_typewriter``
-            # where the buffer is entirely a table placeholder and the
-            # pre-table segment is empty. Substitute a single space so
-            # the edit succeeds and the user no longer sees the leaked
-            # raw markdown table text alongside the PNG follow-up
-            # (Bug C symptom in the v1.12 smoke run).
+            # v1.12 bug D-2 — Discord rejects both ``content=""`` AND
+            # ``content=" "`` (single space) with HTTP 400 code 50006
+            # "Cannot send an empty message" — whitespace-only content
+            # is treated as empty by Discord's validator. This bites
+            # the streaming-cursor cleanup path in
+            # ``_finalize_typewriter`` where the buffer is entirely a
+            # table placeholder and the pre-table segment is empty.
+            # Substitute U+200B (zero-width space): Discord accepts it
+            # as non-empty content and it renders invisibly so the
+            # user sees the live_msg as "cleared" rather than
+            # retaining the leaked raw markdown table text alongside
+            # the PNG follow-up (Bug C symptom in the v1.12 smoke run).
             if not content.strip():
-                log.debug("_safe_edit: empty content; substituting space to avoid Discord 50006")
-                content = " "
+                log.debug("_safe_edit: empty content; substituting U+200B to clear cursor msg without Discord 50006")
+                content = "\u200b"
             kwargs["content"] = content
         if embed is not None:
             kwargs["embed"] = embed

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -83,11 +83,11 @@ class TableRender:
     markdown_source
         Original markdown table text exactly as it appeared in the input
         buffer (verbatim, including any leading/trailing whitespace per line).
-        This is the source-of-truth surfaced by the Copy button (#133).
+        This is the source-of-truth surfaced by the Copy button.
     placeholder
         Token inserted into the surrounding text where the table used to be,
-        e.g. ``"\\n[TABLE_PNG_0]\\n"``. Callers (#134) split on these to
-        interleave text messages with PNG follow-ups.
+        e.g. ``"\\n[TABLE_PNG_0]\\n"``. Callers split on these to interleave
+        text segments with PNG follow-ups (PRD R2.2 ordering).
     """
 
     headers: list[str]
@@ -975,14 +975,19 @@ class DiscordRenderer:
         (``table_N.png`` and ``table_N.md`` sidecar with the verbatim
         markdown source) plus a :class:`CopyTableTextView`. The view is
         persistent (``custom_id="copy_table_text"``) — see
-        :mod:`clauded.cogs._table_view` and PRD R3.3.
+        :mod:`clauded.cogs._table_view` (PRD R3.3).
 
         After each successful send we point ``_last_msg`` at the new
-        message but reset ``_last_msg_text`` to ``""``: a PNG follow-up
-        has no text body for the cost-footer splicer to safely operate
-        on (see #113 — splicing text into an attachment-only message
-        would silently delete the table). The next text send naturally
-        re-populates the shadow.
+        message but reset ``_last_msg_text`` to ``""``. The shadow reset is
+        what prevents the cost-footer splicer from re-writing the previous
+        text body onto this attachment-only message (`current + footer`
+        would otherwise carry the prior chunk's text onto a PNG-only msg).
+        It is NOT about losing the attachment — ``Message.edit(content=…)``
+        does not strip attachments. See #113.
+
+        If a PNG send permanently fails (``_safe_send`` returned ``None``
+        after MAX_HTTP_RETRIES), log an error so the silent drop becomes
+        visible in bot.log (review I2).
         """
         for i, render in enumerate(renders):
             png_file = discord.File(
@@ -999,8 +1004,48 @@ class DiscordRenderer:
             )
             if sent is not None:
                 self._last_msg = sent
-                # No text body — block cost-footer splice (#113).
+                # Block cost-footer splice of the prior text body onto
+                # this PNG message — see docstring + #113.
                 self._last_msg_text = ""
+            else:
+                log.error(
+                    "Table %d PNG send permanently failed (%d bytes)",
+                    i, len(render.png_bytes),
+                )
+
+    async def _send_text_and_tables(
+        self, text: str, renders: list[TableRender]
+    ) -> None:
+        """Interleave text segments and PNG attachments per PRD R2.2.
+
+        Splits ``text`` on each ``render.placeholder`` token (in order) and
+        alternates ``_safe_send(content=segment)`` with the matching PNG
+        follow-up. Segments are passed through ``_smart_split`` so they
+        still respect ``DISCORD_MAX_LEN``. Empty segments (table at start
+        or back-to-back tables) are skipped — never send a blank message.
+
+        This is the fix for review C1: previously the caller sent ``text``
+        whole then PNGs after, leaking ``[TABLE_PNG_N]`` placeholders into
+        the user-visible message body.
+        """
+        segments = text
+        for render in renders:
+            before, _, segments = segments.partition(render.placeholder)
+            if before.strip():
+                for chunk in self._smart_split(before, limit=DISCORD_MAX_LEN):
+                    sent = await self._safe_send(content=chunk)
+                    if sent is not None:
+                        self._last_msg = sent
+                        self._last_msg_text = chunk
+            # Now the PNG (with its own _last_msg / shadow reset).
+            await self._send_table_renders([render])
+        # Tail after the last placeholder (or all of ``text`` if no renders).
+        if segments.strip():
+            for chunk in self._smart_split(segments, limit=DISCORD_MAX_LEN):
+                sent = await self._safe_send(content=chunk)
+                if sent is not None:
+                    self._last_msg = sent
+                    self._last_msg_text = chunk
 
     async def _finalize_typewriter(
         self, live_msg: discord.Message, buffer: str
@@ -1013,30 +1058,54 @@ class DiscordRenderer:
         """
         # E1: Process channel/thread markers before finalizing.
         buffer = await self._process_markers(buffer)
-        # v1.12 / #134: extract tables → PNG follow-ups (see PRD R2). Text
-        # with placeholders is sent first, then each TableRender is emitted
-        # as its own message with a PNG + .md sidecar + CopyTableTextView.
-        stripped_text, table_renders = self._extract_and_render_tables(buffer)
-        buffer = stripped_text
+        # v1.12 — extract tables → PNG follow-ups (PRD R2). On the first
+        # text-bearing chunk we still drive the typewriter via in-place
+        # edit; if tables exist the remaining text is interleaved with
+        # PNG follow-ups via ``_send_text_and_tables`` (review C1).
+        stripped_text, table_renders = await self._extract_and_render_tables(buffer)
 
-        if len(buffer) <= DISCORD_MAX_LEN:
-            chunks = [buffer]
+        if not table_renders:
+            # Fast path — no tables, pre-table behaviour preserved verbatim.
+            buffer = stripped_text
+            if len(buffer) <= DISCORD_MAX_LEN:
+                chunks = [buffer]
+            else:
+                chunks = self._smart_split(buffer, limit=DISCORD_MAX_LEN) or [buffer[:DISCORD_MAX_LEN]]
+
+            first = await self._typewriter_apply(live_msg, chunks[0])
+            if first is not None:
+                self._last_msg = first
+            for chunk in chunks[1:]:
+                sent = await self._safe_send(content=chunk)
+                if sent is not None:
+                    self._last_msg = sent
+            return
+
+        # Interleaved path (PRD R2.2): split ``stripped_text`` on
+        # placeholders. The first text segment (before the first table)
+        # replaces the cursor in ``live_msg``; subsequent segments and PNG
+        # follow-ups are sent fresh. If the first segment is empty (table
+        # at the very start of the buffer), edit the cursor away with the
+        # empty string so the cursor is gone before the PNG arrives.
+        first_seg, _, rest_text = stripped_text.partition(table_renders[0].placeholder)
+        if first_seg.strip():
+            first_chunks = self._smart_split(first_seg, limit=DISCORD_MAX_LEN) or [first_seg[:DISCORD_MAX_LEN]]
         else:
-            chunks = self._smart_split(buffer, limit=DISCORD_MAX_LEN) or [buffer[:DISCORD_MAX_LEN]]
-
-        # First chunk replaces the cursor in live_msg (or sends fresh on failure).
-        first = await self._typewriter_apply(live_msg, chunks[0])
+            first_chunks = [""]
+        first = await self._typewriter_apply(live_msg, first_chunks[0])
         if first is not None:
             self._last_msg = first
-        for chunk in chunks[1:]:
+            self._last_msg_text = first_chunks[0]
+        for chunk in first_chunks[1:]:
             sent = await self._safe_send(content=chunk)
             if sent is not None:
                 self._last_msg = sent
+                self._last_msg_text = chunk
 
-        # Tables — sent as PNG attachments after the text body so the
-        # in-channel order is text-first → tables-after.
-        if table_renders:
-            await self._send_table_renders(table_renders)
+        # First PNG, then the rest of the interleave (text-then-PNG pairs +
+        # final tail). ``_send_text_and_tables`` handles the residual.
+        await self._send_table_renders([table_renders[0]])
+        await self._send_text_and_tables(rest_text, table_renders[1:])
 
     async def _flush(
         self,
@@ -1053,27 +1122,48 @@ class DiscordRenderer:
             buffer = await self._process_markers(buffer)
 
         if typewriter and live_msg is not None:
-            # ``_finalize_typewriter`` runs its own table extraction (#134),
-            # so hand it the markers-processed buffer untouched.
+            # ``_finalize_typewriter`` runs its own table extraction so it
+            # can interleave text segments with PNG follow-ups (PRD R2.2).
             await self._finalize_typewriter(live_msg, buffer)
             return
 
-        # v1.12 / #134: fast-path also splits text from tables before send.
-        # If buffer is empty the extractor is a no-op (returns ``("", [])``).
-        stripped_text, table_renders = self._extract_and_render_tables(buffer)
-        buffer = stripped_text
+        # Fast-path: split text from tables before send. If buffer is empty
+        # the extractor is a no-op (returns ``("", [])``).
+        stripped_text, table_renders = await self._extract_and_render_tables(buffer)
 
         if buffer:
-            chunks = self._smart_split(buffer, limit=DISCORD_MAX_LEN)
-            # If too many chunks, upload as file instead of flooding
+            # If text after table extraction is still too big for inline
+            # chunks, upload as file — re-splice the markdown sources back
+            # into the upload buffer so the `.md` is self-contained (C3).
+            chunks = self._smart_split(stripped_text, limit=DISCORD_MAX_LEN) if stripped_text else []
             if len(chunks) > 4:
                 import io as _io
-                summary = buffer[:200] + "..." if len(buffer) > 200 else buffer
-                f = discord.File(_io.BytesIO(buffer.encode()), filename="claude-response.md")
+                # Re-splice markdown_source back into the upload .md so the
+                # user-downloadable file doesn't contain ``[TABLE_PNG_N]``
+                # placeholders (review C3).
+                upload_buffer = stripped_text
+                for render in table_renders:
+                    upload_buffer = upload_buffer.replace(
+                        render.placeholder,
+                        "\n" + render.markdown_source + "\n",
+                        1,
+                    )
+                summary = upload_buffer[:200] + "..." if len(upload_buffer) > 200 else upload_buffer
+                f = discord.File(_io.BytesIO(upload_buffer.encode()), filename="claude-response.md")
                 await self._safe_send(content=summary, file=f)
+                # Still send the PNG follow-ups so chat carries the visuals.
                 if table_renders:
                     await self._send_table_renders(table_renders)
                 return
+
+            # Standard inline path. If tables exist, use the interleaving
+            # helper so placeholders never leak into the user-visible text
+            # (review C1). Otherwise fall through to the legacy chunked send
+            # which knows how to do the long-code-block file upload.
+            if table_renders:
+                await self._send_text_and_tables(stripped_text, table_renders)
+                return
+
             for chunk in chunks:
                 is_file = self._should_upload_as_file(chunk)
                 if is_file:
@@ -1087,8 +1177,6 @@ class DiscordRenderer:
                     if is_file:
                         # File-only — no text body for the cost footer to splice.
                         self._last_msg_text = ""
-            if table_renders:
-                await self._send_table_renders(table_renders)
             return
 
         # No surrounding text but a table can still exist (e.g., Claude
@@ -1357,10 +1445,11 @@ class DiscordRenderer:
     def _format_tables(text: str) -> str:
         """Legacy: wrap markdown tables in code-fence blocks for Discord.
 
-        Kept intact for backward compatibility during the incremental
-        v1.12 PNG migration (#112). Subtask #134 will switch callers to
-        :meth:`_extract_and_render_tables` and this method may then be
-        removed.
+        Kept as the fallback path for #135 (no-Pillow / missing-font
+        environments) — do not remove. Live callers use
+        :meth:`_extract_and_render_tables` for the PNG path; this method
+        remains the documented escape hatch when PNG rendering is
+        unavailable.
 
         Discord does not render markdown tables, so we wrap them in
         code blocks where at least the column alignment is preserved.
@@ -1415,7 +1504,9 @@ class DiscordRenderer:
         return "\n".join(result)
 
     @staticmethod
-    def _extract_and_render_tables(text: str) -> tuple[str, list[TableRender]]:
+    async def _extract_and_render_tables(
+        text: str,
+    ) -> tuple[str, list[TableRender]]:
         """Extract markdown tables, render to PNG, return placeholders.
 
         Walks ``text`` line-by-line. Each *well-formed* markdown table
@@ -1427,11 +1518,15 @@ class DiscordRenderer:
         - ``headers`` / ``rows`` — parsed cell strings (pipe-stripped, trimmed)
         - ``png_bytes`` — output of :func:`table_png.render_table_png`
         - ``markdown_source`` — original verbatim block of lines that formed
-          the table (for the Copy-as-text button in #133)
+          the table (for the Copy-as-text button)
         - ``placeholder`` — the same token inserted into the returned text
 
         Returns ``(text_with_placeholders, [TableRender, ...])``. If no
         tables are found, returns ``(text, [])`` unchanged.
+
+        PNG generation is dispatched through :func:`asyncio.to_thread` so
+        the renderer's heartbeat-bound event loop is never blocked on the
+        Pillow draw + PNG-encode CPU burst (review I3).
 
         Edge cases (per PRD R1.4 / R6):
 
@@ -1439,6 +1534,13 @@ class DiscordRenderer:
         - Single-column tables (``| Header |``) → re-emitted verbatim.
         - Header-only tables (separator present but no data rows) → verbatim.
         - Malformed tables (no separator row after the header) → verbatim.
+        - PNG render failure (Pillow error, oversize → ``ValueError``) →
+          original lines re-emitted verbatim, error logged (review C2).
+
+        TODO(v1.13): support border-less GFM tables (no leading/trailing
+        pipe). Currently the line must satisfy ``startswith("|") and
+        endswith("|")``; Claude sometimes emits ``Name | Score`` form
+        (review I5).
         """
         lines_in = text.split("\n")
         result: list[str] = []
@@ -1518,8 +1620,23 @@ class DiscordRenderer:
                 i = k
                 continue
 
-            # Well-formed table — render PNG, replace with placeholder.
-            png = render_table_png(headers, rows)
+            # Well-formed table — render PNG (off the event loop), then
+            # replace with placeholder. On any render failure (Pillow OOM,
+            # oversize guard, font corruption), emit the original lines
+            # verbatim so the user never silently loses a table block.
+            try:
+                png = await asyncio.to_thread(render_table_png, headers, rows)
+            except Exception:
+                log.exception(
+                    "PNG render failed for table %d; emitting verbatim",
+                    len(renders),
+                )
+                result.append(header_line)
+                result.append(sep_line)
+                result.extend(data_lines)
+                i = k
+                continue
+
             markdown_source = "\n".join(
                 [header_line, sep_line, *data_lines]
             )

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -50,6 +50,7 @@ from .claude_bridge import (
 from claude_agent_sdk.types import StreamEvent
 from .stream_logger import log_event as _log_stream
 from .table_png import render_table_png
+from .cogs._table_view import CopyTableTextView
 
 if TYPE_CHECKING:
     from .claude_bridge import ClaudeBridge
@@ -965,6 +966,42 @@ class DiscordRenderer:
         new_live = await self._safe_send(content=tail + CURSOR) if tail else None
         return new_live, tail
 
+    async def _send_table_renders(
+        self, renders: list[TableRender]
+    ) -> None:
+        """Send each :class:`TableRender` as a follow-up PNG message.
+
+        Each render becomes one Discord message carrying two attachments
+        (``table_N.png`` and ``table_N.md`` sidecar with the verbatim
+        markdown source) plus a :class:`CopyTableTextView`. The view is
+        persistent (``custom_id="copy_table_text"``) — see
+        :mod:`clauded.cogs._table_view` and PRD R3.3.
+
+        After each successful send we point ``_last_msg`` at the new
+        message but reset ``_last_msg_text`` to ``""``: a PNG follow-up
+        has no text body for the cost-footer splicer to safely operate
+        on (see #113 — splicing text into an attachment-only message
+        would silently delete the table). The next text send naturally
+        re-populates the shadow.
+        """
+        for i, render in enumerate(renders):
+            png_file = discord.File(
+                io.BytesIO(render.png_bytes),
+                filename=f"table_{i}.png",
+            )
+            md_file = discord.File(
+                io.BytesIO(render.markdown_source.encode()),
+                filename=f"table_{i}.md",
+            )
+            sent = await self._safe_send(
+                files=[png_file, md_file],
+                view=CopyTableTextView(),
+            )
+            if sent is not None:
+                self._last_msg = sent
+                # No text body — block cost-footer splice (#113).
+                self._last_msg_text = ""
+
     async def _finalize_typewriter(
         self, live_msg: discord.Message, buffer: str
     ) -> None:
@@ -976,7 +1013,11 @@ class DiscordRenderer:
         """
         # E1: Process channel/thread markers before finalizing.
         buffer = await self._process_markers(buffer)
-        buffer = self._format_tables(buffer)
+        # v1.12 / #134: extract tables → PNG follow-ups (see PRD R2). Text
+        # with placeholders is sent first, then each TableRender is emitted
+        # as its own message with a PNG + .md sidecar + CopyTableTextView.
+        stripped_text, table_renders = self._extract_and_render_tables(buffer)
+        buffer = stripped_text
 
         if len(buffer) <= DISCORD_MAX_LEN:
             chunks = [buffer]
@@ -992,6 +1033,11 @@ class DiscordRenderer:
             if sent is not None:
                 self._last_msg = sent
 
+        # Tables — sent as PNG attachments after the text body so the
+        # in-channel order is text-first → tables-after.
+        if table_renders:
+            await self._send_table_renders(table_renders)
+
     async def _flush(
         self,
         live_msg: discord.Message | None,
@@ -1005,11 +1051,17 @@ class DiscordRenderer:
         # Process channel/thread management markers before sending.
         if buffer:
             buffer = await self._process_markers(buffer)
-        buffer = self._format_tables(buffer)
 
         if typewriter and live_msg is not None:
+            # ``_finalize_typewriter`` runs its own table extraction (#134),
+            # so hand it the markers-processed buffer untouched.
             await self._finalize_typewriter(live_msg, buffer)
             return
+
+        # v1.12 / #134: fast-path also splits text from tables before send.
+        # If buffer is empty the extractor is a no-op (returns ``("", [])``).
+        stripped_text, table_renders = self._extract_and_render_tables(buffer)
+        buffer = stripped_text
 
         if buffer:
             chunks = self._smart_split(buffer, limit=DISCORD_MAX_LEN)
@@ -1019,6 +1071,8 @@ class DiscordRenderer:
                 summary = buffer[:200] + "..." if len(buffer) > 200 else buffer
                 f = discord.File(_io.BytesIO(buffer.encode()), filename="claude-response.md")
                 await self._safe_send(content=summary, file=f)
+                if table_renders:
+                    await self._send_table_renders(table_renders)
                 return
             for chunk in chunks:
                 is_file = self._should_upload_as_file(chunk)
@@ -1033,6 +1087,14 @@ class DiscordRenderer:
                     if is_file:
                         # File-only — no text body for the cost footer to splice.
                         self._last_msg_text = ""
+            if table_renders:
+                await self._send_table_renders(table_renders)
+            return
+
+        # No surrounding text but a table can still exist (e.g., Claude
+        # replied with a bare table) — emit the PNG(s) directly.
+        if table_renders:
+            await self._send_table_renders(table_renders)
             return
 
         # No text buffered. If we never showed *anything* (no text, no tools),
@@ -1163,6 +1225,7 @@ class DiscordRenderer:
         *,
         embed: discord.Embed | None = None,
         file: discord.File | None = None,
+        files: list[discord.File] | None = None,
         view: discord.ui.View | None = None,
     ) -> discord.Message | None:
         """Send a message with retry/backoff on transient HTTP errors.
@@ -1173,8 +1236,19 @@ class DiscordRenderer:
         ``MAX_HTTP_RETRIES`` times with the ``_BACKOFF`` schedule before
         giving up. On giveup with a non-empty ``content``, we log at error
         level so the drop shows up in bot.log.
+
+        ``file`` (single) and ``files`` (list) are mutually exclusive — both
+        map onto ``discord.abc.Messageable.send``'s twin kwargs. The list
+        form is used by #134 to attach a PNG table + ``.md`` sidecar in one
+        message together with a :class:`CopyTableTextView` persistent view.
         """
-        if not content and embed is None and file is None and view is None:
+        if (
+            not content
+            and embed is None
+            and file is None
+            and files is None
+            and view is None
+        ):
             return None
 
         kwargs: dict = {}
@@ -1184,18 +1258,28 @@ class DiscordRenderer:
             kwargs["embed"] = embed
         if file is not None:
             kwargs["file"] = file
+        if files is not None:
+            kwargs["files"] = files
         if view is not None:
             kwargs["view"] = view
 
         def _reset_file() -> None:
-            # Reset file stream between attempts so the second send doesn't
-            # see an empty buffer.
+            # Reset file stream(s) between attempts so the second send
+            # doesn't see an empty buffer.
             f = kwargs.get("file")
             if f is not None and hasattr(f, "fp") and hasattr(f.fp, "seek"):
                 try:
                     f.fp.seek(0)
                 except Exception:
                     pass
+            fs = kwargs.get("files")
+            if fs:
+                for entry in fs:
+                    if hasattr(entry, "fp") and hasattr(entry.fp, "seek"):
+                        try:
+                            entry.fp.seek(0)
+                        except Exception:
+                            pass
 
         async def _op() -> discord.Message | None:
             return await self.target.send(**kwargs)
@@ -1204,7 +1288,9 @@ class DiscordRenderer:
             _op,
             label="send",
             content_len=len(content or ""),
-            between_attempts=_reset_file if "file" in kwargs else None,
+            between_attempts=(
+                _reset_file if ("file" in kwargs or "files" in kwargs) else None
+            ),
         )
         # Only advance the shadow on content-bearing sends. Embed-only and
         # file-only sends do NOT touch _last_msg here — callers that want

--- a/src/clauded/table_png.py
+++ b/src/clauded/table_png.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import io
 import re
-from typing import Iterable
 
 from PIL import Image, ImageDraw, ImageFont
 
@@ -45,6 +44,13 @@ ACCENT_W = 4
 MAX_CELL_CHARS = 120
 ELLIPSIS = "…"
 
+# DoS guards (review I4). Caller catches the ValueError and falls back to
+# emitting the original markdown verbatim — see C2 try/except in
+# DiscordRenderer._extract_and_render_tables.
+MAX_COLS = 20
+MAX_ROWS = 200
+MAX_TABLE_PIXELS = 8000 * 4000  # ~96 MB at 3 bytes/pixel
+
 # Matches markdown links ``[name](url)``. Conservative — no nested brackets.
 _LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 
@@ -52,10 +58,13 @@ _LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 # --- Font resolution -----------------------------------------------------
 
 # Module-level so tests can monkeypatch the candidate list.
+# PingFang first: it has good Latin coverage AND CJK glyphs, so it works as
+# the primary font on the happy path while preventing tofu boxes for Chinese
+# text (PRD R4.2 — review I6).
 FONT_CANDIDATES = (
-    "/System/Library/Fonts/Menlo.ttc",
-    "/System/Library/Fonts/PingFang.ttc",
-    "Arial Unicode.ttf",
+    "/System/Library/Fonts/PingFang.ttc",                      # CJK first (PRD R4.2)
+    "/System/Library/Fonts/Menlo.ttc",                         # mono fallback
+    "/System/Library/Fonts/Supplemental/Arial Unicode.ttf",    # broad fallback
 )
 
 
@@ -126,9 +135,25 @@ def render_table_png(headers: list[str], rows: list[list[str]]) -> bytes:
     - Empty cells render blank (no crash).
 
     Returns PNG bytes parseable by ``PIL.Image.open(BytesIO(b))``.
+
+    Raises
+    ------
+    ValueError
+        If ``headers`` / ``rows`` exceed :data:`MAX_COLS` / :data:`MAX_ROWS`
+        or the computed image area exceeds :data:`MAX_TABLE_PIXELS`. The
+        caller is expected to catch and fall back to verbatim markdown.
     """
     headers = list(headers) if headers else [""]
     ncols = len(headers)
+
+    if ncols > MAX_COLS:
+        raise ValueError(
+            f"table too wide: {ncols} cols (max {MAX_COLS})"
+        )
+    if rows is not None and len(rows) > MAX_ROWS:
+        raise ValueError(
+            f"table too tall: {len(rows)} rows (max {MAX_ROWS})"
+        )
 
     # Normalise rows: pad/truncate to ``ncols``.
     norm_rows: list[list[str]] = []
@@ -164,6 +189,11 @@ def render_table_png(headers: list[str], rows: list[list[str]]) -> bytes:
     total_w = sum(col_w) if col_w else 0
     W = max(total_w + PAD * 2, PAD * 2 + 8)
     H = PAD * 2 + HEAD_H + sum(row_heights)
+
+    if W * H > MAX_TABLE_PIXELS:
+        raise ValueError(
+            f"table pixel budget exceeded: {W}×{H} > {MAX_TABLE_PIXELS}"
+        )
 
     img = Image.new("RGB", (W, H), BG)
     draw = ImageDraw.Draw(img)
@@ -210,4 +240,10 @@ def render_table_png(headers: list[str], rows: list[list[str]]) -> bytes:
     return buf.getvalue()
 
 
-__all__ = ["render_table_png"]
+__all__ = [
+    "render_table_png",
+    "MAX_CELL_CHARS",
+    "MAX_COLS",
+    "MAX_ROWS",
+    "MAX_TABLE_PIXELS",
+]

--- a/src/clauded/table_png.py
+++ b/src/clauded/table_png.py
@@ -1,0 +1,213 @@
+"""PNG renderer for markdown tables (v1.12 / #131).
+
+Single entry point: :func:`render_table_png` — given parsed headers + rows,
+produces PNG bytes suitable for sending as a Discord attachment.
+
+Design (per PRD R4):
+- Pillow direct draw, no HTML/CSS pipeline.
+- Dark Discord theme, blurple accent stripe on the left.
+- Mac system fonts (Menlo for body/header, PingFang as CJK fallback,
+  Arial Unicode as broad fallback, ``ImageFont.load_default`` as last resort).
+- No bundled fonts — Linux deploy hardening is a separate subtask.
+- ``font.getbbox`` measures actual rendered width (correct for CJK + emoji).
+"""
+from __future__ import annotations
+
+import io
+import re
+from typing import Iterable
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+# --- Theme ---------------------------------------------------------------
+
+BG = (32, 34, 37)
+HEAD_BG = (35, 39, 42)
+ROW_EVEN = (47, 49, 54)
+ROW_ODD = (54, 57, 63)
+TEXT = (220, 221, 222)
+HEAD_TEXT = (255, 255, 255)
+ACCENT = (88, 101, 242)   # Discord blurple
+LINE = (60, 64, 72)
+
+# --- Layout --------------------------------------------------------------
+
+PAD = 16
+CELL_X = 12
+CELL_Y = 8
+ROW_H = 24
+HEAD_H = 28
+ACCENT_W = 4
+
+# --- Display rules -------------------------------------------------------
+
+MAX_CELL_CHARS = 120
+ELLIPSIS = "…"
+
+# Matches markdown links ``[name](url)``. Conservative — no nested brackets.
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+
+# --- Font resolution -----------------------------------------------------
+
+# Module-level so tests can monkeypatch the candidate list.
+FONT_CANDIDATES = (
+    "/System/Library/Fonts/Menlo.ttc",
+    "/System/Library/Fonts/PingFang.ttc",
+    "Arial Unicode.ttf",
+)
+
+
+def _load_font(size: int):
+    """Try each candidate path; fall back to ``load_default`` (never crashes)."""
+    for path in FONT_CANDIDATES:
+        try:
+            return ImageFont.truetype(path, size)
+        except (OSError, IOError):
+            continue
+    return ImageFont.load_default()
+
+
+# --- Cell preprocessing --------------------------------------------------
+
+def _format_cell(text: str) -> str:
+    """Apply display-only transforms to a cell.
+
+    - Markdown links ``[name](url)`` → ``name (url)`` (PNG can't render links).
+    - Strip backticks (Pillow has no inline-code style).
+    - ``<br>`` → newline (drawn as multiline).
+    - Truncate to ``MAX_CELL_CHARS`` with ``…``.
+    """
+    if text is None:
+        return ""
+    s = str(text)
+    s = _LINK_RE.sub(lambda m: f"{m.group(1)} ({m.group(2)})", s)
+    s = s.replace("`", "")
+    s = re.sub(r"<br\s*/?>", "\n", s, flags=re.IGNORECASE)
+    if len(s) > MAX_CELL_CHARS:
+        s = s[: MAX_CELL_CHARS - 1] + ELLIPSIS
+    return s
+
+
+def _measure(text: str, font) -> int:
+    """Return rendered pixel width of ``text`` for ``font``."""
+    if not text:
+        return 0
+    # Multiline: take the widest line.
+    width = 0
+    for line in text.split("\n"):
+        bbox = font.getbbox(line)
+        width = max(width, bbox[2] - bbox[0])
+    return width
+
+
+def _line_count(text: str) -> int:
+    """Number of visual lines (≥1) in a formatted cell."""
+    if not text:
+        return 1
+    return text.count("\n") + 1
+
+
+# --- Public API ----------------------------------------------------------
+
+def render_table_png(headers: list[str], rows: list[list[str]]) -> bytes:
+    """Render a markdown table to PNG bytes.
+
+    ``headers``: list of column header strings.
+    ``rows``: list of row lists (each row is a list of cell strings).
+              Rows shorter than ``headers`` are padded with empty cells.
+
+    Display transforms (per PRD R4.3 / R6.4-R6.6):
+    - Strips ` backticks from cells.
+    - Renders ``[name](url)`` markdown links as ``name (url)`` plain text.
+    - ``<br>`` → newline (cell grows in height).
+    - Truncates cells longer than 120 chars with ``…``.
+    - Empty cells render blank (no crash).
+
+    Returns PNG bytes parseable by ``PIL.Image.open(BytesIO(b))``.
+    """
+    headers = list(headers) if headers else [""]
+    ncols = len(headers)
+
+    # Normalise rows: pad/truncate to ``ncols``.
+    norm_rows: list[list[str]] = []
+    for r in (rows or []):
+        r = list(r) if r else []
+        if len(r) < ncols:
+            r = r + [""] * (ncols - len(r))
+        elif len(r) > ncols:
+            r = r[:ncols]
+        norm_rows.append(r)
+
+    # Apply display transforms once up front.
+    fmt_headers = [_format_cell(h) for h in headers]
+    fmt_rows = [[_format_cell(c) for c in r] for r in norm_rows]
+
+    font_body = _load_font(13)
+    font_head = _load_font(14)
+
+    # Column widths — max of header width + every row cell width.
+    col_w: list[int] = []
+    for ci in range(ncols):
+        w = _measure(fmt_headers[ci], font_head)
+        for r in fmt_rows:
+            w = max(w, _measure(r[ci], font_body))
+        col_w.append(w + CELL_X * 2)
+
+    # Row heights — grow for multiline ``<br>`` cells.
+    row_heights = []
+    for r in fmt_rows:
+        lines = max((_line_count(c) for c in r), default=1)
+        row_heights.append(max(ROW_H, ROW_H + (lines - 1) * 16))
+
+    total_w = sum(col_w) if col_w else 0
+    W = max(total_w + PAD * 2, PAD * 2 + 8)
+    H = PAD * 2 + HEAD_H + sum(row_heights)
+
+    img = Image.new("RGB", (W, H), BG)
+    draw = ImageDraw.Draw(img)
+
+    # Left blurple accent stripe.
+    draw.rectangle((0, 0, ACCENT_W, H), fill=ACCENT)
+
+    # --- Header row ----------------------------------------------------
+    y = PAD
+    draw.rectangle((PAD, y, PAD + total_w, y + HEAD_H), fill=HEAD_BG)
+    x = PAD
+    for ci, h in enumerate(fmt_headers):
+        draw.text((x + CELL_X, y + CELL_Y - 2), h, fill=HEAD_TEXT, font=font_head)
+        x += col_w[ci]
+        if ci < ncols - 1:
+            draw.line((x, y, x, y + HEAD_H), fill=LINE, width=1)
+    y += HEAD_H
+    # Accent under the header.
+    draw.line((PAD, y, PAD + total_w, y), fill=ACCENT, width=2)
+
+    # --- Data rows -----------------------------------------------------
+    for ri, r in enumerate(fmt_rows):
+        rh = row_heights[ri]
+        bg = ROW_EVEN if ri % 2 == 0 else ROW_ODD
+        draw.rectangle((PAD, y, PAD + total_w, y + rh), fill=bg)
+        x = PAD
+        for ci, cell in enumerate(r):
+            if cell:
+                # multiline_text handles single-line strings too.
+                draw.multiline_text(
+                    (x + CELL_X, y + CELL_Y - 2),
+                    cell,
+                    fill=TEXT,
+                    font=font_body,
+                    spacing=2,
+                )
+            x += col_w[ci]
+            if ci < ncols - 1:
+                draw.line((x, y, x, y + rh), fill=LINE, width=1)
+        y += rh
+
+    buf = io.BytesIO()
+    img.save(buf, "PNG")
+    return buf.getvalue()
+
+
+__all__ = ["render_table_png"]

--- a/tests/test_copy_table_view.py
+++ b/tests/test_copy_table_view.py
@@ -34,8 +34,8 @@ def _make_interaction(attachments: list) -> MagicMock:
 @pytest.mark.asyncio
 async def test_copy_returns_ephemeral_text_for_short_table() -> None:
     md_source = "| a | b |\n|---|---|\n| 1 | 2 |"
-    png = _make_attachment("table.png", b"\x89PNG...")
-    md = _make_attachment("table.md", md_source.encode("utf-8"))
+    png = _make_attachment("table_0.png", b"\x89PNG...")
+    md = _make_attachment("table_0.md", md_source.encode("utf-8"))
     inter = _make_interaction([png, md])
 
     view = CopyTableTextView()
@@ -55,8 +55,8 @@ async def test_copy_returns_ephemeral_text_for_short_table() -> None:
 async def test_copy_returns_file_for_long_table() -> None:
     # > 1900 chars triggers the file path
     md_source = "x" * 2000
-    png = _make_attachment("table.png", b"\x89PNG...")
-    md = _make_attachment("table.md", md_source.encode("utf-8"))
+    png = _make_attachment("table_0.png", b"\x89PNG...")
+    md = _make_attachment("table_0.md", md_source.encode("utf-8"))
     inter = _make_interaction([png, md])
 
     view = CopyTableTextView()
@@ -72,7 +72,7 @@ async def test_copy_returns_file_for_long_table() -> None:
 
 @pytest.mark.asyncio
 async def test_copy_handles_missing_attachment_gracefully() -> None:
-    png = _make_attachment("table.png", b"\x89PNG...")
+    png = _make_attachment("table_0.png", b"\x89PNG...")
     inter = _make_interaction([png])  # no .md sidecar
 
     view = CopyTableTextView()
@@ -85,3 +85,33 @@ async def test_copy_handles_missing_attachment_gracefully() -> None:
     sent_content = args[0] if args else kwargs.get("content")
     assert "Couldn't find" in sent_content or "couldn't find" in sent_content.lower()
     assert kwargs.get("ephemeral") is True
+
+
+# ---------------------------------------------------------------------------
+# Review I7: filename prefix-match — only ``table_*.md`` sidecars match.
+# A ``claude-response.md`` (long-upload fallback) on the same message
+# must NOT trigger the Copy button against the wrong file.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_copy_ignores_non_table_md_attachments() -> None:
+    """``claude-response.md`` is the long-upload fallback name; it must
+    not satisfy the Copy-as-text view's attachment lookup (review I7)."""
+    long_upload = _make_attachment(
+        "claude-response.md", b"this is the long-upload, not a table sidecar"
+    )
+    inter = _make_interaction([long_upload])
+
+    view = CopyTableTextView()
+    button = MagicMock()
+    await view.copy.callback.callback(view, inter, button)
+
+    inter.response.send_message.assert_awaited_once()
+    args = inter.response.send_message.call_args.args
+    kwargs = inter.response.send_message.call_args.kwargs
+    sent_content = args[0] if args else kwargs.get("content")
+    # Falls through to the "couldn't find" branch — never reads the
+    # claude-response.md by mistake.
+    assert "Couldn't find" in sent_content or "couldn't find" in sent_content.lower()
+    long_upload.read.assert_not_awaited()

--- a/tests/test_copy_table_view.py
+++ b/tests/test_copy_table_view.py
@@ -1,0 +1,87 @@
+"""Tests for CopyTableTextView persistent button (#112, #133).
+
+The view is stateless: it reads the markdown source from the parent message's
+``.md`` sidecar attachment and replies ephemerally. Tests use ``AsyncMock`` for
+the async ``attachment.read`` and ``interaction.response.send_message``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from clauded.cogs._table_view import CopyTableTextView
+
+
+def _make_attachment(filename: str, content: bytes) -> MagicMock:
+    att = MagicMock(spec=discord.Attachment)
+    att.filename = filename
+    att.read = AsyncMock(return_value=content)
+    return att
+
+
+def _make_interaction(attachments: list) -> MagicMock:
+    inter = MagicMock(spec=discord.Interaction)
+    inter.message = MagicMock()
+    inter.message.attachments = attachments
+    inter.response = MagicMock()
+    inter.response.send_message = AsyncMock()
+    return inter
+
+
+@pytest.mark.asyncio
+async def test_copy_returns_ephemeral_text_for_short_table() -> None:
+    md_source = "| a | b |\n|---|---|\n| 1 | 2 |"
+    png = _make_attachment("table.png", b"\x89PNG...")
+    md = _make_attachment("table.md", md_source.encode("utf-8"))
+    inter = _make_interaction([png, md])
+
+    view = CopyTableTextView()
+    button = MagicMock()
+    # Unwrap the _ItemCallback wrapper installed by @ui.button
+    await view.copy.callback.callback(view, inter, button)
+
+    inter.response.send_message.assert_awaited_once()
+    _, kwargs = inter.response.send_message.call_args
+    args = inter.response.send_message.call_args.args
+    sent_content = args[0] if args else kwargs.get("content")
+    assert sent_content == f"```\n{md_source}\n```"
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_copy_returns_file_for_long_table() -> None:
+    # > 1900 chars triggers the file path
+    md_source = "x" * 2000
+    png = _make_attachment("table.png", b"\x89PNG...")
+    md = _make_attachment("table.md", md_source.encode("utf-8"))
+    inter = _make_interaction([png, md])
+
+    view = CopyTableTextView()
+    button = MagicMock()
+    await view.copy.callback.callback(view, inter, button)
+
+    inter.response.send_message.assert_awaited_once()
+    _, kwargs = inter.response.send_message.call_args
+    assert "file" in kwargs
+    assert isinstance(kwargs["file"], discord.File)
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_copy_handles_missing_attachment_gracefully() -> None:
+    png = _make_attachment("table.png", b"\x89PNG...")
+    inter = _make_interaction([png])  # no .md sidecar
+
+    view = CopyTableTextView()
+    button = MagicMock()
+    await view.copy.callback.callback(view, inter, button)
+
+    inter.response.send_message.assert_awaited_once()
+    args = inter.response.send_message.call_args.args
+    kwargs = inter.response.send_message.call_args.kwargs
+    sent_content = args[0] if args else kwargs.get("content")
+    assert "Couldn't find" in sent_content or "couldn't find" in sent_content.lower()
+    assert kwargs.get("ephemeral") is True

--- a/tests/test_renderer_retries.py
+++ b/tests/test_renderer_retries.py
@@ -687,3 +687,75 @@ async def test_shadow_survives_embed_send_between_text_edits(_no_sleep):
     # Cost-footer-equivalent read MUST see the long content, not "".
     current = r._last_msg_text.rstrip(CURSOR)
     assert current.startswith("hi there, here is a long response")
+
+
+# ---------------------------------------------------------------------------
+# Review I1 — files= retry must seek(0) every stream before re-attempting.
+# Without this, a transient HTTP error mid-send would leave the BytesIO at
+# EOF on retry and Discord would receive a 0-byte attachment.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_safe_send_files_list_resets_streams_on_retry(_no_sleep):
+    """``_safe_send(files=[f1, f2])`` with one retryable 503 → both file
+    streams are rewound to position 0 before the successful attempt, and
+    a read after retry returns the original sentinel bytes."""
+    import io as _io
+    import discord
+
+    f1_bytes = b"alpha\n"
+    f2_bytes = b"png-sentinel-0123456789"
+
+    f1 = discord.File(_io.BytesIO(f1_bytes), filename="table_0.md")
+    f2 = discord.File(_io.BytesIO(f2_bytes), filename="table_0.png")
+
+    # Snapshot tell() positions when send is invoked. The first attempt
+    # will be at (0, 0) — fresh BytesIO. We then advance both streams to
+    # EOF inside the first call (mimicking discord.py reading the buffer)
+    # and raise. The renderer's between_attempts hook MUST seek(0) before
+    # the second attempt — that's the I1 contract.
+    snapshots: list[tuple[int, int]] = []
+
+    target = FakeTarget()
+
+    async def _send_with_snapshot(content=None, **kw):
+        target.send_calls += 1
+        fs = kw.get("files") or ([kw["file"]] if kw.get("file") else [])
+        snapshots.append(tuple(f.fp.tell() for f in fs))  # type: ignore[arg-type]
+        if target.send_raises:
+            exc = target.send_raises.pop(0)
+            if exc is not None:
+                # Simulate discord.py reading the buffer to EOF before
+                # the HTTP failure surfaces.
+                for f in fs:
+                    f.fp.read()
+                raise exc
+        msg = FakeMessage(content or "")
+        target.messages.append(msg)
+        return msg
+
+    target.send = _send_with_snapshot  # type: ignore[method-assign]
+    target.send_raises = [_http(503), None]
+
+    renderer = DiscordRenderer(target)
+    result = await renderer._safe_send(files=[f1, f2])
+
+    assert result is not None
+    assert target.send_calls == 2
+    # First attempt entered at (0, 0) — fresh streams.
+    assert snapshots[0] == (0, 0), f"first attempt positions: {snapshots[0]}"
+    # CRITICAL pin (I1): the second attempt also saw (0, 0) — i.e.
+    # _reset_file rewound both streams that the first attempt drained.
+    # Without the I1 fix, snapshots[1] would equal (len(f1_bytes),
+    # len(f2_bytes)).
+    assert snapshots[1] == (0, 0), (
+        f"second (retry) attempt positions: {snapshots[1]} — "
+        "_reset_file did not rewind both streams"
+    )
+    # Sentinel bytes still readable after retry succeeds.
+    f1.fp.seek(0)
+    f2.fp.seek(0)
+    assert f1.fp.read() == f1_bytes
+    assert f2.fp.read() == f2_bytes
+

--- a/tests/test_renderer_tables.py
+++ b/tests/test_renderer_tables.py
@@ -1,0 +1,290 @@
+"""Integration tests for v1.12 table PNG rendering (#134 / PRD R2 + R3.3).
+
+These tests pin the wiring between the renderer pipeline and the new
+table-extraction path:
+
+1. ``_flush`` with a buffer containing prose + a markdown table sends the
+   prose text first, then a follow-up message bearing a PNG attachment +
+   the ``.md`` sidecar + a :class:`CopyTableTextView` instance.
+2. ``_flush`` with a buffer that has no tables sends a single text
+   message and never invokes the PNG follow-up path.
+3. A markdown table nested inside a ``` code fence is NOT extracted —
+   it's left intact in the text body, and no PNG message is emitted.
+4. ``ClaudedBot.setup_hook`` registers the persistent
+   :class:`CopyTableTextView` via ``self.add_view`` so that button
+   clicks keep working across bot restarts (PRD R3.3).
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+from PIL import Image
+
+from clauded.cogs._table_view import CopyTableTextView
+from clauded.discord_renderer import DiscordRenderer
+
+
+# ---------------------------------------------------------------------------
+# Fakes — mirror the lightweight pattern in test_renderer_retries.py.
+# ---------------------------------------------------------------------------
+
+
+class FakeMessage:
+    _next_id = 0
+
+    def __init__(self, content: str = "") -> None:
+        FakeMessage._next_id += 1
+        self.id = FakeMessage._next_id
+        self.content = content
+        self.kwargs: dict = {}
+
+    async def edit(self, *, content=None, **kw):
+        if content is not None:
+            self.content = content
+        return self
+
+
+class FakeTarget:
+    """Records every ``send`` call so tests can assert on kwargs."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.messages: list[FakeMessage] = []
+        self.guild = None
+        self.parent = None
+        self.id = 1
+        self.name = "fake"
+
+    async def send(self, content=None, **kw) -> FakeMessage:
+        call = {"content": content, **kw}
+        self.calls.append(call)
+        msg = FakeMessage(content or "")
+        # Surface the kwargs on the returned message for assertions.
+        msg.kwargs = call
+        self.messages.append(msg)
+        return msg
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Skip backoff sleeps so tests stay fast."""
+    import asyncio
+
+    async def _instant(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _instant)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _png_bytes_signature_ok(b: bytes) -> bool:
+    """Confirm ``b`` is a real PNG by parsing it with Pillow."""
+    img = Image.open(io.BytesIO(b))
+    return img.format == "PNG"
+
+
+# ---------------------------------------------------------------------------
+# 1. Buffer with a table → text-then-PNG follow-up
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_buffer_with_table_sends_text_then_png_followup():
+    """Buffer = prose + table → 2 sends: text first, then PNG + view + .md."""
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+
+    buffer = (
+        "Here is a comparison of two options:\n"
+        "| Name | Score |\n"
+        "|------|-------|\n"
+        "| Alpha | 10 |\n"
+        "| Beta | 7 |\n"
+        "Pick whichever fits."
+    )
+
+    await renderer._flush(
+        live_msg=None,
+        buffer=buffer,
+        typewriter=False,
+        saw_text=True,
+        tool_msgs={},
+    )
+
+    # Exactly two messages: text body, then PNG follow-up.
+    assert len(target.calls) == 2
+
+    text_call, png_call = target.calls
+
+    # ----- Text message -----
+    text_content = text_call.get("content") or ""
+    assert "Here is a comparison" in text_content
+    assert "Pick whichever fits." in text_content
+    # The raw markdown table is NOT present in the text body — it was
+    # extracted out (a placeholder may remain).
+    assert "| Alpha | 10 |" not in text_content
+    assert "| Beta | 7 |" not in text_content
+    # The text call carries no PNG attachments.
+    assert "files" not in text_call or text_call.get("files") is None
+    assert "view" not in text_call or text_call.get("view") is None
+
+    # ----- PNG follow-up -----
+    files = png_call.get("files")
+    assert files is not None and len(files) == 2
+    filenames = sorted(f.filename for f in files)
+    assert filenames == ["table_0.md", "table_0.png"]
+    # PNG attachment is a real PNG.
+    png_file = next(f for f in files if f.filename.endswith(".png"))
+    png_file.fp.seek(0)
+    assert _png_bytes_signature_ok(png_file.fp.read())
+    # Sidecar carries the verbatim markdown source (column pipes intact).
+    md_file = next(f for f in files if f.filename.endswith(".md"))
+    md_file.fp.seek(0)
+    md_src = md_file.fp.read().decode()
+    assert "| Alpha | 10 |" in md_src
+    assert "| Beta | 7 |" in md_src
+    # Persistent view attached.
+    view = png_call.get("view")
+    assert isinstance(view, CopyTableTextView)
+    # _last_msg points at the PNG follow-up; shadow reset to "" so the
+    # cost-footer splicer can't reach into the attachment-only message.
+    assert renderer._last_msg is target.messages[-1]
+    assert renderer._last_msg_text == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. Buffer with no tables → existing fast-path behaviour preserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_buffer_no_table_unchanged():
+    """No table → exactly one send, no files / view, content is original prose."""
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+
+    buffer = "Just regular prose without any markdown table content."
+
+    await renderer._flush(
+        live_msg=None,
+        buffer=buffer,
+        typewriter=False,
+        saw_text=True,
+        tool_msgs={},
+    )
+
+    assert len(target.calls) == 1
+    only = target.calls[0]
+    assert only.get("content") == buffer
+    # No attachments, no view — pure text send.
+    assert only.get("files") is None
+    assert only.get("file") is None
+    assert only.get("view") is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Tables nested in a code fence are not extracted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_table_in_code_fence_not_replaced():
+    """A ``|...|`` block inside ``` fence is left verbatim; no PNG message."""
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+
+    buffer = (
+        "Example output:\n"
+        "```\n"
+        "| id | label |\n"
+        "|----|-------|\n"
+        "| 1  | one   |\n"
+        "```\n"
+        "End of example."
+    )
+
+    await renderer._flush(
+        live_msg=None,
+        buffer=buffer,
+        typewriter=False,
+        saw_text=True,
+        tool_msgs={},
+    )
+
+    # Exactly one send — no PNG follow-up because the table is fenced.
+    assert len(target.calls) == 1
+    only = target.calls[0]
+    # The fenced table survives verbatim in the text body.
+    text = only.get("content") or ""
+    assert "| id | label |" in text
+    assert "| 1  | one   |" in text
+    assert "End of example." in text
+    # And no follow-up attachment / view was sent.
+    assert only.get("files") is None
+    assert only.get("view") is None
+
+
+# ---------------------------------------------------------------------------
+# 4. setup_hook registers the persistent CopyTableTextView
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_persistent_view_registered_at_startup():
+    """``ClaudedBot.setup_hook`` must call ``add_view(CopyTableTextView())``.
+
+    Required by PRD R3.3 so the Copy-as-text button keeps responding to
+    clicks after a bot restart (custom_id=``copy_table_text`` persistent).
+    """
+    from clauded.bot import ClaudedBot
+
+    # Build a bot instance without going through ``commands.Bot.__init__``
+    # (it wants a running event loop + token). We only need the
+    # ``setup_hook`` method bound to a real instance so the
+    # ``self.add_view(...)`` call exercised below dispatches correctly.
+    bot = ClaudedBot.__new__(ClaudedBot)
+
+    add_view_calls: list = []
+    bot.add_view = MagicMock(side_effect=lambda v, **kw: add_view_calls.append(v))
+    bot._cleanup_task = MagicMock()
+    bot._cleanup_task.start = MagicMock()
+    # NB: ``ClaudedBot.tree`` is a property inherited from ``commands.Bot``
+    # — we can't replace it on a ``__new__``-built instance, but that's
+    # fine: the ``add_view`` call we care about runs BEFORE the
+    # ``self.tree.add_command(...)`` block, so any failure further down
+    # is caught by the ``try/except`` below without falsifying the assert.
+
+    # Side-step the ``claude --version`` subprocess.
+    with patch("asyncio.create_subprocess_exec", new=AsyncMock(side_effect=Exception("no claude"))):
+        try:
+            await ClaudedBot.setup_hook(bot)
+        except Exception:
+            # The later slash-command registration / tree.sync block
+            # fails on a half-initialised bot; the ``add_view`` invariant
+            # is verified BEFORE that block, which is the only thing we
+            # care about pinning here.
+            pass
+
+    # Exactly one ``add_view`` call, with a CopyTableTextView instance.
+    assert len(add_view_calls) == 1, (
+        f"expected 1 add_view call, got {len(add_view_calls)}"
+    )
+    assert isinstance(add_view_calls[0], CopyTableTextView)
+    # The view's button uses the persistent custom_id required by R3.3.
+    custom_ids = [
+        getattr(c, "custom_id", None) for c in add_view_calls[0].children
+    ]
+    assert "copy_table_text" in custom_ids

--- a/tests/test_renderer_tables.py
+++ b/tests/test_renderer_tables.py
@@ -528,3 +528,107 @@ async def test_png_render_oversized_falls_back_to_verbatim():
     assert "Outro." in text
     # Placeholder never appears in the returned text.
     assert "[TABLE_PNG_" not in text
+
+
+# ---------------------------------------------------------------------------
+# 10. Bug C (v1.12 smoke): streaming msg must not retain raw table markdown
+# after finalize emits the PNG follow-up. Pre-fix, D1/D3 threads showed
+# ``[1]=raw markdown table text`` then ``[2]=PNG`` — user saw duplicated
+# content. Fix: ``_safe_edit`` substitutes a single space for empty
+# content (avoids Discord 50006), so ``_finalize_typewriter`` actually
+# manages to clear the streaming cursor msg of the table text before
+# the PNG is sent.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_typewriter_clears_streaming_msg_of_leaked_table():
+    """Buffer is a bare markdown table (no surrounding prose) — exactly
+    D1's shape. The pre-existing ``live_msg`` (the typewriter cursor)
+    held the raw table text while streaming. After ``_finalize_typewriter``
+    runs, the cursor msg's final ``content`` must NOT contain the raw
+    ``|---|---|`` separator or data rows — those belong only in the PNG
+    follow-up message.
+    """
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+
+    # Pre-existing cursor msg holds the raw streamed table text
+    # (this is what the typewriter would have accumulated mid-stream).
+    streaming_content = (
+        "| Name | Score |\n"
+        "|------|-------|\n"
+        "| Alpha | 10 |\n"
+        "| Beta | 7 |"
+    )
+    live_msg = FakeMessage(streaming_content)
+
+    # The finalize call sees the same content as ``buffer`` — entirely
+    # a table, no surrounding prose. ``stripped_text`` is therefore just
+    # the placeholder, ``first_seg`` is empty, and the code path that
+    # previously crashed with Discord 50006 is exercised.
+    buffer = streaming_content
+
+    await renderer._finalize_typewriter(live_msg, buffer)
+
+    # Streaming msg must have been cleared of the leaked table text.
+    assert "|---|---|" not in live_msg.content, "raw separator leaked"
+    assert "|------|-------|" not in live_msg.content, "raw separator leaked"
+    assert "| Alpha | 10 |" not in live_msg.content, "raw data row leaked"
+    assert "| Beta | 7 |" not in live_msg.content, "raw data row leaked"
+
+    # And the PNG follow-up went out as a separate message.
+    png_calls = [c for c in target.calls if c.get("files")]
+    assert len(png_calls) == 1
+    filenames = sorted(f.filename for f in png_calls[0]["files"])
+    assert filenames == ["table_0.md", "table_0.png"]
+
+
+# ---------------------------------------------------------------------------
+# 11. Bug D-2 (v1.12 smoke): _safe_edit must not pass content="" to
+# Discord — that returns HTTP 400 code 50006. Substitute a single space
+# so the edit succeeds and the streaming cursor msg actually gets cleared.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_safe_edit_skips_empty_content():
+    """Calling ``_safe_edit(msg, content="")`` must not send ``content=""``
+    to Discord (avoids 50006). The fix substitutes a single space so the
+    edit goes through and the streaming msg gets cleared rather than
+    stuck at its prior content.
+    """
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+
+    # Capture every edit kwargs to assert the substitution.
+    recorded: list[dict] = []
+
+    class RecordingMessage(FakeMessage):
+        async def edit(self, *, content=None, **kw):
+            recorded.append({"content": content, **kw})
+            if content is not None:
+                self.content = content
+            return self
+
+    msg = RecordingMessage("prior content")
+
+    ok = await renderer._safe_edit(msg, content="")
+    assert ok is True
+
+    # Exactly one edit happened — and the content sent to Discord was
+    # NOT the empty string. Either it's been substituted with a non-empty
+    # fallback (space) or the call was skipped entirely; both satisfy
+    # "never send content=''" to Discord.
+    edit_calls = [r for r in recorded if r.get("content") is not None]
+    if edit_calls:
+        # Substitute path: content is non-empty.
+        for r in edit_calls:
+            assert r["content"] != "", "must not send content='' to Discord"
+            assert len(r["content"]) > 0
+    # No matter which path, the prior content must NOT survive (Bug C
+    # would re-emerge if the streaming msg kept its raw-table text).
+    # The fallback-space path clears it; the skip path leaves it. Both
+    # are acceptable per the v1.12 spec — but the streaming-msg test
+    # above pins the user-visible behaviour.
+

--- a/tests/test_renderer_tables.py
+++ b/tests/test_renderer_tables.py
@@ -1,26 +1,25 @@
-"""Integration tests for v1.12 table PNG rendering (#134 / PRD R2 + R3.3).
+"""Integration tests for v1.12 table PNG rendering (PRD R2 + R3.3).
 
-These tests pin the wiring between the renderer pipeline and the new
-table-extraction path:
+These tests pin the wiring between the renderer pipeline and the table-
+extraction path:
 
-1. ``_flush`` with a buffer containing prose + a markdown table sends the
-   prose text first, then a follow-up message bearing a PNG attachment +
-   the ``.md`` sidecar + a :class:`CopyTableTextView` instance.
+1. ``_flush`` with a buffer containing prose-before + a table + prose-after
+   sends three messages in order: text-before, PNG follow-up, text-after.
+   This is the PRD R2.2 interleaving contract (review C1).
 2. ``_flush`` with a buffer that has no tables sends a single text
    message and never invokes the PNG follow-up path.
 3. A markdown table nested inside a ``` code fence is NOT extracted —
    it's left intact in the text body, and no PNG message is emitted.
-4. ``ClaudedBot.setup_hook`` registers the persistent
-   :class:`CopyTableTextView` via ``self.add_view`` so that button
-   clicks keep working across bot restarts (PRD R3.3).
+4. ``CopyTableTextView`` is a persistent view with the right custom_id
+   (review simplicity: lightweight replacement for the prior heavy
+   ``setup_hook`` integration test).
 """
 
 from __future__ import annotations
 
 import io
-from unittest.mock import AsyncMock, MagicMock, patch
+import logging
 
-import discord
 import pytest
 from PIL import Image
 
@@ -97,13 +96,19 @@ def _png_bytes_signature_ok(b: bytes) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# 1. Buffer with a table → text-then-PNG follow-up
+# 1. Buffer with a table → interleaved text-before, PNG, text-after
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_buffer_with_table_sends_text_then_png_followup():
-    """Buffer = prose + table → 2 sends: text first, then PNG + view + .md."""
+    """Buffer = prose-before + table + prose-after → 3 sends in PRD R2.2 order.
+
+    Pre-fix the call sequence was [text-with-placeholder, PNG] and the
+    user saw ``[TABLE_PNG_0]`` literally in the text body (review C1).
+    Post-fix it's [text-before, PNG, text-after] with no placeholder text
+    in any user-visible content.
+    """
     target = FakeTarget()
     renderer = DiscordRenderer(target)
 
@@ -124,22 +129,20 @@ async def test_buffer_with_table_sends_text_then_png_followup():
         tool_msgs={},
     )
 
-    # Exactly two messages: text body, then PNG follow-up.
-    assert len(target.calls) == 2
+    # PRD R2.2 — three messages: text-before, PNG, text-after.
+    assert len(target.calls) == 3
+    pre_text_call, png_call, post_text_call = target.calls
 
-    text_call, png_call = target.calls
-
-    # ----- Text message -----
-    text_content = text_call.get("content") or ""
-    assert "Here is a comparison" in text_content
-    assert "Pick whichever fits." in text_content
-    # The raw markdown table is NOT present in the text body — it was
-    # extracted out (a placeholder may remain).
-    assert "| Alpha | 10 |" not in text_content
-    assert "| Beta | 7 |" not in text_content
-    # The text call carries no PNG attachments.
-    assert "files" not in text_call or text_call.get("files") is None
-    assert "view" not in text_call or text_call.get("view") is None
+    # ----- Pre-table text -----
+    pre_content = pre_text_call.get("content") or ""
+    assert "Here is a comparison" in pre_content
+    # No placeholder leak (review C1 assertion).
+    assert "[TABLE_PNG_" not in pre_content, "placeholder leaked to Discord"
+    # No raw table rows in the prose body.
+    assert "| Alpha | 10 |" not in pre_content
+    assert "| Beta | 7 |" not in pre_content
+    assert pre_text_call.get("files") is None
+    assert pre_text_call.get("view") is None
 
     # ----- PNG follow-up -----
     files = png_call.get("files")
@@ -159,10 +162,19 @@ async def test_buffer_with_table_sends_text_then_png_followup():
     # Persistent view attached.
     view = png_call.get("view")
     assert isinstance(view, CopyTableTextView)
-    # _last_msg points at the PNG follow-up; shadow reset to "" so the
-    # cost-footer splicer can't reach into the attachment-only message.
+
+    # ----- Post-table text -----
+    post_content = post_text_call.get("content") or ""
+    assert "Pick whichever fits." in post_content
+    assert "[TABLE_PNG_" not in post_content, "placeholder leaked to Discord"
+    assert post_text_call.get("files") is None
+    assert post_text_call.get("view") is None
+
+    # ``_last_msg`` ends pointing at the final text send (the prose tail).
     assert renderer._last_msg is target.messages[-1]
-    assert renderer._last_msg_text == ""
+    # Shadow tracks the final text content so the cost-footer splicer can
+    # safely append onto the prose tail.
+    assert renderer._last_msg_text == post_content
 
 
 # ---------------------------------------------------------------------------
@@ -232,59 +244,210 @@ async def test_table_in_code_fence_not_replaced():
     assert "| id | label |" in text
     assert "| 1  | one   |" in text
     assert "End of example." in text
+    assert "[TABLE_PNG_" not in text, "placeholder leaked to Discord"
     # And no follow-up attachment / view was sent.
     assert only.get("files") is None
     assert only.get("view") is None
 
 
 # ---------------------------------------------------------------------------
-# 4. setup_hook registers the persistent CopyTableTextView
+# 4. CopyTableTextView has persistent custom_id
+# ---------------------------------------------------------------------------
+
+
+def test_copy_view_has_persistent_custom_id():
+    """Lightweight pin for PRD R3.3: the Copy-as-text view is persistent
+    (``timeout=None``) and its button uses the stable ``custom_id`` that
+    ``bot.setup_hook``'s ``add_view`` global handler dispatches against.
+
+    Replaces the heavier ``test_persistent_view_registered_at_startup``
+    which had to drive a half-initialised ``ClaudedBot`` instance.
+    """
+    view = CopyTableTextView()
+    assert view.timeout is None  # persistent across restarts
+    custom_ids = [getattr(c, "custom_id", None) for c in view.children]
+    assert "copy_table_text" in custom_ids
+
+
+# ---------------------------------------------------------------------------
+# 5. Long-upload .md path re-splices markdown source (review C3)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_persistent_view_registered_at_startup():
-    """``ClaudedBot.setup_hook`` must call ``add_view(CopyTableTextView())``.
-
-    Required by PRD R3.3 so the Copy-as-text button keeps responding to
-    clicks after a bot restart (custom_id=``copy_table_text`` persistent).
+async def test_long_upload_md_contains_table_source_not_placeholder(monkeypatch):
+    """When ``_flush`` falls back to ``claude-response.md`` upload, the
+    file body must contain the original markdown table — NOT a leaked
+    ``[TABLE_PNG_N]`` placeholder (review C3).
     """
-    from clauded.bot import ClaudedBot
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
 
-    # Build a bot instance without going through ``commands.Bot.__init__``
-    # (it wants a running event loop + token). We only need the
-    # ``setup_hook`` method bound to a real instance so the
-    # ``self.add_view(...)`` call exercised below dispatches correctly.
-    bot = ClaudedBot.__new__(ClaudedBot)
-
-    add_view_calls: list = []
-    bot.add_view = MagicMock(side_effect=lambda v, **kw: add_view_calls.append(v))
-    bot._cleanup_task = MagicMock()
-    bot._cleanup_task.start = MagicMock()
-    # NB: ``ClaudedBot.tree`` is a property inherited from ``commands.Bot``
-    # — we can't replace it on a ``__new__``-built instance, but that's
-    # fine: the ``add_view`` call we care about runs BEFORE the
-    # ``self.tree.add_command(...)`` block, so any failure further down
-    # is caught by the ``try/except`` below without falsifying the assert.
-
-    # Side-step the ``claude --version`` subprocess.
-    with patch("asyncio.create_subprocess_exec", new=AsyncMock(side_effect=Exception("no claude"))):
-        try:
-            await ClaudedBot.setup_hook(bot)
-        except Exception:
-            # The later slash-command registration / tree.sync block
-            # fails on a half-initialised bot; the ``add_view`` invariant
-            # is verified BEFORE that block, which is the only thing we
-            # care about pinning here.
-            pass
-
-    # Exactly one ``add_view`` call, with a CopyTableTextView instance.
-    assert len(add_view_calls) == 1, (
-        f"expected 1 add_view call, got {len(add_view_calls)}"
+    # Force the >4-chunk long-upload branch.
+    monkeypatch.setattr(
+        DiscordRenderer,
+        "_smart_split",
+        staticmethod(lambda *a, **kw: ["c1", "c2", "c3", "c4", "c5"]),
     )
-    assert isinstance(add_view_calls[0], CopyTableTextView)
-    # The view's button uses the persistent custom_id required by R3.3.
-    custom_ids = [
-        getattr(c, "custom_id", None) for c in add_view_calls[0].children
-    ]
-    assert "copy_table_text" in custom_ids
+
+    buffer = (
+        "Intro.\n"
+        "| A | B |\n"
+        "|---|---|\n"
+        "| 1 | 2 |\n"
+        "Outro."
+    )
+
+    await renderer._flush(
+        live_msg=None,
+        buffer=buffer,
+        typewriter=False,
+        saw_text=True,
+        tool_msgs={},
+    )
+
+    # First send is the upload (content + file), follow-up is the PNG.
+    upload_call = next(c for c in target.calls if c.get("file") is not None)
+    f = upload_call["file"]
+    f.fp.seek(0)
+    body = f.fp.read().decode()
+    # The .md must NOT carry placeholders.
+    assert "[TABLE_PNG_" not in body, "placeholder leaked into .md upload"
+    # And the original table markdown is back in the file body.
+    assert "| A | B |" in body
+    assert "| 1 | 2 |" in body
+    # PNG follow-up still went out.
+    assert any(c.get("files") for c in target.calls)
+
+
+# ---------------------------------------------------------------------------
+# 6. Render exception falls back to verbatim emit (review C2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_render_exception_emits_table_verbatim(monkeypatch):
+    """If ``render_table_png`` raises, the original table lines must come
+    back in the text body (no exception propagates, no silent drop).
+    """
+    from clauded import discord_renderer as dr_mod
+
+    def _boom(_headers, _rows):
+        raise RuntimeError("simulated Pillow failure")
+
+    monkeypatch.setattr(dr_mod, "render_table_png", _boom)
+
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+
+    buffer = (
+        "Before.\n"
+        "| A | B |\n"
+        "|---|---|\n"
+        "| 1 | 2 |\n"
+        "After."
+    )
+
+    await renderer._flush(
+        live_msg=None,
+        buffer=buffer,
+        typewriter=False,
+        saw_text=True,
+        tool_msgs={},
+    )
+
+    # Exactly one text message — no PNG follow-up was sent.
+    assert all(c.get("files") is None for c in target.calls)
+    # The table source survives verbatim in the user-visible text.
+    text = " ".join((c.get("content") or "") for c in target.calls)
+    assert "Before." in text
+    assert "After." in text
+    assert "| A | B |" in text
+    assert "| 1 | 2 |" in text
+    assert "[TABLE_PNG_" not in text, "placeholder leaked on render failure"
+
+
+# ---------------------------------------------------------------------------
+# 7. _send_table_renders logs on permanent drop (review I2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_table_renders_logs_on_permanent_drop(_no_sleep, caplog):
+    """If ``_safe_send`` returns ``None`` (permanent failure), the loop
+    must log ``ERROR`` so the silent drop becomes visible (review I2).
+    """
+    from clauded.discord_renderer import TableRender
+
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+
+    # Stub _safe_send to permanently fail (returns None).
+    async def _always_none(*_a, **_kw):
+        return None
+    renderer._safe_send = _always_none  # type: ignore[assignment]
+
+    fake_render = TableRender(
+        headers=["A", "B"],
+        rows=[["1", "2"]],
+        png_bytes=b"\x89PNGfake",
+        markdown_source="| A | B |\n|---|---|\n| 1 | 2 |",
+        placeholder="\n[TABLE_PNG_0]\n",
+    )
+
+    with caplog.at_level(logging.ERROR, logger="clauded.discord_renderer"):
+        await renderer._send_table_renders([fake_render])
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1
+    msg = errors[0].getMessage()
+    assert "Table 0" in msg
+    assert "PNG send permanently failed" in msg
+
+
+# ---------------------------------------------------------------------------
+# 8. Cost-footer × PNG message contract (review I8)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cost_footer_attaches_to_png_message():
+    """Contract pin (manager pick (a)): the cost footer rides the PNG
+    message — after ``_flush`` finishes for a buffer that ends in a table,
+    ``renderer._last_msg`` is the PNG message and a subsequent
+    ``_safe_edit`` of ``_last_msg`` with the footer content overwrites
+    that PNG message's content (attachments survive, per discord.py).
+    """
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+
+    # Buffer ENDS with a table — no prose tail follows.
+    buffer = (
+        "Compare:\n"
+        "| A | B |\n"
+        "|---|---|\n"
+        "| 1 | 2 |\n"
+    )
+    await renderer._flush(
+        live_msg=None,
+        buffer=buffer,
+        typewriter=False,
+        saw_text=True,
+        tool_msgs={},
+    )
+
+    # Last call must be the PNG send (files= present).
+    last_call = target.calls[-1]
+    assert last_call.get("files") is not None, "PNG must be last send"
+    assert renderer._last_msg is target.messages[-1]
+    # Shadow reset to "" — see _send_table_renders docstring + #113.
+    assert renderer._last_msg_text == ""
+
+    # Simulate the cost-footer write path: edit the current _last_msg
+    # (a PNG) with the footer string. ``Message.edit(content=…)`` does
+    # NOT strip attachments — the test pins that the renderer's shadow
+    # tracks the new content for any subsequent splice.
+    footer = "-# 💰 $0.10 │ ⏱️ 5.0s"
+    ok = await renderer._safe_edit(renderer._last_msg, content=footer)
+    assert ok is True
+    assert renderer._last_msg.content == footer

--- a/tests/test_renderer_tables.py
+++ b/tests/test_renderer_tables.py
@@ -534,10 +534,10 @@ async def test_png_render_oversized_falls_back_to_verbatim():
 # 10. Bug C (v1.12 smoke): streaming msg must not retain raw table markdown
 # after finalize emits the PNG follow-up. Pre-fix, D1/D3 threads showed
 # ``[1]=raw markdown table text`` then ``[2]=PNG`` — user saw duplicated
-# content. Fix: ``_safe_edit`` substitutes a single space for empty
-# content (avoids Discord 50006), so ``_finalize_typewriter`` actually
-# manages to clear the streaming cursor msg of the table text before
-# the PNG is sent.
+# content. Fix: ``_safe_edit`` substitutes U+200B (zero-width space) for
+# empty content (avoids Discord 50006 which also rejects ``" "``), so
+# ``_finalize_typewriter`` actually manages to clear the streaming cursor
+# msg of the table text before the PNG is sent.
 # ---------------------------------------------------------------------------
 
 
@@ -548,7 +548,8 @@ async def test_finalize_typewriter_clears_streaming_msg_of_leaked_table():
     held the raw table text while streaming. After ``_finalize_typewriter``
     runs, the cursor msg's final ``content`` must NOT contain the raw
     ``|---|---|`` separator or data rows — those belong only in the PNG
-    follow-up message.
+    follow-up message. The user-visible state is "cleared" via U+200B
+    (zero-width space), which Discord accepts as non-empty.
     """
     target = FakeTarget()
     renderer = DiscordRenderer(target)
@@ -577,6 +578,15 @@ async def test_finalize_typewriter_clears_streaming_msg_of_leaked_table():
     assert "| Alpha | 10 |" not in live_msg.content, "raw data row leaked"
     assert "| Beta | 7 |" not in live_msg.content, "raw data row leaked"
 
+    # Positive assertion: live_msg.content is U+200B (zero-width space),
+    # the substitute used by ``_safe_edit`` for empty content. Discord
+    # rejects both "" and " " with 50006; U+200B renders invisibly so
+    # the user sees the msg as cleared.
+    assert live_msg.content == "\u200b", (
+        "expected U+200B substitute; got "
+        f"{live_msg.content!r}"
+    )
+
     # And the PNG follow-up went out as a separate message.
     png_calls = [c for c in target.calls if c.get("files")]
     assert len(png_calls) == 1
@@ -585,18 +595,20 @@ async def test_finalize_typewriter_clears_streaming_msg_of_leaked_table():
 
 
 # ---------------------------------------------------------------------------
-# 11. Bug D-2 (v1.12 smoke): _safe_edit must not pass content="" to
-# Discord — that returns HTTP 400 code 50006. Substitute a single space
-# so the edit succeeds and the streaming cursor msg actually gets cleared.
+# 11. Bug D-2 (v1.12 smoke): _safe_edit must not pass content="" — or
+# content=" " — to Discord; both return HTTP 400 code 50006 ("Cannot
+# send an empty message"). Substitute U+200B (zero-width space) so the
+# edit succeeds and the streaming cursor msg actually gets cleared.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_safe_edit_skips_empty_content():
-    """Calling ``_safe_edit(msg, content="")`` must not send ``content=""``
-    to Discord (avoids 50006). The fix substitutes a single space so the
-    edit goes through and the streaming msg gets cleared rather than
-    stuck at its prior content.
+    """Calling ``_safe_edit(msg, content="")`` must substitute U+200B
+    (zero-width space) before edit — Discord rejects both ``""`` and
+    ``" "`` (single space) with HTTP 400 code 50006. U+200B is the
+    canonical non-empty-but-invisible substitute so the streaming msg
+    gets cleared rather than stuck at its prior content.
     """
     target = FakeTarget()
     renderer = DiscordRenderer(target)
@@ -616,19 +628,18 @@ async def test_safe_edit_skips_empty_content():
     ok = await renderer._safe_edit(msg, content="")
     assert ok is True
 
-    # Exactly one edit happened — and the content sent to Discord was
-    # NOT the empty string. Either it's been substituted with a non-empty
-    # fallback (space) or the call was skipped entirely; both satisfy
-    # "never send content=''" to Discord.
+    # Exactly one edit happened, and the content sent to Discord was
+    # the U+200B zero-width space — NOT empty, NOT a plain space.
     edit_calls = [r for r in recorded if r.get("content") is not None]
-    if edit_calls:
-        # Substitute path: content is non-empty.
-        for r in edit_calls:
-            assert r["content"] != "", "must not send content='' to Discord"
-            assert len(r["content"]) > 0
-    # No matter which path, the prior content must NOT survive (Bug C
-    # would re-emerge if the streaming msg kept its raw-table text).
-    # The fallback-space path clears it; the skip path leaves it. Both
-    # are acceptable per the v1.12 spec — but the streaming-msg test
-    # above pins the user-visible behaviour.
+    assert len(edit_calls) == 1, (
+        f"expected exactly one edit call; got {len(edit_calls)}"
+    )
+    sent = edit_calls[0]["content"]
+    assert sent == "\u200b", (
+        "must substitute U+200B (not '' and not ' '); "
+        f"got {sent!r}"
+    )
+    # And the prior content did NOT survive — Bug C would re-emerge
+    # if the streaming msg kept its raw-table text.
+    assert msg.content == "\u200b"
 

--- a/tests/test_renderer_tables.py
+++ b/tests/test_renderer_tables.py
@@ -451,3 +451,80 @@ async def test_cost_footer_attaches_to_png_message():
     ok = await renderer._safe_edit(renderer._last_msg, content=footer)
     assert ok is True
     assert renderer._last_msg.content == footer
+
+
+# ---------------------------------------------------------------------------
+# 9. Pillow defensive fallback (#135 / PRD R6 + acceptance E)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_pillow_falls_back_to_code_fence(monkeypatch):
+    """If Pillow is unavailable, ``_extract_and_render_tables`` short-circuits
+    to the legacy ``_format_tables`` code-fence wrap and returns zero
+    :class:`TableRender` instances. Bot must not crash; user sees the
+    table inside a ``` fence rather than as a PNG attachment
+    (PRD R6 + acceptance E).
+    """
+    from clauded import discord_renderer as dr_mod
+
+    # Simulate Pillow / table_png import failure at module load time.
+    monkeypatch.setattr(dr_mod, "PILLOW_AVAILABLE", False)
+
+    buffer = (
+        "Before.\n"
+        "| Name | Score |\n"
+        "|------|-------|\n"
+        "| Alpha | 10 |\n"
+        "| Beta | 7 |\n"
+        "After."
+    )
+
+    text, renders = await DiscordRenderer._extract_and_render_tables(buffer)
+
+    # No PNG renders produced — caller falls through to its text-only path.
+    assert renders == []
+
+    # Legacy code-fence wrap: the table lines survive verbatim sandwiched
+    # between a pair of ``` fences (the format produced by
+    # ``DiscordRenderer._format_tables``).
+    assert "```" in text
+    assert "| Name | Score |" in text
+    assert "| Alpha | 10 |" in text
+    assert "| Beta | 7 |" in text
+    # Surrounding prose is preserved.
+    assert "Before." in text
+    assert "After." in text
+    # No placeholder ever emitted on the fallback path.
+    assert "[TABLE_PNG_" not in text
+
+
+@pytest.mark.asyncio
+async def test_png_render_oversized_falls_back_to_verbatim():
+    """A 25-column table trips the ``MAX_COLS=20`` guard in
+    :func:`table_png.render_table_png` → ``ValueError``. The existing
+    per-table ``except Exception`` in ``_extract_and_render_tables``
+    (C2) catches it and emits the original lines verbatim — the
+    placeholder must NOT leak into the returned text and no
+    :class:`TableRender` is produced (#135).
+    """
+    # Build a 25-column table — exceeds MAX_COLS (20).
+    n_cols = 25
+    header = "| " + " | ".join(f"H{i}" for i in range(n_cols)) + " |"
+    sep = "|" + "|".join(["---"] * n_cols) + "|"
+    row = "| " + " | ".join(str(i) for i in range(n_cols)) + " |"
+    buffer = f"Intro.\n{header}\n{sep}\n{row}\nOutro."
+
+    text, renders = await DiscordRenderer._extract_and_render_tables(buffer)
+
+    # No renders — the oversize guard tripped, caught by C2 try/except.
+    assert renders == []
+    # Table lines are emitted verbatim (NOT replaced by a placeholder).
+    assert header in text
+    assert sep in text
+    assert row in text
+    # Surrounding prose preserved.
+    assert "Intro." in text
+    assert "Outro." in text
+    # Placeholder never appears in the returned text.
+    assert "[TABLE_PNG_" not in text

--- a/tests/test_table_extraction.py
+++ b/tests/test_table_extraction.py
@@ -1,0 +1,129 @@
+"""Tests for ``DiscordRenderer._extract_and_render_tables`` (v1.12 / #132).
+
+Spec: docs/prd/v1.12-table-rendering.md R1 and issue #132.
+
+Six tests covering well-formed extraction, code-fence preservation, malformed
+input, ordering across multiple tables, single-column rejection, and verbatim
+preservation of ``markdown_source`` for the Copy-as-text button (#133).
+"""
+from __future__ import annotations
+
+import io
+
+from PIL import Image
+
+from clauded.discord_renderer import DiscordRenderer, TableRender
+
+
+def _is_png(b: bytes) -> bool:
+    img = Image.open(io.BytesIO(b))
+    return img.format == "PNG"
+
+
+def test_simple_table_extracted():
+    """A plain markdown table → 1 TableRender + text-with-placeholder."""
+    text = (
+        "Here is a table:\n"
+        "| Name | Age |\n"
+        "|------|-----|\n"
+        "| Alice | 30 |\n"
+        "| Bob | 25 |\n"
+        "End."
+    )
+    out, renders = DiscordRenderer._extract_and_render_tables(text)
+    assert len(renders) == 1
+    r = renders[0]
+    assert isinstance(r, TableRender)
+    assert r.headers == ["Name", "Age"]
+    assert r.rows == [["Alice", "30"], ["Bob", "25"]]
+    assert _is_png(r.png_bytes)
+    # Placeholder replaces the table in the returned text.
+    assert r.placeholder == "\n[TABLE_PNG_0]\n"
+    assert r.placeholder in out
+    assert "| Alice | 30 |" not in out
+    assert "Here is a table:" in out
+    assert "End." in out
+
+
+def test_table_in_code_fence_left_alone():
+    """Tables inside ``` fences are passed through verbatim, no extraction."""
+    text = (
+        "Output:\n"
+        "```\n"
+        "| id | name |\n"
+        "|----|------|\n"
+        "| 1  | Alice |\n"
+        "```\n"
+        "Done."
+    )
+    out, renders = DiscordRenderer._extract_and_render_tables(text)
+    assert renders == []
+    # Text comes back unchanged.
+    assert out == text
+
+
+def test_malformed_table_not_extracted():
+    """Header row with no separator row → not a table, verbatim."""
+    text = (
+        "Heading:\n"
+        "| Name | Age |\n"
+        "| Alice | 30 |\n"
+        "End."
+    )
+    out, renders = DiscordRenderer._extract_and_render_tables(text)
+    assert renders == []
+    # The pipe lines survive untouched.
+    assert "| Name | Age |" in out
+    assert "| Alice | 30 |" in out
+
+
+def test_multiple_tables_each_rendered():
+    """Two well-formed tables separated by prose → 2 TableRenders, in order."""
+    text = (
+        "First:\n"
+        "| A | B |\n"
+        "|---|---|\n"
+        "| 1 | 2 |\n"
+        "\nMiddle paragraph.\n\n"
+        "Second:\n"
+        "| X | Y |\n"
+        "|---|---|\n"
+        "| 9 | 8 |\n"
+        "End."
+    )
+    out, renders = DiscordRenderer._extract_and_render_tables(text)
+    assert len(renders) == 2
+    assert renders[0].placeholder == "\n[TABLE_PNG_0]\n"
+    assert renders[1].placeholder == "\n[TABLE_PNG_1]\n"
+    assert renders[0].headers == ["A", "B"]
+    assert renders[1].headers == ["X", "Y"]
+    # Ordering preserved in the output text.
+    assert out.index("[TABLE_PNG_0]") < out.index("[TABLE_PNG_1]")
+    assert "Middle paragraph." in out
+
+
+def test_single_column_table_not_extracted():
+    """``| Header |`` style single-column tables are emitted verbatim."""
+    text = (
+        "Single column:\n"
+        "| Header |\n"
+        "|--------|\n"
+        "| only |\n"
+        "End."
+    )
+    out, renders = DiscordRenderer._extract_and_render_tables(text)
+    assert renders == []
+    assert "| Header |" in out
+    assert "| only |" in out
+
+
+def test_markdown_source_preserved():
+    """``TableRender.markdown_source`` equals the original table text verbatim."""
+    header = "| Col1 | Col2 |"
+    sep = "|------|------|"
+    row1 = "| a    | b    |"
+    row2 = "| c    | d    |"
+    text = "Prelude.\n" + "\n".join([header, sep, row1, row2]) + "\nEpilogue."
+    _, renders = DiscordRenderer._extract_and_render_tables(text)
+    assert len(renders) == 1
+    assert renders[0].markdown_source == "\n".join([header, sep, row1, row2])

--- a/tests/test_table_extraction.py
+++ b/tests/test_table_extraction.py
@@ -1,15 +1,21 @@
-"""Tests for ``DiscordRenderer._extract_and_render_tables`` (v1.12 / #132).
+"""Tests for ``DiscordRenderer._extract_and_render_tables`` (v1.12).
 
-Spec: docs/prd/v1.12-table-rendering.md R1 and issue #132.
+Spec: docs/prd/v1.12-table-rendering.md R1.
 
-Six tests covering well-formed extraction, code-fence preservation, malformed
-input, ordering across multiple tables, single-column rejection, and verbatim
-preservation of ``markdown_source`` for the Copy-as-text button (#133).
+Tests cover well-formed extraction, code-fence preservation, malformed
+input, ordering across multiple tables, single-column rejection, verbatim
+preservation of ``markdown_source`` for the Copy-as-text button, header-only
+rejection (R1.4), empty-body cell preservation (R6.4), and current
+"no escape" semantics for ``\\|`` inside cells.
+
+``_extract_and_render_tables`` is async (dispatches PNG render through
+``asyncio.to_thread`` — review I3), so tests run under ``pytest.mark.asyncio``.
 """
 from __future__ import annotations
 
 import io
 
+import pytest
 from PIL import Image
 
 from clauded.discord_renderer import DiscordRenderer, TableRender
@@ -20,7 +26,8 @@ def _is_png(b: bytes) -> bool:
     return img.format == "PNG"
 
 
-def test_simple_table_extracted():
+@pytest.mark.asyncio
+async def test_simple_table_extracted():
     """A plain markdown table → 1 TableRender + text-with-placeholder."""
     text = (
         "Here is a table:\n"
@@ -30,7 +37,7 @@ def test_simple_table_extracted():
         "| Bob | 25 |\n"
         "End."
     )
-    out, renders = DiscordRenderer._extract_and_render_tables(text)
+    out, renders = await DiscordRenderer._extract_and_render_tables(text)
     assert len(renders) == 1
     r = renders[0]
     assert isinstance(r, TableRender)
@@ -45,7 +52,8 @@ def test_simple_table_extracted():
     assert "End." in out
 
 
-def test_table_in_code_fence_left_alone():
+@pytest.mark.asyncio
+async def test_table_in_code_fence_left_alone():
     """Tables inside ``` fences are passed through verbatim, no extraction."""
     text = (
         "Output:\n"
@@ -56,13 +64,14 @@ def test_table_in_code_fence_left_alone():
         "```\n"
         "Done."
     )
-    out, renders = DiscordRenderer._extract_and_render_tables(text)
+    out, renders = await DiscordRenderer._extract_and_render_tables(text)
     assert renders == []
     # Text comes back unchanged.
     assert out == text
 
 
-def test_malformed_table_not_extracted():
+@pytest.mark.asyncio
+async def test_malformed_table_not_extracted():
     """Header row with no separator row → not a table, verbatim."""
     text = (
         "Heading:\n"
@@ -70,14 +79,15 @@ def test_malformed_table_not_extracted():
         "| Alice | 30 |\n"
         "End."
     )
-    out, renders = DiscordRenderer._extract_and_render_tables(text)
+    out, renders = await DiscordRenderer._extract_and_render_tables(text)
     assert renders == []
     # The pipe lines survive untouched.
     assert "| Name | Age |" in out
     assert "| Alice | 30 |" in out
 
 
-def test_multiple_tables_each_rendered():
+@pytest.mark.asyncio
+async def test_multiple_tables_each_rendered():
     """Two well-formed tables separated by prose → 2 TableRenders, in order."""
     text = (
         "First:\n"
@@ -91,7 +101,7 @@ def test_multiple_tables_each_rendered():
         "| 9 | 8 |\n"
         "End."
     )
-    out, renders = DiscordRenderer._extract_and_render_tables(text)
+    out, renders = await DiscordRenderer._extract_and_render_tables(text)
     assert len(renders) == 2
     assert renders[0].placeholder == "\n[TABLE_PNG_0]\n"
     assert renders[1].placeholder == "\n[TABLE_PNG_1]\n"
@@ -102,7 +112,8 @@ def test_multiple_tables_each_rendered():
     assert "Middle paragraph." in out
 
 
-def test_single_column_table_not_extracted():
+@pytest.mark.asyncio
+async def test_single_column_table_not_extracted():
     """``| Header |`` style single-column tables are emitted verbatim."""
     text = (
         "Single column:\n"
@@ -111,19 +122,93 @@ def test_single_column_table_not_extracted():
         "| only |\n"
         "End."
     )
-    out, renders = DiscordRenderer._extract_and_render_tables(text)
+    out, renders = await DiscordRenderer._extract_and_render_tables(text)
     assert renders == []
     assert "| Header |" in out
     assert "| only |" in out
 
 
-def test_markdown_source_preserved():
+@pytest.mark.asyncio
+async def test_markdown_source_preserved():
     """``TableRender.markdown_source`` equals the original table text verbatim."""
     header = "| Col1 | Col2 |"
     sep = "|------|------|"
     row1 = "| a    | b    |"
     row2 = "| c    | d    |"
     text = "Prelude.\n" + "\n".join([header, sep, row1, row2]) + "\nEpilogue."
-    _, renders = DiscordRenderer._extract_and_render_tables(text)
+    _, renders = await DiscordRenderer._extract_and_render_tables(text)
     assert len(renders) == 1
     assert renders[0].markdown_source == "\n".join([header, sep, row1, row2])
+
+
+# ---------------------------------------------------------------------------
+# Coverage additions (PR #137 round-1 review).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_header_only_table_not_extracted():
+    """PRD R1.4 — a header row + separator row with NO body rows must be
+    emitted verbatim (no TableRender, no placeholder). Pins the extractor
+    against a future refactor that would render an empty-body table.
+    """
+    text = (
+        "Heading:\n"
+        "| Name | Age |\n"
+        "|------|-----|\n"
+        "End of section."
+    )
+    out, renders = await DiscordRenderer._extract_and_render_tables(text)
+    assert renders == []
+    # All three original lines survive verbatim.
+    assert "| Name | Age |" in out
+    assert "|------|-----|" in out
+    assert "End of section." in out
+
+
+@pytest.mark.asyncio
+async def test_empty_body_cells_preserved():
+    """PRD R6.4 — cells that are empty between pipes (``| | x |``) must be
+    preserved as empty strings in the parsed row data so PNG rendering
+    keeps the column count consistent with the header.
+    """
+    text = (
+        "Mixed:\n"
+        "| A | B | C |\n"
+        "|---|---|---|\n"
+        "|   | x |   |\n"
+        "| y |   | z |\n"
+        "Done."
+    )
+    _, renders = await DiscordRenderer._extract_and_render_tables(text)
+    assert len(renders) == 1
+    r = renders[0]
+    assert r.headers == ["A", "B", "C"]
+    # Empty cells survive as empty strings (not dropped, not None).
+    assert r.rows == [["", "x", ""], ["y", "", "z"]]
+
+
+@pytest.mark.asyncio
+async def test_escaped_pipe_in_cell():
+    """Document current "no escape" semantics: ``\\|`` inside a cell is
+    treated like any other ``|`` and splits the cell. Pinning behaviour so
+    a future "support escaped pipes" change is a deliberate decision.
+    """
+    text = (
+        "| Name | Value |\n"
+        "|------|-------|\n"
+        "| a\\|b | c |\n"
+    )
+    _, renders = await DiscordRenderer._extract_and_render_tables(text)
+    assert len(renders) == 1
+    r = renders[0]
+    # ``a\|b`` splits at the backslash-pipe → the cell becomes 3 fragments,
+    # producing a 3-column row even though headers have 2 columns. Pin the
+    # observed "no escape" behaviour: PNG renderer's normalisation
+    # (truncate/pad to header count) happens later — at extraction we
+    # simply split on every ``|``.
+    assert r.headers == ["Name", "Value"]
+    assert len(r.rows) == 1
+    # 3 split fragments — confirms the escape was NOT honoured.
+    assert len(r.rows[0]) == 3
+    assert r.rows[0] == ["a\\", "b", "c"]

--- a/tests/test_table_extraction.py
+++ b/tests/test_table_extraction.py
@@ -72,18 +72,24 @@ async def test_table_in_code_fence_left_alone():
 
 @pytest.mark.asyncio
 async def test_malformed_table_not_extracted():
-    """Header row with no separator row → not a table, verbatim."""
+    """Header row with no following ``|...|`` line → not a table, verbatim.
+
+    (Note: a header followed by a same-cell-count ``|...|`` row IS now
+    accepted under the relaxed shape — see
+    ``test_table_without_separator_extracted``. This test pins the case
+    where the next line is plain prose so there's nothing to parse as
+    either a separator or a data row.)
+    """
     text = (
         "Heading:\n"
         "| Name | Age |\n"
-        "| Alice | 30 |\n"
         "End."
     )
     out, renders = await DiscordRenderer._extract_and_render_tables(text)
     assert renders == []
-    # The pipe lines survive untouched.
+    # The pipe line survives untouched.
     assert "| Name | Age |" in out
-    assert "| Alice | 30 |" in out
+    assert "End." in out
 
 
 @pytest.mark.asyncio
@@ -212,3 +218,72 @@ async def test_escaped_pipe_in_cell():
     # 3 split fragments — confirms the escape was NOT honoured.
     assert len(r.rows[0]) == 3
     assert r.rows[0] == ["a\\", "b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 (v1.12): relaxed shape — accept tables without a ``|---|---|``
+# separator row when the next line is another ``|...|`` with matching
+# cell count. Claude SDK frequently emits tables in this shape, so the
+# strict matcher was dropping production tables into the legacy
+# code-fence fallback path.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_table_without_separator_extracted():
+    """Header followed directly by data rows (no ``|---|---|`` separator)
+    with matching cell count → 1 TableRender, headers + rows parsed, and
+    ``markdown_source`` contains a synthesized separator so the ``.md``
+    sidecar stays GFM-valid.
+    """
+    text = "| a | b |\n| 1 | 2 |\n| 3 | 4 |"
+    _, renders = await DiscordRenderer._extract_and_render_tables(text)
+    assert len(renders) == 1
+    r = renders[0]
+    assert r.headers == ["a", "b"]
+    assert r.rows == [["1", "2"], ["3", "4"]]
+    # ``markdown_source`` carries a synthesized 2-column GFM separator
+    # so downloads of the ``.md`` sidecar render correctly anywhere
+    # GFM is honoured.
+    assert "|---|---|" in r.markdown_source
+    # And the synthesized separator is positioned between header and rows.
+    lines = r.markdown_source.splitlines()
+    assert lines[0].strip() == "| a | b |"
+    assert lines[1].strip() == "|---|---|"
+    assert lines[2].strip() == "| 1 | 2 |"
+    assert lines[3].strip() == "| 3 | 4 |"
+
+
+@pytest.mark.asyncio
+async def test_separator_still_recognized_when_present():
+    """Strict GFM path (header + separator + rows) is unchanged."""
+    text = (
+        "| Name | Age |\n"
+        "|------|-----|\n"
+        "| Alice | 30 |\n"
+        "| Bob | 25 |"
+    )
+    _, renders = await DiscordRenderer._extract_and_render_tables(text)
+    assert len(renders) == 1
+    r = renders[0]
+    assert r.headers == ["Name", "Age"]
+    assert r.rows == [["Alice", "30"], ["Bob", "25"]]
+    # On the strict path the separator is verbatim from input, NOT the
+    # synthesized ``|---|---|`` shape (it has 6-dash spans here).
+    assert "|------|-----|" in r.markdown_source
+
+
+@pytest.mark.asyncio
+async def test_no_separator_mismatched_cells_falls_back_verbatim():
+    """Header + next ``|...|`` row with different cell count → not a table.
+
+    The cell-count guard prevents the relaxed path from gluing two
+    unrelated pipe-shaped lines together. Both lines must survive
+    verbatim in the output.
+    """
+    text = "| a | b | c |\n| 1 | 2 |"
+    out, renders = await DiscordRenderer._extract_and_render_tables(text)
+    assert renders == []
+    # Both lines survive in the output unchanged.
+    assert "| a | b | c |" in out
+    assert "| 1 | 2 |" in out

--- a/tests/test_table_extraction.py
+++ b/tests/test_table_extraction.py
@@ -287,3 +287,57 @@ async def test_no_separator_mismatched_cells_falls_back_verbatim():
     # Both lines survive in the output unchanged.
     assert "| a | b | c |" in out
     assert "| 1 | 2 |" in out
+
+
+# ---------------------------------------------------------------------------
+# v1.12 Bug D — quad-backtick outer fence preserves inner table verbatim.
+# CommonMark §4.5: a fence opens with N≥3 backticks and only closes on a
+# line whose backtick run length is ≥N. The pre-fix tracker toggled on any
+# ``startswith("```")`` line so an inner triple-backtick boundary inside a
+# quad-backtick outer fence closed the fence prematurely, letting the
+# inner markdown table leak out to PNG extraction (violates PRD R5).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_quad_backtick_outer_fence_preserves_inner_table():
+    """Outer ````` ```` ````` fence wrapping a triple-backtick block that
+    wraps a markdown table → 0 TableRenders, returned text equals input.
+
+    User-facing intent: "show me literally this markdown, don't render it".
+    The extractor must not touch a single character inside the quad fence.
+    """
+    text = (
+        "Before.\n"
+        "````\n"
+        "```\n"
+        "| h |\n"
+        "|---|\n"
+        "| v |\n"
+        "```\n"
+        "````\n"
+        "After."
+    )
+    out, renders = await DiscordRenderer._extract_and_render_tables(text)
+    assert renders == [], "quad-fence inner table must NOT be extracted"
+    assert out == text, "returned text must equal input verbatim"
+
+
+@pytest.mark.asyncio
+async def test_triple_backtick_fence_still_works():
+    """Regression pin: simple ``` fence around a markdown table still
+    suppresses extraction (pre-existing R5 behaviour unchanged by the
+    quad-fence fix).
+    """
+    text = (
+        "Before.\n"
+        "```\n"
+        "| h |\n"
+        "|---|\n"
+        "| v |\n"
+        "```\n"
+        "After."
+    )
+    out, renders = await DiscordRenderer._extract_and_render_tables(text)
+    assert renders == [], "triple-fence inner table must NOT be extracted"
+    assert out == text, "returned text must equal input verbatim"

--- a/tests/test_table_png.py
+++ b/tests/test_table_png.py
@@ -1,0 +1,101 @@
+"""Tests for ``clauded.table_png.render_table_png`` (v1.12 / #131)."""
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+from clauded import table_png
+from clauded.table_png import (
+    MAX_CELL_CHARS,
+    _format_cell,
+    render_table_png,
+)
+
+
+def _parse(b: bytes) -> Image.Image:
+    """Open PNG bytes; raises if invalid."""
+    img = Image.open(io.BytesIO(b))
+    assert img.format == "PNG"
+    return img
+
+
+def test_simple_table_renders_valid_png():
+    """A vanilla 3-col × 3-row ASCII table produces parseable PNG bytes."""
+    headers = ["A", "B", "C"]
+    rows = [
+        ["a1", "b1", "c1"],
+        ["a2", "b2", "c2"],
+        ["a3", "b3", "c3"],
+    ]
+    out = render_table_png(headers, rows)
+    assert isinstance(out, bytes) and len(out) > 0
+    img = _parse(out)
+    # Width / height must be positive (sanity).
+    assert img.width > 0 and img.height > 0
+
+
+def test_cjk_table_renders_no_crash():
+    """CJK cells render without exception and produce valid PNG."""
+    headers = ["项目", "状态", "说明"]
+    rows = [
+        ["你好", "完成", "测试中文"],
+        ["世界", "进行", "另一行"],
+    ]
+    out = render_table_png(headers, rows)
+    _parse(out)
+
+
+def test_emoji_table_renders_no_crash():
+    """Emoji cells render without exception."""
+    headers = ["Mood", "Status", "Note"]
+    rows = [
+        ["😀", "✅", "happy 🎉"],
+        ["😢", "❌", "sad 💔"],
+    ]
+    out = render_table_png(headers, rows)
+    _parse(out)
+
+
+def test_long_cell_truncated():
+    """Cells longer than 120 chars are truncated with an ellipsis."""
+    long_text = "x" * 200
+    formatted = _format_cell(long_text)
+    assert formatted.endswith("…")
+    assert len(formatted) == MAX_CELL_CHARS
+    # Public renderer must still produce valid PNG with the long cell.
+    out = render_table_png(["H"], [[long_text]])
+    _parse(out)
+
+
+def test_backticks_stripped_from_display():
+    """Backticks are stripped from cell content for PNG display."""
+    assert _format_cell("`effort`") == "effort"
+    assert _format_cell("a `b` c") == "a b c"
+    # Renderer must still produce valid PNG with backticked cells.
+    out = render_table_png(["Col"], [["`effort`"]])
+    _parse(out)
+
+
+def test_pillow_fallback_when_fonts_missing(monkeypatch):
+    """If no system font path resolves, fall back to ``load_default``."""
+    # Force every truetype lookup to fail.
+    monkeypatch.setattr(
+        table_png, "FONT_CANDIDATES", ("/nonexistent/font.ttf",)
+    )
+    out = render_table_png(["A", "B"], [["1", "2"]])
+    _parse(out)
+
+
+def test_empty_rows_does_not_crash():
+    """Empty / blank cell content renders without exception."""
+    # Empty cell strings.
+    out = render_table_png(["A", "B"], [["", ""]])
+    _parse(out)
+    # Empty row (no cells at all) — renderer pads to header count.
+    out = render_table_png(["A", "B"], [[]])
+    _parse(out)
+    # No rows at all (header-only — still valid output).
+    out = render_table_png(["A", "B"], [])
+    _parse(out)

--- a/tests/test_table_png.py
+++ b/tests/test_table_png.py
@@ -9,7 +9,10 @@ from PIL import Image
 from clauded import table_png
 from clauded.table_png import (
     MAX_CELL_CHARS,
+    MAX_COLS,
+    MAX_ROWS,
     _format_cell,
+    _load_font,
     render_table_png,
 )
 
@@ -37,7 +40,12 @@ def test_simple_table_renders_valid_png():
 
 
 def test_cjk_table_renders_no_crash():
-    """CJK cells render without exception and produce valid PNG."""
+    """CJK cells render without exception and produce valid PNG.
+
+    Also pins review I6: ``_load_font`` selects a real system font (not
+    the bitmap ``ImageFont.load_default`` fallback) on macOS, so CJK
+    glyphs are rendered rather than tofu boxes.
+    """
     headers = ["项目", "状态", "说明"]
     rows = [
         ["你好", "完成", "测试中文"],
@@ -45,6 +53,17 @@ def test_cjk_table_renders_no_crash():
     ]
     out = render_table_png(headers, rows)
     _parse(out)
+
+    # I6 pin: a TrueType font was loaded (PingFang first), not the
+    # bitmap default. ``load_default`` returns an ImageFont (no ``.path``);
+    # truetype fonts expose ``.path`` pointing at the file.
+    font = _load_font(13)
+    assert hasattr(font, "path"), (
+        f"_load_font fell back to bitmap default (font={font!r}); "
+        "FONT_CANDIDATES order may be regressed"
+    )
+    # On macOS the first candidate should resolve.
+    assert "PingFang" in font.path or "Menlo" in font.path or "Arial" in font.path
 
 
 def test_emoji_table_renders_no_crash():
@@ -99,3 +118,37 @@ def test_empty_rows_does_not_crash():
     # No rows at all (header-only — still valid output).
     out = render_table_png(["A", "B"], [])
     _parse(out)
+
+
+# ---------------------------------------------------------------------------
+# Review I4: DoS guards — oversize tables raise ValueError so the caller
+# (DiscordRenderer._extract_and_render_tables) can fall back to verbatim
+# emit via its C2 try/except.
+# ---------------------------------------------------------------------------
+
+
+def test_render_table_png_rejects_oversized_columns():
+    """A table with > MAX_COLS columns raises ``ValueError`` before
+    allocating any image memory."""
+    too_wide_headers = [f"c{i}" for i in range(MAX_COLS + 1)]
+    too_wide_row = ["x"] * (MAX_COLS + 1)
+    with pytest.raises(ValueError, match="too wide"):
+        render_table_png(too_wide_headers, [too_wide_row])
+
+
+def test_render_table_png_rejects_oversized_rows():
+    """A table with > MAX_ROWS body rows raises ``ValueError``."""
+    headers = ["A", "B"]
+    rows = [["x", "y"] for _ in range(MAX_ROWS + 1)]
+    with pytest.raises(ValueError, match="too tall"):
+        render_table_png(headers, rows)
+
+
+def test_render_table_png_rejects_oversized_pixel_budget(monkeypatch):
+    """If the computed image area exceeds the per-table pixel budget,
+    raise ``ValueError`` rather than allocate hundreds of MB."""
+    # Shrink the budget so a normal small table trips it.
+    monkeypatch.setattr(table_png, "MAX_TABLE_PIXELS", 100)
+    with pytest.raises(ValueError, match="pixel budget"):
+        render_table_png(["A", "B"], [["1", "2"]])
+

--- a/tests/test_thread_race.py
+++ b/tests/test_thread_race.py
@@ -1,0 +1,293 @@
+"""Tests for Discord thread-creation race recovery in ``ClaudedBot``.
+
+The Discord gateway occasionally duplicates ``MESSAGE_CREATE`` events,
+which causes ``on_message`` to run twice for the same message. The first
+invocation wins the ``message.create_thread()`` call; the second loses
+with ``discord.HTTPException`` code ``160004`` ("a thread has already
+been created for this message"). Before this fix the loser path posted
+a misleading ``❌ Failed to create a thread for this message.`` error
+into the channel even though a thread had in fact been created.
+
+This module pins the recovery behaviour: on 160004 we re-fetch the
+message, observe ``message.thread`` is set, reuse that thread, and fall
+through to the normal bridge-startup path with **no** user-visible error.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from clauded.bot import ClaudedBot
+from clauded.config import Config
+from clauded.cost_tracker import CostTracker
+from clauded.project_manager import ProjectManager
+from clauded.session_manager import SessionManager
+
+
+# ---------------------------------------------------------------------------
+# Fake Discord plumbing — kept self-contained so tests are independent of
+# the unbound-fallback fixtures' specific FakeMessage semantics.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeAuthor:
+    id: int = 999
+    bot: bool = False
+    name: str = "alice"
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@dataclass
+class FakeUser:
+    id: int = 42
+    name: str = "bot"
+
+
+class FakeThread:
+    """Minimal stand-in for a created Discord thread."""
+
+    def __init__(self, thread_id: int, name: str = "session") -> None:
+        self.id = thread_id
+        self.name = name
+        self.parent_id: int | None = None
+        self.messages: list[dict[str, Any]] = []
+
+    async def send(self, content: str | None = None, **kwargs: Any) -> Any:
+        self.messages.append({"content": content, **kwargs})
+        return MagicMock()
+
+
+def _make_http_exception(code: int) -> discord.HTTPException:
+    """Build a real ``discord.HTTPException`` carrying the given error code.
+
+    The class reads ``code`` out of the JSON payload, so we pass it in
+    the dict-shaped ``message`` arg. We don't go through the real
+    aiohttp response — only ``status`` and ``reason`` are touched.
+    """
+    resp = MagicMock()
+    resp.status = 400
+    resp.reason = "Bad Request"
+    return discord.HTTPException(resp, {"code": code, "message": "thread exists"})
+
+
+class FakeChannel:
+    """Stand-in for ``discord.TextChannel`` (the parent of the thread).
+
+    Records ``send()`` calls so the test can assert no error message
+    was surfaced. ``fetch_message`` is a MagicMock that the test wires
+    up to return the same FakeMessage with ``.thread`` set.
+    """
+
+    def __init__(self, channel_id: int) -> None:
+        self.id = channel_id
+        self.parent_id: int | None = None
+        self.sent: list[Any] = []
+        # ``fetch_message`` is set by the test fixture.
+        self.fetch_message: AsyncMock = AsyncMock()
+
+    async def send(self, content: str | None = None, **kwargs: Any) -> Any:
+        self.sent.append({"content": content, **kwargs})
+        return MagicMock()
+
+
+class FakeRaceMessage:
+    """Message whose ``create_thread`` raises HTTPException(code=160004)."""
+
+    def __init__(
+        self,
+        *,
+        channel: FakeChannel,
+        content: str,
+        bot_user_id: int,
+        existing_thread: FakeThread,
+    ) -> None:
+        self.id = 12345
+        self.channel = channel
+        self.content = content
+        self.mentions = [MagicMock(id=bot_user_id)]
+        self.role_mentions: list[Any] = []
+        self.author = FakeAuthor()
+        self.attachments: list[Any] = []
+        self.replies: list[str] = []
+        # When the race winner's MESSAGE_CREATE handler runs first,
+        # Discord internally attaches the created thread to the message;
+        # after we re-fetch on 160004 we should observe it here.
+        self.thread: FakeThread | None = None
+        self._existing_thread = existing_thread
+        self._create_thread_calls = 0
+
+    async def reply(self, content: str, **kwargs: Any) -> Any:
+        self.replies.append(content)
+        return MagicMock()
+
+    async def create_thread(self, *, name: str, **kwargs: Any) -> FakeThread:
+        # Loser path: thread already exists → Discord returns 160004.
+        self._create_thread_calls += 1
+        raise _make_http_exception(160004)
+
+    async def add_reaction(self, _emoji: str) -> None:
+        return None
+
+    async def remove_reaction(self, _emoji: str, _user: Any) -> None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Bot fixtures — same shape as test_bot_unbound_message.py.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Config:
+    return Config(
+        discord_bot_token="tok",
+        claude_model="sonnet",
+        claude_permission_mode="default",
+        projects_root=str(tmp_path),
+        # Enable the home-dir fallback so the handler proceeds past the
+        # is_bound() gate without needing an actual bind.
+        allow_unbound_fallback=True,
+    )
+
+
+@pytest.fixture
+def bot(cfg: Config, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ClaudedBot:
+    """Build a ``ClaudedBot`` without going through ``commands.Bot.__init__``."""
+    pm = ProjectManager(data_dir=str(tmp_path / "data"), projects_root=str(tmp_path))
+
+    bot = ClaudedBot.__new__(ClaudedBot)
+    bot.config = cfg
+    bot.project_manager = pm
+    bot.session_manager = SessionManager()
+    bot.cost_tracker = CostTracker()
+    bot.agent_manager = MagicMock()
+    bot._start_time = 0.0
+    bot._claude_version = "test"
+    bot._debug_logging = False
+    bot._pre_tool_notifications = False
+    bot._notify_enabled = {}
+    bot._connection = MagicMock()
+    fake_user = FakeUser(id=42, name="bot")
+    monkeypatch.setattr(ClaudedBot, "user", property(lambda self: fake_user))
+
+    # ``isinstance(channel, discord.TextChannel)`` must accept FakeChannel.
+    monkeypatch.setattr(discord, "TextChannel", FakeChannel)
+
+    class _Forum:  # noqa: D401
+        pass
+
+    monkeypatch.setattr(discord, "ForumChannel", _Forum)
+
+    return bot
+
+
+@pytest.fixture
+def captured_sessions(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Capture every ``SessionManager.create_session`` call and short-circuit
+    the renderer so the test focuses on the thread-race recovery branch."""
+    captured: list[dict[str, Any]] = []
+
+    async def _fake_create(
+        self: SessionManager,
+        thread_id: int,
+        project_path: str,
+        config: Config,
+        session_config: Any = None,
+    ) -> Any:
+        bridge = MagicMock()
+        bridge.total_cost = 0.0
+        bridge.is_active = True
+        bridge.session_id = None
+        captured.append(
+            {
+                "thread_id": thread_id,
+                "project_path": project_path,
+                "session_config": session_config,
+            }
+        )
+        self._sessions[thread_id] = bridge
+        return bridge
+
+    monkeypatch.setattr(SessionManager, "create_session", _fake_create)
+
+    async def _noop_render(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401
+        return None
+
+    monkeypatch.setattr(ClaudedBot, "_render_with_retry", _noop_render)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Test: 160004 → reuse the existing thread, no error surface.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_thread_race_160004_reuses_existing_thread(
+    bot: ClaudedBot,
+    captured_sessions: list[dict[str, Any]],
+) -> None:
+    """Duplicate MESSAGE_CREATE race:
+
+    1. ``message.create_thread`` raises ``HTTPException(code=160004)`` —
+       a competing dispatch already created the thread.
+    2. The handler re-fetches the message via ``channel.fetch_message``.
+    3. The refetched message exposes the existing thread on ``.thread``.
+    4. The handler reuses that thread, surfaces NO error embed, and
+       continues into the normal bridge-startup path (``create_session``
+       is invoked for that thread id).
+    """
+    existing_thread = FakeThread(thread_id=77777, name="race-winner-thread")
+    channel = FakeChannel(channel_id=9001)
+    msg = FakeRaceMessage(
+        channel=channel,
+        content="<@42> hello",
+        bot_user_id=42,
+        existing_thread=existing_thread,
+    )
+
+    # When the handler refetches after 160004, return a copy of ``msg``
+    # whose ``.thread`` is the existing thread (the race winner's).
+    # The handler reads several attrs off the refetched message after
+    # this point (``add_reaction``, ``remove_reaction``, ``content``,
+    # ``attachments``, ``author``) — wire them all to async-safe stubs.
+    refetched = MagicMock()
+    refetched.id = msg.id
+    refetched.thread = existing_thread
+    refetched.content = msg.content
+    refetched.attachments = []
+    refetched.author = msg.author
+    refetched.add_reaction = AsyncMock(return_value=None)
+    refetched.remove_reaction = AsyncMock(return_value=None)
+    channel.fetch_message.return_value = refetched
+
+    await bot._handle_channel_message(msg)
+
+    # ----- Race assertions -----
+    # 1) Refetch happened with the original message id.
+    channel.fetch_message.assert_awaited_once_with(msg.id)
+
+    # 2) NO error message was surfaced into the channel.
+    error_sends = [s for s in channel.sent if isinstance(s.get("content"), str)]
+    assert not any(
+        "Failed to create a thread" in (s.get("content") or "") for s in error_sends
+    ), f"Unexpected error surfaced into channel: {channel.sent!r}"
+
+    # 3) The handler proceeded into bridge startup on the EXISTING thread —
+    #    not on a brand-new one. ``create_session`` was invoked with
+    #    ``thread_id == existing_thread.id``.
+    assert captured_sessions, "Expected create_session to be called after recovery"
+    assert captured_sessions[0]["thread_id"] == existing_thread.id
+
+    # 4) ``create_thread`` was called exactly once (the failing attempt);
+    #    we did NOT loop or retry.
+    assert msg._create_thread_calls == 1


### PR DESCRIPTION
Closes #112.

## Summary

Replace `_format_tables` code-fence wrap with single PNG attachment + persistent 📋 Copy-as-text button, per user-verified design via 3 rounds of live Discord demo.

## Sub-tasks

- #131 — `src/clauded/table_png.py` PNG renderer (Pillow + macOS system fonts, no font bundle)
- #132 — `_extract_and_render_tables` extractor (parses tables, builds TableRender list)
- #133 — `CopyTableTextView` persistent button (reads `.md` sidecar from message attachments)
- #134 — Integration: `_finalize_typewriter` / `_flush` migrated, `bot.setup_hook` registers persistent view, `_safe_send` extended with `files=`

## Test status

`pytest tests/`: **356 pass / 2 pre-existing P1** (test_subagent_threads.py:442, 518, commit 2608502, unrelated).

Net diff vs main: 10 files, +1382/-8 (PRD 222 + sub1-4 sources + tests).

## R1 review

Posted as PR comment. 4 RC + 3 APPROVE. **C1 (placeholder text leaks into Discord) + C2 (PNG render exception aborts entire flush) + C3 (long-upload `.md` contains placeholders)** must be fixed for R2.