### PR TITLE
v1.13: /skill list slash command (#109)

### DIFF
--- a/docs/prd/v1.13-skill-list.md
+++ b/docs/prd/v1.13-skill-list.md
@@ -1,0 +1,155 @@
+# PRD — `/skill list` slash command (#109)
+
+**Status:** Approved (manager-confirmed decisions 2026-05-11).
+**Branch:** `feat/v1.13-skill-list`.
+**Scope:** single PR, no subtask split. Estimated ~300 LOC including tests.
+
+## Goal
+
+Add `/skill list` so Discord users can discover what skills Claude will auto-inject in the current channel's session, **without** having to invoke them first.
+
+## User-visible behavior
+
+A new ephemeral embed-only command:
+
+```
+/skill list
+```
+
+Returns an ephemeral embed visible only to the invoking user, grouped by source.
+
+### Happy path (bound channel, active session)
+
+Title: `🧰 Skills (N)` where N = count of skill-backed slash commands.
+
+Body grouped by:
+1. **Project** — commands whose description ends with `" (project)"`
+2. **User (Global)** — commands whose description ends with `" (user)"`
+3. **Plugin: <name>** — commands whose description ends with `" (plugin:<name>)"` (one section per plugin, alphabetized)
+
+Each row: `• <name> — <description with source-tag suffix stripped, truncated to 120 chars + …>`
+
+Built-in commands (`clear`, `compact`, `init`, `review`, …) are **excluded** — they have no source-tag suffix and are not user-installed skills.
+
+### Edge cases
+
+- **Unbound channel** — STILL WORKS. The temp-client path uses `setting_sources=["user"]` only (no `"project"` / no `"local"`). Project section is omitted from the embed; user is told via a footer line: `_💡 Unbound channel — showing global skills only. Run `/project bind <path>` to see project skills._`
+- **Bound but no active session** — defer + spin up a temporary `ClaudeSDKClient`. UX shows "Loading skills…" via `interaction.response.defer(ephemeral=True)`. Latency budget 5 s; CLI cold start is ~2-4 s in practice.
+- **CLI not found / connection error** — catch `CLINotFoundError`, `CLIConnectionError`, generic `Exception`. Return a friendly red embed titled `❌ Skills unavailable` with the error class name in the description (not full stack).
+- **`get_server_info()` returns `None`** — same friendly error path.
+- **No skills found** (only built-in commands) — embed shows `🧰 Skills (0)` + a body line `No user or project skills installed.`
+- **>4000 chars total embed content** — truncate with `…and N more skills (use Claude CLI to see all)`. We don't paginate in v1.13; live probe currently returns 2 user skills, so the truncation branch is mostly defensive.
+- **Half-broken SKILL.md** (description is `""` from CLI) — display as `• <name> — _(no description)_`.
+
+## Data model — what `get_server_info()["commands"]` actually returns
+
+Verified by live probe on 2026-05-11:
+
+```python
+info = await client.get_server_info()
+# info.keys() = ['commands', 'agents', 'output_style', 'available_output_styles', 'models', 'account', 'pid']
+# info["commands"] is list[dict] with keys: name, description, argumentHint
+# Source is encoded as a trailing suffix on description:
+#   " (user)"           → ~/.claude/skills/<name>/SKILL.md
+#   " (project)"        → <project>/.claude/skills/<name>/SKILL.md  (requires "project" or "local" in setting_sources)
+#   " (plugin:<name>)"  → from an enabled plugin
+#   no suffix           → Claude Code built-in
+```
+
+Total 19 commands today; 2 user skills (`crew`, `opc`); 0 project/plugin in this repo.
+
+## Architecture
+
+New file: `src/clauded/cogs/skill.py`.
+
+Pattern: mirrors `cogs/agent.py` (single-file group + decorators, no manager class).
+
+### Skill resolution priority
+
+```
+Path A — active bridge piggyback:
+    bridge = session_manager.get_session(thread_id_or_channel_id)
+    if bridge and bridge.is_active and bridge._client is not None:
+        info = await bridge._client.get_server_info()
+        # 0-1 ms read of cached _initialization_result
+
+Path B — fallback (no active session, or bridge has no client):
+    cwd, is_bound = project_manager.get_path_or_default(channel_id)
+    setting_sources = ["user", "project", "local"] if is_bound else ["user"]
+    async with ClaudeSDKClient(ClaudeAgentOptions(cwd=str(cwd), setting_sources=setting_sources)) as tmp:
+        info = await tmp.get_server_info()
+    # ~2-4 s cold start
+```
+
+Skill filtering:
+```python
+def _classify(cmd: dict) -> tuple[str, str, str]:
+    """Return (group, displayName, displayDescription) or ('', '', '') for built-ins."""
+    name = cmd.get("name", "")
+    desc = cmd.get("description", "") or ""
+    if desc.endswith(" (user)"):
+        return ("user", name, desc[:-7].rstrip())
+    if desc.endswith(" (project)"):
+        return ("project", name, desc[:-10].rstrip())
+    if desc.endswith(")") and " (plugin:" in desc:
+        # " (plugin:foo)" — extract plugin name
+        idx = desc.rfind(" (plugin:")
+        plugin_name = desc[idx+9:-1]
+        return (f"plugin:{plugin_name}", name, desc[:idx].rstrip())
+    return ("", "", "")  # built-in — filter out
+```
+
+Channel resolution (same pattern as `_unbound.reject_if_unbound`):
+- DM/no channel → friendly error "must be in a channel"
+- Thread → use `thread.parent_id`
+- Else → use `channel.id`
+
+## Acceptance criteria
+
+### Happy path
+- [x] `/skill list` in a channel where `~/.claude/skills/crew` and `~/.claude/skills/opc` exist returns ephemeral embed with 2 skills grouped under **User (Global)**
+- [x] Source-tag suffix removed from displayed description
+- [x] Title shows `🧰 Skills (2)`
+- [x] Built-in commands (`clear`, `compact`, …) NOT shown
+
+### Edge cases
+- [x] Unbound channel → uses `setting_sources=["user"]` + footer hint
+- [x] Bound + no active session → spin-up temp client; latency < 5s in test (mock to 0)
+- [x] CLINotFoundError / CLIConnectionError → red `❌ Skills unavailable` embed
+- [x] `get_server_info()` → None → red error embed
+- [x] Zero skills installed → empty-state body line
+- [x] Half-broken SKILL.md (empty description) → `_(no description)_`
+
+### Tests (new file `tests/test_skill_list.py`)
+- [x] `_classify` table-driven test for `(user)`, `(project)`, `(plugin:foo)`, no-suffix, and edge cases like `"foo (plugin:bar) more text"` (NOT a plugin — suffix-only match)
+- [x] Mock `ClaudeSDKClient` returning fixture with 2 user + 1 project + 1 plugin + 3 built-in → assert grouping & filtering
+- [x] Mock active bridge path (Path A) → assert `get_server_info` called on `bridge._client`, no temp client spun
+- [x] Mock no-active-bridge path (Path B, bound) → assert temp `ClaudeSDKClient` created with `setting_sources=["user","project","local"]`
+- [x] Mock no-active-bridge path (Path B, unbound) → assert temp client uses `setting_sources=["user"]` and footer added
+- [x] Mock `CLIConnectionError` raised → assert red error embed, no crash
+- [x] Mock `get_server_info()` returns None → assert red error embed
+- [x] Mock empty commands list (only built-ins after filter) → assert empty-state line
+- [x] Mock 50 user skills → assert no >4000 char overrun (truncation kicks in)
+
+### Performance
+- [x] Path A: < 50 ms in unit test (in-memory mock)
+- [x] Path B: documented ~2-4s real-world; not tested live
+
+## Out of scope (future v1.14+ issues)
+
+- `/skill info <name>` — show full SKILL.md frontmatter + body excerpt (CLI doesn't expose, would need filesystem read)
+- `/skill enable <name>` / `/skill disable <name>` — uses `ClaudeAgentOptions.skills` field
+- File watcher / auto-refresh — `get_server_info()` is a session-startup snapshot, matches CLI behavior
+- Pagination — defer until a real skill load justifies it
+
+## Rollback
+
+Pure additive feature; revert the cog + the one-line `bot.py` registration.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `_client` private attribute access breaks if SDK refactors | Pin SDK ≥ 0.1.80; v1.14 ask SDK upstream for public accessor |
+| Long-lived users have hundreds of skills → embed bloat | 4000-char truncation + v1.14 pagination |
+| Plugin source-tag format changes | `_classify` returns `("", "", "")` on unrecognized → built-in path; user just sees fewer skills, no crash |

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -162,6 +162,7 @@ class ClaudedBot(commands.Bot):
         from .cogs.tools import tools_group, budget_group
         from .cogs.agent import agent_group
         from .cogs.mcp import mcp_group
+        from .cogs.skill import skill_group
         from .cogs.ops import (
             cost_group, health_check, review_pr, plugin_group,
             send_to_claude, pin_message, ratelimit_info,
@@ -179,6 +180,7 @@ class ClaudedBot(commands.Bot):
         self.tree.add_command(review_pr)
         self.tree.add_command(agent_group)
         self.tree.add_command(mcp_group)
+        self.tree.add_command(skill_group)
         self.tree.add_command(max_turns_cmd)
         self.tree.add_command(fallback_model_cmd)
         self.tree.add_command(plugin_group)

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -146,6 +146,24 @@ class ClaudeBridge:
         """True iff the underlying client is currently connected."""
         return self._active
 
+    async def get_server_info(self) -> dict | None:
+        """Return cached server init info, or ``None`` if not connected.
+
+        Public wrapper for ``_client.get_server_info()`` — keeps callers
+        out of the bridge's private state (cog/skill.py uses this for
+        ``/skill list``).
+
+        This is a cache read of the SDK's ``_initialization_result``;
+        the call performs no I/O and is safe to invoke concurrently
+        with an in-flight ``send_message`` stream on the same client.
+        A future SDK refactor could break that assumption — callers
+        should still wrap this in ``try/except`` and degrade gracefully.
+        """
+        client = self._client
+        if client is None or not self._active:
+            return None
+        return await client.get_server_info()
+
     async def start(self) -> None:
         """Create and connect the underlying ``ClaudeSDKClient``."""
         full_system_prompt = (self.system_prompt or "") + _CHANNEL_MGMT_PROMPT

--- a/src/clauded/cogs/_unbound.py
+++ b/src/clauded/cogs/_unbound.py
@@ -1,4 +1,14 @@
-"""Unified unbound-channel refusal + hint string for Group A commands."""
+"""Unified unbound-channel refusal + hint string for Group A commands.
+
+Policy convention:
+
+* **Group A (state-mutating)** cogs call :func:`reject_if_unbound` (e.g.
+  ``/agent create``, ``/clear``, ``/budget``) — hard refusal in unbound
+  channels because the command needs a concrete project context.
+* **Group B (read-only / discovery)** cogs call
+  :func:`resolve_channel_id` + ``project_manager.get_path_or_default``
+  and degrade gracefully (e.g. ``/cost``, ``/health``, ``/skill list``).
+"""
 
 from __future__ import annotations
 
@@ -19,17 +29,27 @@ UNBOUND_HINT_MESSAGE = (
 NO_CHANNEL_MESSAGE = "❌ This command must be run in a channel."
 
 
+def resolve_channel_id(interaction: discord.Interaction) -> int | None:
+    """Resolve the channel id used for project/session lookups.
+
+    Returns ``None`` for DM channels (explicit or by cache-miss
+    fallback) so callers can surface a friendly "must be run in a
+    channel" error. Threads resolve to their parent channel so a
+    thread inherits its parent's bound state.
+    """
+    ch = interaction.channel
+    if ch is None or isinstance(ch, discord.DMChannel):
+        # DM, cache miss, or permission gap — treat all "no real
+        # channel" cases uniformly so Group A/B policies stay aligned.
+        return None
+    if isinstance(ch, discord.Thread):
+        return ch.parent_id or interaction.channel_id
+    return ch.id
+
+
 async def reject_if_unbound(interaction: discord.Interaction, bot) -> bool:
     """Refuse Group A commands on unbound channels. Returns True iff refusal sent."""
-    ch = interaction.channel
-    if ch is None:
-        # DM, cache miss, or permission gap — fall back to interaction.channel_id.
-        channel_id = interaction.channel_id
-    elif isinstance(ch, discord.Thread):
-        # Threads inherit the parent channel's bound state.
-        channel_id = ch.parent_id or interaction.channel_id
-    else:
-        channel_id = ch.id
+    channel_id = resolve_channel_id(interaction)
 
     sender = (
         interaction.followup.send

--- a/src/clauded/cogs/skill.py
+++ b/src/clauded/cogs/skill.py
@@ -14,14 +14,11 @@ import logging
 import discord
 from discord import app_commands
 
-from claude_agent_sdk import (
-    ClaudeSDKClient,
-    ClaudeAgentOptions,
-    CLINotFoundError,
-    CLIConnectionError,
-)
+from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions
 
 from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE
+from ..skill_parser import classify_command
+from ._unbound import NO_CHANNEL_MESSAGE, resolve_channel_id
 
 log = logging.getLogger("clauded.bot")
 
@@ -32,72 +29,12 @@ skill_group = app_commands.Group(
 )
 
 
-def _classify(cmd: dict) -> tuple[str, str, str]:
-    """Return ``(group, displayName, displayDescription)`` for a CLI command.
-
-    ``group`` is one of ``"user"``, ``"project"``, ``"plugin:<name>"``, or
-    ``""`` for built-in commands (which the caller filters out). The
-    displayed description has the source-tag suffix stripped.
-
-    See PRD §Architecture for the source-tag-suffix encoding.
-    """
-    name = cmd.get("name", "")
-    desc = cmd.get("description", "") or ""
-    if desc.endswith(" (user)"):
-        return ("user", name, desc[:-7].rstrip())
-    if desc.endswith(" (project)"):
-        return ("project", name, desc[:-10].rstrip())
-    if desc.endswith(")") and " (plugin:" in desc:
-        # " (plugin:foo)" — extract plugin name
-        idx = desc.rfind(" (plugin:")
-        plugin_name = desc[idx + 9:-1]
-        return (f"plugin:{plugin_name}", name, desc[:idx].rstrip())
-    return ("", "", "")  # built-in — filter out
-
-
-# Discord limits we observe defensively. Per-field value cap is the hard
-# 1024-char Discord limit; the 4000-char total budget comes from the PRD
-# truncation guard (see PRD edge-case ">4000 chars total embed content").
+# Discord per-field hard limit. The total-embed budget caps conservatively
+# below Discord's 6000-char serialized ceiling to leave room for
+# title/footer. Real pagination is a v1.14 follow-up (PRD §Out-of-scope).
 _FIELD_VALUE_CAP = 1024
-_EMBED_TOTAL_BUDGET = 4000
+_EMBED_TOTAL_BUDGET = 5500
 _DESC_TRUNCATE_AT = 120
-
-
-def _format_row(name: str, desc: str) -> str:
-    """Render a single skill row: ``• <name> — <truncated desc>``."""
-    if not desc:
-        body = "_(no description)_"
-    elif len(desc) > _DESC_TRUNCATE_AT:
-        body = desc[:_DESC_TRUNCATE_AT] + "…"
-    else:
-        body = desc
-    return f"• {name} — {body}"
-
-
-def _ordered_group_keys(groups: dict[str, list[tuple[str, str]]]) -> list[str]:
-    """Return group keys in the PRD display order.
-
-    Order: Project, User (Global), then each Plugin alphabetized. Missing
-    groups are simply absent.
-    """
-    keys: list[str] = []
-    if "project" in groups:
-        keys.append("project")
-    if "user" in groups:
-        keys.append("user")
-    plugin_keys = sorted(k for k in groups if k.startswith("plugin:"))
-    keys.extend(plugin_keys)
-    return keys
-
-
-def _group_field_name(key: str) -> str:
-    if key == "project":
-        return "Project"
-    if key == "user":
-        return "User (Global)"
-    if key.startswith("plugin:"):
-        return f"Plugin: {key[len('plugin:'):]}"
-    return key  # defensive
 
 
 def _build_skills_embed(
@@ -108,9 +45,16 @@ def _build_skills_embed(
 ) -> discord.Embed:
     """Render the grouped skills into a single ``discord.Embed``.
 
-    Enforces both Discord's per-field 1024-char limit AND the PRD
-    4000-char total-embed budget by trimming rows from the tail and
-    appending a "…and N more" notice if anything had to be dropped.
+    Each group becomes one field with rows joined by newlines, capped
+    at the per-field 1024-char limit by simple slice + ellipsis. If
+    the total serialized embed exceeds ``_EMBED_TOTAL_BUDGET`` we
+    drop trailing skills (last group, last rows) until it fits and
+    add a single "…and N more" notice.
+
+    Note: skill names and descriptions are user-visible, sourced from
+    the operator's local ``~/.claude/skills/`` and project
+    ``.claude/skills/`` directories — do not store secrets in skill
+    *names*.
     """
     embed = discord.Embed(title=f"🧰 Skills ({total_skill_count})", color=COLOR_INFO)
 
@@ -126,85 +70,66 @@ def _build_skills_embed(
         embed.description = "No user or project skills installed."
         return embed
 
-    # Build (key, [rendered_row, …]) in display order. We render every row
-    # up-front so we can compute the truncation tail accurately.
-    ordered: list[tuple[str, list[str]]] = []
-    for key in _ordered_group_keys(groups):
-        rows = [_format_row(n, d) for (n, d) in groups[key]]
-        ordered.append((key, rows))
+    # Group display order: Project → User (Global) → Plugin:<name> alphabetized.
+    ordered_keys: list[str] = []
+    if "project" in groups:
+        ordered_keys.append("project")
+    if "user" in groups:
+        ordered_keys.append("user")
+    ordered_keys.extend(sorted(k for k in groups if k.startswith("plugin:")))
 
-    # Walk groups in order, packing rows into each field while respecting
-    # the per-field 1024-char cap and the per-embed 4000-char cap. Rows
-    # we couldn't fit get counted as "dropped".
-    dropped = 0
-    truncation_field_overhead = 64  # rough budget for the "…and N more" line
+    def _row(name: str, desc: str) -> str:
+        if not desc:
+            body = "_(no description)_"
+        elif len(desc) > _DESC_TRUNCATE_AT:
+            body = desc[:_DESC_TRUNCATE_AT] + "…"
+        else:
+            body = desc
+        return f"• {name} — {body}"
 
-    def current_len(e: discord.Embed) -> int:
-        # discord.py's ``Embed.__len__`` returns the serialized length.
-        return len(e)
+    def _field_label(key: str) -> str:
+        if key == "project":
+            return "Project"
+        if key == "user":
+            return "User (Global)"
+        return f"Plugin: {key[len('plugin:'):]}"  # "plugin:<name>"
 
-    for key, rows in ordered:
-        field_name = _group_field_name(key)
-        if not rows:
-            continue
-        accumulated_lines: list[str] = []
-        accumulated_len = 0  # tracks accumulated body length only
-        for row in rows:
-            # +1 for the joining newline if there's already something there.
-            extra = len(row) + (1 if accumulated_lines else 0)
-            new_field_len = accumulated_len + extra
-            if new_field_len > _FIELD_VALUE_CAP:
-                dropped += 1
+    def _add_fields(group_rows: dict[str, list[str]]) -> None:
+        for key in ordered_keys:
+            if key not in group_rows or not group_rows[key]:
                 continue
-            # Tentative new total: simulate adding this row to the field.
-            # We compute the would-be total length by adding the row
-            # (and possibly a newline) plus, on first row of a new field,
-            # the field-name + structural overhead (~ len(name) + ~6).
-            structural = 0 if accumulated_lines else len(field_name) + 6
-            tentative_total = (
-                current_len(embed)
-                + extra
-                + structural
-                + truncation_field_overhead
-            )
-            if tentative_total > _EMBED_TOTAL_BUDGET:
-                dropped += 1
-                continue
-            accumulated_lines.append(row)
-            accumulated_len += extra
-        if accumulated_lines:
+            value = "\n".join(group_rows[key])
+            if len(value) > _FIELD_VALUE_CAP:
+                value = value[: _FIELD_VALUE_CAP - 1] + "…"
+            embed.add_field(name=_field_label(key), value=value, inline=False)
+
+    # Initial render: all rows.
+    rendered: dict[str, list[str]] = {
+        key: [_row(n, d) for (n, d) in groups[key]] for key in ordered_keys
+    }
+    _add_fields(rendered)
+
+    # If the serialized embed blew the total budget, drop trailing
+    # rows (deterministic: last group's tail first) until it fits.
+    if len(embed) > _EMBED_TOTAL_BUDGET:
+        dropped = 0
+        while len(embed) > _EMBED_TOTAL_BUDGET and any(rendered[k] for k in ordered_keys):
+            # Pop from the last non-empty group.
+            for key in reversed(ordered_keys):
+                if rendered[key]:
+                    rendered[key].pop()
+                    dropped += 1
+                    break
+            embed.clear_fields()
+            _add_fields(rendered)
+        if dropped > 0:
             embed.add_field(
-                name=field_name,
-                value="\n".join(accumulated_lines),
+                name="\u200b",  # zero-width space — Discord requires non-empty name
+                value=f"_…and {dropped} more skills (use Claude CLI to see all)_",
                 inline=False,
             )
 
-    if dropped > 0:
-        embed.add_field(
-            name="\u200b",  # zero-width space — Discord requires a non-empty name
-            value=f"_…and {dropped} more skills (use Claude CLI to see all)_",
-            inline=False,
-        )
-
     return embed
-
-
-def _resolve_channel_id(interaction: discord.Interaction) -> int | None:
-    """Resolve the channel id used for project/session lookups.
-
-    Returns ``None`` for DMs / no-channel contexts so the caller can
-    surface a friendly error. Threads resolve to their parent channel
-    (matching ``_unbound.reject_if_unbound``).
-    """
-    ch = interaction.channel
-    if ch is None:
-        # DM, cache miss, or permission gap.
-        return interaction.channel_id
-    if isinstance(ch, discord.DMChannel):
-        return None
-    if isinstance(ch, discord.Thread):
-        return ch.parent_id or interaction.channel_id
-    return ch.id
 
 
 @skill_group.command(name="list", description="List skills available to the current channel.")
@@ -215,7 +140,7 @@ async def skill_list(interaction: discord.Interaction) -> None:
 
     * **Path A** — if there's already an active ``ClaudeBridge`` for this
       thread/channel, piggyback its connected client and call
-      ``get_server_info()`` directly (~0–1 ms, cached snapshot).
+      ``bridge.get_server_info()`` (~0–1 ms, cached snapshot).
     * **Path B** — otherwise, spin up a transient ``ClaudeSDKClient`` with
       the channel's resolved cwd and the appropriate ``setting_sources``
       (``["user", "project", "local"]`` if bound, ``["user"]`` if not),
@@ -232,12 +157,9 @@ async def skill_list(interaction: discord.Interaction) -> None:
 
     await interaction.response.defer(ephemeral=True)
 
-    # ---- Channel resolution (PRD §Architecture "Channel resolution") ----
-    channel_id = _resolve_channel_id(interaction)
+    channel_id = resolve_channel_id(interaction)
     if channel_id is None:
-        await interaction.followup.send(
-            "❌ This command must be run in a channel.", ephemeral=True
-        )
+        await interaction.followup.send(NO_CHANNEL_MESSAGE, ephemeral=True)
         return
 
     cwd, is_bound = bot.project_manager.get_path_or_default(channel_id)
@@ -246,15 +168,16 @@ async def skill_list(interaction: discord.Interaction) -> None:
     info_err: Exception | None = None
 
     # ---- Path A: piggyback the live bridge if there is one. ----
-    # NOTE: we deliberately touch ``bridge._client`` here. The PRD risk
-    # table (docs/prd/v1.13-skill-list.md §Risks) flags this as private-
-    # attribute access; mitigation is to pin SDK ≥ 0.1.80 and ask
-    # upstream for a public accessor in v1.14.
+    # ``bridge.get_server_info()`` is a cache read of the SDK's
+    # ``_initialization_result``; safe to call concurrently with an
+    # in-flight ``send_message`` stream. We still wrap in a broad
+    # ``except`` because a future SDK refactor could change that —
+    # if it ever raises, Path B handles the cold path.
+    bridge = bot.session_manager.get_session(channel_id)
     try:
-        bridge = bot.session_manager.get_session(channel_id)
-        if bridge is not None and bridge.is_active and bridge._client is not None:
-            info = await bridge._client.get_server_info()
-    except Exception as exc:  # pragma: no cover - defensive; Path B retries
+        if bridge is not None:
+            info = await bridge.get_server_info()
+    except Exception as exc:
         log.debug("Path A get_server_info failed, falling through: %r", exc)
         info = None
 
@@ -263,23 +186,22 @@ async def skill_list(interaction: discord.Interaction) -> None:
         setting_sources = ["user", "project", "local"] if is_bound else ["user"]
         try:
             async with ClaudeSDKClient(
-                ClaudeAgentOptions(cwd=str(cwd), setting_sources=setting_sources)
+                options=ClaudeAgentOptions(
+                    cwd=str(cwd), setting_sources=setting_sources
+                )
             ) as tmp:
                 info = await tmp.get_server_info()
-        except CLINotFoundError as exc:
-            info_err = exc
-        except CLIConnectionError as exc:
-            info_err = exc
-        except Exception as exc:  # noqa: BLE001 — surface any failure as a friendly embed
+        except Exception as exc:  # noqa: BLE001 — any failure → friendly red embed
             info_err = exc
 
     if info_err is not None or info is None:
         if info_err is None:
-            # info is None with no exception — synthetic message preserves the
-            # "type name + value" shape so users see something useful.
-            desc = "`NoServerInfo`: get_server_info() returned None"
+            desc = "Claude CLI returned no command list."
         else:
-            desc = f"`{type(info_err).__name__}`: {info_err}"
+            # Class name only — exception bodies may echo cli_path /
+            # home dirs / env from SDK error strings. Full exception
+            # is in DEBUG logs above for operators.
+            desc = f"`{type(info_err).__name__}`"
         embed = discord.Embed(
             title="❌ Skills unavailable",
             description=desc,
@@ -292,7 +214,7 @@ async def skill_list(interaction: discord.Interaction) -> None:
     commands_list = info.get("commands", []) or []
     groups: dict[str, list[tuple[str, str]]] = {}
     for cmd in commands_list:
-        group, display_name, display_desc = _classify(cmd)
+        group, display_name, display_desc = classify_command(cmd)
         if not group:
             continue
         groups.setdefault(group, []).append((display_name, display_desc))
@@ -303,6 +225,3 @@ async def skill_list(interaction: discord.Interaction) -> None:
         groups, is_bound=is_bound, total_skill_count=total_skill_count
     )
     await interaction.followup.send(embed=embed, ephemeral=True)
-
-
-__all__ = ["skill_group", "skill_list", "_classify"]

--- a/src/clauded/cogs/skill.py
+++ b/src/clauded/cogs/skill.py
@@ -29,106 +29,83 @@ skill_group = app_commands.Group(
 )
 
 
-# Discord per-field hard limit. The total-embed budget caps conservatively
-# below Discord's 6000-char serialized ceiling to leave room for
-# title/footer. Real pagination is a v1.14 follow-up (PRD §Out-of-scope).
-_FIELD_VALUE_CAP = 1024
-_EMBED_TOTAL_BUDGET = 5500
 _DESC_TRUNCATE_AT = 120
+_UNBOUND_FOOTER = (
+    "💡 Unbound channel — showing global skills only. "
+    "Run /project bind <path> to see project skills."
+)
 
 
-def _build_skills_embed(
-    groups: dict[str, list[tuple[str, str]]],
-    *,
-    is_bound: bool,
-    total_skill_count: int,
-) -> discord.Embed:
-    """Render the grouped skills into a single ``discord.Embed``.
+def _ordered_group_keys(grouped: dict[str, list[tuple[str, str]]]) -> list[str]:
+    keys: list[str] = []
+    if "project" in grouped:
+        keys.append("project")
+    if "user" in grouped:
+        keys.append("user")
+    keys.extend(sorted(k for k in grouped if k.startswith("plugin:")))
+    return keys
 
-    Each group becomes one field with rows joined by newlines, capped
-    at the per-field 1024-char limit by simple slice + ellipsis. If
-    the total serialized embed exceeds ``_EMBED_TOTAL_BUDGET`` we
-    drop trailing skills (last group, last rows) until it fits and
-    add a single "…and N more" notice.
 
-    Note: skill names and descriptions are user-visible, sourced from
-    the operator's local ``~/.claude/skills/`` and project
-    ``.claude/skills/`` directories — do not store secrets in skill
-    *names*.
+def _field_label(key: str) -> str:
+    if key == "project":
+        return "Project"
+    if key == "user":
+        return "User (Global)"
+    return f"Plugin: {key[len('plugin:'):]}"
+
+
+def _build_skills_embed(grouped: dict[str, list[tuple[str, str]]], is_unbound: bool) -> discord.Embed:
+    """Render grouped skills into an ephemeral blue embed.
+
+    Per-field cap 1024 chars (Discord limit); per-row desc truncated to 120 chars.
+    If total embed length exceeds 5500 chars (under Discord's 6000), drop trailing
+    rows globally and add a single trailing field noting how many were dropped.
     """
-    embed = discord.Embed(title=f"🧰 Skills ({total_skill_count})", color=COLOR_INFO)
-
-    if not is_bound:
-        embed.set_footer(
-            text=(
-                "💡 Unbound channel — showing global skills only. "
-                "Run /project bind <path> to see project skills."
-            )
-        )
-
-    if total_skill_count == 0:
+    total = sum(len(rows) for rows in grouped.values())
+    embed = discord.Embed(title=f"🧰 Skills ({total})", color=COLOR_INFO)
+    if total == 0:
         embed.description = "No user or project skills installed."
+        if is_unbound:
+            embed.set_footer(text=_UNBOUND_FOOTER)
         return embed
 
-    # Group display order: Project → User (Global) → Plugin:<name> alphabetized.
-    ordered_keys: list[str] = []
-    if "project" in groups:
-        ordered_keys.append("project")
-    if "user" in groups:
-        ordered_keys.append("user")
-    ordered_keys.extend(sorted(k for k in groups if k.startswith("plugin:")))
+    # Build all rows up front in a flat list (group, name, desc-line); we'll
+    # drop from the tail if we exceed the embed budget.
+    flat: list[tuple[str, str]] = []  # (group_label, "• name — desc")
+    for key in _ordered_group_keys(grouped):
+        for name, desc in grouped[key]:
+            d = desc.strip() or "_(no description)_"
+            if len(d) > _DESC_TRUNCATE_AT:
+                d = d[: _DESC_TRUNCATE_AT - 1].rstrip() + "…"
+            flat.append((_field_label(key), f"• {name} — {d}"))
 
-    def _row(name: str, desc: str) -> str:
-        if not desc:
-            body = "_(no description)_"
-        elif len(desc) > _DESC_TRUNCATE_AT:
-            body = desc[:_DESC_TRUNCATE_AT] + "…"
-        else:
-            body = desc
-        return f"• {name} — {body}"
-
-    def _field_label(key: str) -> str:
-        if key == "project":
-            return "Project"
-        if key == "user":
-            return "User (Global)"
-        return f"Plugin: {key[len('plugin:'):]}"  # "plugin:<name>"
-
-    def _add_fields(group_rows: dict[str, list[str]]) -> None:
-        for key in ordered_keys:
-            if key not in group_rows or not group_rows[key]:
-                continue
-            value = "\n".join(group_rows[key])
-            if len(value) > _FIELD_VALUE_CAP:
-                value = value[: _FIELD_VALUE_CAP - 1] + "…"
-            embed.add_field(name=_field_label(key), value=value, inline=False)
-
-    # Initial render: all rows.
-    rendered: dict[str, list[str]] = {
-        key: [_row(n, d) for (n, d) in groups[key]] for key in ordered_keys
-    }
-    _add_fields(rendered)
-
-    # If the serialized embed blew the total budget, drop trailing
-    # rows (deterministic: last group's tail first) until it fits.
-    if len(embed) > _EMBED_TOTAL_BUDGET:
-        dropped = 0
-        while len(embed) > _EMBED_TOTAL_BUDGET and any(rendered[k] for k in ordered_keys):
-            # Pop from the last non-empty group.
-            for key in reversed(ordered_keys):
-                if rendered[key]:
-                    rendered[key].pop()
-                    dropped += 1
+    dropped = 0
+    while True:
+        # Pack consecutive same-group rows into fields, each ≤1024 chars.
+        e = discord.Embed(title=embed.title, color=COLOR_INFO)
+        i = 0
+        while i < len(flat):
+            label = flat[i][0]
+            chunk: list[str] = []
+            chunk_len = 0
+            while i < len(flat) and flat[i][0] == label:
+                row = flat[i][1]
+                if chunk_len + len(row) + 1 > 1024:
                     break
-            embed.clear_fields()
-            _add_fields(rendered)
-        if dropped > 0:
-            embed.add_field(
-                name="\u200b",  # zero-width space — Discord requires non-empty name
-                value=f"_…and {dropped} more skills (use Claude CLI to see all)_",
-                inline=False,
-            )
+                chunk.append(row)
+                chunk_len += len(row) + 1
+                i += 1
+            e.add_field(name=label, value="\n".join(chunk), inline=False)
+        if dropped:
+            e.add_field(name="\u200b", value=f"_…and {dropped} more skills (use Claude CLI to see all)_", inline=False)
+        if len(e) <= 5500 or not flat:
+            embed = e
+            break
+        flat.pop()
+        dropped += 1
 
+    if is_unbound:
+        embed.set_footer(text=_UNBOUND_FOOTER)
     return embed
 
 
@@ -136,17 +113,8 @@ def _build_skills_embed(
 async def skill_list(interaction: discord.Interaction) -> None:
     """List user/project/plugin skills the Claude session can auto-invoke.
 
-    Two probe paths:
-
-    * **Path A** — if there's already an active ``ClaudeBridge`` for this
-      thread/channel, piggyback its connected client and call
-      ``bridge.get_server_info()`` (~0–1 ms, cached snapshot).
-    * **Path B** — otherwise, spin up a transient ``ClaudeSDKClient`` with
-      the channel's resolved cwd and the appropriate ``setting_sources``
-      (``["user", "project", "local"]`` if bound, ``["user"]`` if not),
-      then ``get_server_info()`` (~2–4 s cold start).
-
-    See PRD ``docs/prd/v1.13-skill-list.md`` §Architecture.
+    See PRD ``docs/prd/v1.13-skill-list.md`` §Architecture for Path A
+    (bridge piggyback) vs Path B (transient SDK client) details.
     """
     from ..bot import ClaudedBot
 
@@ -167,12 +135,7 @@ async def skill_list(interaction: discord.Interaction) -> None:
     info: dict | None = None
     info_err: Exception | None = None
 
-    # ---- Path A: piggyback the live bridge if there is one. ----
-    # ``bridge.get_server_info()`` is a cache read of the SDK's
-    # ``_initialization_result``; safe to call concurrently with an
-    # in-flight ``send_message`` stream. We still wrap in a broad
-    # ``except`` because a future SDK refactor could change that —
-    # if it ever raises, Path B handles the cold path.
+    # Path A: piggyback the live bridge if there is one.
     bridge = bot.session_manager.get_session(channel_id)
     try:
         if bridge is not None:
@@ -181,7 +144,7 @@ async def skill_list(interaction: discord.Interaction) -> None:
         log.debug("Path A get_server_info failed, falling through: %r", exc)
         info = None
 
-    # ---- Path B: spin up a transient client. ----
+    # Path B: spin up a transient client.
     if info is None:
         setting_sources = ["user", "project", "local"] if is_bound else ["user"]
         try:
@@ -210,7 +173,7 @@ async def skill_list(interaction: discord.Interaction) -> None:
         await interaction.followup.send(embed=embed, ephemeral=True)
         return
 
-    # ---- Classify and group ----
+    # Classify and group.
     commands_list = info.get("commands", []) or []
     groups: dict[str, list[tuple[str, str]]] = {}
     for cmd in commands_list:
@@ -219,9 +182,5 @@ async def skill_list(interaction: discord.Interaction) -> None:
             continue
         groups.setdefault(group, []).append((display_name, display_desc))
 
-    total_skill_count = sum(len(v) for v in groups.values())
-
-    embed = _build_skills_embed(
-        groups, is_bound=is_bound, total_skill_count=total_skill_count
-    )
+    embed = _build_skills_embed(groups, is_unbound=not is_bound)
     await interaction.followup.send(embed=embed, ephemeral=True)

--- a/src/clauded/cogs/skill.py
+++ b/src/clauded/cogs/skill.py
@@ -1,0 +1,308 @@
+"""Skill discovery commands: /skill group.
+
+Adds ``/skill list`` (PRD docs/prd/v1.13-skill-list.md, issue #109): lists
+the user/project/plugin slash-commands that the Claude CLI will inject
+into the current channel's session. Built-in commands (``clear``,
+``compact``, …) are filtered out so users only see "skills" — i.e., the
+content of ``~/.claude/skills/`` and ``<project>/.claude/skills/``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord import app_commands
+
+from claude_agent_sdk import (
+    ClaudeSDKClient,
+    ClaudeAgentOptions,
+    CLINotFoundError,
+    CLIConnectionError,
+)
+
+from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE
+
+log = logging.getLogger("clauded.bot")
+
+
+skill_group = app_commands.Group(
+    name="skill",
+    description="List skills available to the Claude session.",
+)
+
+
+def _classify(cmd: dict) -> tuple[str, str, str]:
+    """Return ``(group, displayName, displayDescription)`` for a CLI command.
+
+    ``group`` is one of ``"user"``, ``"project"``, ``"plugin:<name>"``, or
+    ``""`` for built-in commands (which the caller filters out). The
+    displayed description has the source-tag suffix stripped.
+
+    See PRD §Architecture for the source-tag-suffix encoding.
+    """
+    name = cmd.get("name", "")
+    desc = cmd.get("description", "") or ""
+    if desc.endswith(" (user)"):
+        return ("user", name, desc[:-7].rstrip())
+    if desc.endswith(" (project)"):
+        return ("project", name, desc[:-10].rstrip())
+    if desc.endswith(")") and " (plugin:" in desc:
+        # " (plugin:foo)" — extract plugin name
+        idx = desc.rfind(" (plugin:")
+        plugin_name = desc[idx + 9:-1]
+        return (f"plugin:{plugin_name}", name, desc[:idx].rstrip())
+    return ("", "", "")  # built-in — filter out
+
+
+# Discord limits we observe defensively. Per-field value cap is the hard
+# 1024-char Discord limit; the 4000-char total budget comes from the PRD
+# truncation guard (see PRD edge-case ">4000 chars total embed content").
+_FIELD_VALUE_CAP = 1024
+_EMBED_TOTAL_BUDGET = 4000
+_DESC_TRUNCATE_AT = 120
+
+
+def _format_row(name: str, desc: str) -> str:
+    """Render a single skill row: ``• <name> — <truncated desc>``."""
+    if not desc:
+        body = "_(no description)_"
+    elif len(desc) > _DESC_TRUNCATE_AT:
+        body = desc[:_DESC_TRUNCATE_AT] + "…"
+    else:
+        body = desc
+    return f"• {name} — {body}"
+
+
+def _ordered_group_keys(groups: dict[str, list[tuple[str, str]]]) -> list[str]:
+    """Return group keys in the PRD display order.
+
+    Order: Project, User (Global), then each Plugin alphabetized. Missing
+    groups are simply absent.
+    """
+    keys: list[str] = []
+    if "project" in groups:
+        keys.append("project")
+    if "user" in groups:
+        keys.append("user")
+    plugin_keys = sorted(k for k in groups if k.startswith("plugin:"))
+    keys.extend(plugin_keys)
+    return keys
+
+
+def _group_field_name(key: str) -> str:
+    if key == "project":
+        return "Project"
+    if key == "user":
+        return "User (Global)"
+    if key.startswith("plugin:"):
+        return f"Plugin: {key[len('plugin:'):]}"
+    return key  # defensive
+
+
+def _build_skills_embed(
+    groups: dict[str, list[tuple[str, str]]],
+    *,
+    is_bound: bool,
+    total_skill_count: int,
+) -> discord.Embed:
+    """Render the grouped skills into a single ``discord.Embed``.
+
+    Enforces both Discord's per-field 1024-char limit AND the PRD
+    4000-char total-embed budget by trimming rows from the tail and
+    appending a "…and N more" notice if anything had to be dropped.
+    """
+    embed = discord.Embed(title=f"🧰 Skills ({total_skill_count})", color=COLOR_INFO)
+
+    if not is_bound:
+        embed.set_footer(
+            text=(
+                "💡 Unbound channel — showing global skills only. "
+                "Run /project bind <path> to see project skills."
+            )
+        )
+
+    if total_skill_count == 0:
+        embed.description = "No user or project skills installed."
+        return embed
+
+    # Build (key, [rendered_row, …]) in display order. We render every row
+    # up-front so we can compute the truncation tail accurately.
+    ordered: list[tuple[str, list[str]]] = []
+    for key in _ordered_group_keys(groups):
+        rows = [_format_row(n, d) for (n, d) in groups[key]]
+        ordered.append((key, rows))
+
+    # Walk groups in order, packing rows into each field while respecting
+    # the per-field 1024-char cap and the per-embed 4000-char cap. Rows
+    # we couldn't fit get counted as "dropped".
+    dropped = 0
+    truncation_field_overhead = 64  # rough budget for the "…and N more" line
+
+    def current_len(e: discord.Embed) -> int:
+        # discord.py's ``Embed.__len__`` returns the serialized length.
+        return len(e)
+
+    for key, rows in ordered:
+        field_name = _group_field_name(key)
+        if not rows:
+            continue
+        accumulated_lines: list[str] = []
+        accumulated_len = 0  # tracks accumulated body length only
+        for row in rows:
+            # +1 for the joining newline if there's already something there.
+            extra = len(row) + (1 if accumulated_lines else 0)
+            new_field_len = accumulated_len + extra
+            if new_field_len > _FIELD_VALUE_CAP:
+                dropped += 1
+                continue
+            # Tentative new total: simulate adding this row to the field.
+            # We compute the would-be total length by adding the row
+            # (and possibly a newline) plus, on first row of a new field,
+            # the field-name + structural overhead (~ len(name) + ~6).
+            structural = 0 if accumulated_lines else len(field_name) + 6
+            tentative_total = (
+                current_len(embed)
+                + extra
+                + structural
+                + truncation_field_overhead
+            )
+            if tentative_total > _EMBED_TOTAL_BUDGET:
+                dropped += 1
+                continue
+            accumulated_lines.append(row)
+            accumulated_len += extra
+        if accumulated_lines:
+            embed.add_field(
+                name=field_name,
+                value="\n".join(accumulated_lines),
+                inline=False,
+            )
+
+    if dropped > 0:
+        embed.add_field(
+            name="\u200b",  # zero-width space — Discord requires a non-empty name
+            value=f"_…and {dropped} more skills (use Claude CLI to see all)_",
+            inline=False,
+        )
+
+    return embed
+
+
+def _resolve_channel_id(interaction: discord.Interaction) -> int | None:
+    """Resolve the channel id used for project/session lookups.
+
+    Returns ``None`` for DMs / no-channel contexts so the caller can
+    surface a friendly error. Threads resolve to their parent channel
+    (matching ``_unbound.reject_if_unbound``).
+    """
+    ch = interaction.channel
+    if ch is None:
+        # DM, cache miss, or permission gap.
+        return interaction.channel_id
+    if isinstance(ch, discord.DMChannel):
+        return None
+    if isinstance(ch, discord.Thread):
+        return ch.parent_id or interaction.channel_id
+    return ch.id
+
+
+@skill_group.command(name="list", description="List skills available to the current channel.")
+async def skill_list(interaction: discord.Interaction) -> None:
+    """List user/project/plugin skills the Claude session can auto-invoke.
+
+    Two probe paths:
+
+    * **Path A** — if there's already an active ``ClaudeBridge`` for this
+      thread/channel, piggyback its connected client and call
+      ``get_server_info()`` directly (~0–1 ms, cached snapshot).
+    * **Path B** — otherwise, spin up a transient ``ClaudeSDKClient`` with
+      the channel's resolved cwd and the appropriate ``setting_sources``
+      (``["user", "project", "local"]`` if bound, ``["user"]`` if not),
+      then ``get_server_info()`` (~2–4 s cold start).
+
+    See PRD ``docs/prd/v1.13-skill-list.md`` §Architecture.
+    """
+    from ..bot import ClaudedBot
+
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+
+    await interaction.response.defer(ephemeral=True)
+
+    # ---- Channel resolution (PRD §Architecture "Channel resolution") ----
+    channel_id = _resolve_channel_id(interaction)
+    if channel_id is None:
+        await interaction.followup.send(
+            "❌ This command must be run in a channel.", ephemeral=True
+        )
+        return
+
+    cwd, is_bound = bot.project_manager.get_path_or_default(channel_id)
+
+    info: dict | None = None
+    info_err: Exception | None = None
+
+    # ---- Path A: piggyback the live bridge if there is one. ----
+    # NOTE: we deliberately touch ``bridge._client`` here. The PRD risk
+    # table (docs/prd/v1.13-skill-list.md §Risks) flags this as private-
+    # attribute access; mitigation is to pin SDK ≥ 0.1.80 and ask
+    # upstream for a public accessor in v1.14.
+    try:
+        bridge = bot.session_manager.get_session(channel_id)
+        if bridge is not None and bridge.is_active and bridge._client is not None:
+            info = await bridge._client.get_server_info()
+    except Exception as exc:  # pragma: no cover - defensive; Path B retries
+        log.debug("Path A get_server_info failed, falling through: %r", exc)
+        info = None
+
+    # ---- Path B: spin up a transient client. ----
+    if info is None:
+        setting_sources = ["user", "project", "local"] if is_bound else ["user"]
+        try:
+            async with ClaudeSDKClient(
+                ClaudeAgentOptions(cwd=str(cwd), setting_sources=setting_sources)
+            ) as tmp:
+                info = await tmp.get_server_info()
+        except CLINotFoundError as exc:
+            info_err = exc
+        except CLIConnectionError as exc:
+            info_err = exc
+        except Exception as exc:  # noqa: BLE001 — surface any failure as a friendly embed
+            info_err = exc
+
+    if info_err is not None or info is None:
+        if info_err is None:
+            # info is None with no exception — synthetic message preserves the
+            # "type name + value" shape so users see something useful.
+            desc = "`NoServerInfo`: get_server_info() returned None"
+        else:
+            desc = f"`{type(info_err).__name__}`: {info_err}"
+        embed = discord.Embed(
+            title="❌ Skills unavailable",
+            description=desc,
+            color=COLOR_TOOL_FAILURE,
+        )
+        await interaction.followup.send(embed=embed, ephemeral=True)
+        return
+
+    # ---- Classify and group ----
+    commands_list = info.get("commands", []) or []
+    groups: dict[str, list[tuple[str, str]]] = {}
+    for cmd in commands_list:
+        group, display_name, display_desc = _classify(cmd)
+        if not group:
+            continue
+        groups.setdefault(group, []).append((display_name, display_desc))
+
+    total_skill_count = sum(len(v) for v in groups.values())
+
+    embed = _build_skills_embed(
+        groups, is_bound=is_bound, total_skill_count=total_skill_count
+    )
+    await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+__all__ = ["skill_group", "skill_list", "_classify"]

--- a/src/clauded/skill_parser.py
+++ b/src/clauded/skill_parser.py
@@ -1,0 +1,48 @@
+"""SDK source-tag parser shared by /skill list (and future /skill info).
+
+The Claude Code CLI's ``get_server_info()["commands"]`` encodes the
+source of each command as a trailing description suffix:
+
+* ``" (user)"`` — user-level skill from ``~/.claude/skills/``
+* ``" (project)"`` — project-local skill from ``<project>/.claude/skills/``
+* ``" (plugin:<name>)"`` — plugin-provided command
+
+Built-in commands (``clear``, ``compact``, ``init``, …) have no suffix.
+
+This module parses that convention into a structured
+``(group, name, description)`` tuple. The grammar is undocumented SDK
+surface — pinned by live probe on 2026-05-11 and acceptance-tested in
+``tests/test_skill_parser.py``.
+"""
+
+from __future__ import annotations
+
+
+def classify_command(cmd: dict) -> tuple[str, str, str]:
+    """Return ``(group, display_name, display_desc)`` for a CLI command.
+
+    ``group`` is one of ``"user"``, ``"project"``, ``"plugin:<name>"``,
+    or ``""`` for built-in / unrecognized commands (which the caller is
+    expected to filter out). The displayed description has the
+    source-tag suffix stripped.
+    """
+    name = cmd.get("name", "")
+    desc = cmd.get("description", "") or ""
+    if desc.endswith(" (user)"):
+        return ("user", name, desc[:-7].rstrip())
+    if desc.endswith(" (project)"):
+        return ("project", name, desc[:-10].rstrip())
+    if desc.endswith(")") and " (plugin:" in desc:
+        # " (plugin:foo)" — extract plugin name. We require the slice
+        # between "(plugin:" and the trailing ")" to be paren-free so
+        # that descriptions like "X (plugin:p) extra)" (where the
+        # trailing ")" is not the plugin marker's close) fall through.
+        idx = desc.rfind(" (plugin:")
+        plugin_name = desc[idx + 9:-1]
+        if ")" in plugin_name or "(" in plugin_name:
+            return ("", "", "")
+        return (f"plugin:{plugin_name}", name, desc[:idx].rstrip())
+    return ("", "", "")  # built-in — filter out
+
+
+__all__ = ["classify_command"]

--- a/src/clauded/skill_parser.py
+++ b/src/clauded/skill_parser.py
@@ -1,31 +1,16 @@
-"""SDK source-tag parser shared by /skill list (and future /skill info).
+"""SDK source-tag parser for ``/skill list``.
 
-The Claude Code CLI's ``get_server_info()["commands"]`` encodes the
-source of each command as a trailing description suffix:
-
-* ``" (user)"`` — user-level skill from ``~/.claude/skills/``
-* ``" (project)"`` — project-local skill from ``<project>/.claude/skills/``
-* ``" (plugin:<name>)"`` — plugin-provided command
-
-Built-in commands (``clear``, ``compact``, ``init``, …) have no suffix.
-
-This module parses that convention into a structured
-``(group, name, description)`` tuple. The grammar is undocumented SDK
-surface — pinned by live probe on 2026-05-11 and acceptance-tested in
-``tests/test_skill_parser.py``.
+Parses the trailing ``" (user)" / " (project)" / " (plugin:<name>)"``
+suffix that Claude CLI's ``get_server_info()["commands"]`` puts on each
+command's description. Pinned by live probe 2026-05-11; built-ins have
+no suffix and return ``("", "", "")``.
 """
 
 from __future__ import annotations
 
 
 def classify_command(cmd: dict) -> tuple[str, str, str]:
-    """Return ``(group, display_name, display_desc)`` for a CLI command.
-
-    ``group`` is one of ``"user"``, ``"project"``, ``"plugin:<name>"``,
-    or ``""`` for built-in / unrecognized commands (which the caller is
-    expected to filter out). The displayed description has the
-    source-tag suffix stripped.
-    """
+    """Return ``(group, display_name, display_desc)``; ``group=""`` for built-ins."""
     name = cmd.get("name", "")
     desc = cmd.get("description", "") or ""
     if desc.endswith(" (user)"):
@@ -33,16 +18,12 @@ def classify_command(cmd: dict) -> tuple[str, str, str]:
     if desc.endswith(" (project)"):
         return ("project", name, desc[:-10].rstrip())
     if desc.endswith(")") and " (plugin:" in desc:
-        # " (plugin:foo)" — extract plugin name. We require the slice
-        # between "(plugin:" and the trailing ")" to be paren-free so
-        # that descriptions like "X (plugin:p) extra)" (where the
-        # trailing ")" is not the plugin marker's close) fall through.
+        # Require the slice between "(plugin:" and the trailing ")" to be
+        # paren-free so "X (plugin:p) extra)" (where the trailing ")" is
+        # not the plugin marker's close) falls through to built-in.
         idx = desc.rfind(" (plugin:")
         plugin_name = desc[idx + 9:-1]
         if ")" in plugin_name or "(" in plugin_name:
             return ("", "", "")
         return (f"plugin:{plugin_name}", name, desc[:idx].rstrip())
-    return ("", "", "")  # built-in — filter out
-
-
-__all__ = ["classify_command"]
+    return ("", "", "")

--- a/tests/test_skill_list.py
+++ b/tests/test_skill_list.py
@@ -1,0 +1,444 @@
+"""Tests for ``/skill list`` (PRD docs/prd/v1.13-skill-list.md, issue #109).
+
+Covers the PRD §Tests checklist:
+
+* ``_classify`` table-driven over (user), (project), (plugin:foo), no
+  suffix, and the edge case ``"foo (plugin:bar) more text"`` (must NOT
+  be classified as a plugin because the suffix is not at end-of-string).
+* Path A — active bridge piggyback.
+* Path B — temp ``ClaudeSDKClient`` for bound + unbound channels.
+* ``CLIConnectionError`` → red error embed.
+* ``get_server_info()`` returns ``None`` → red error embed.
+* Empty/built-in-only commands list → empty-state body.
+* 50 user skills with long descriptions → no field >1024 chars and the
+  truncation footer is appended when we have to drop rows.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import discord
+
+from clauded.bot import ClaudedBot
+from clauded.cogs.skill import _classify, skill_list
+
+
+# ---------------------------------------------------------------------------
+# _classify — table-driven
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "cmd, expected",
+    [
+        # User skill
+        (
+            {"name": "crew", "description": "Multi-agent workflow (user)"},
+            ("user", "crew", "Multi-agent workflow"),
+        ),
+        # Project skill
+        (
+            {"name": "testproj", "description": "Project-specific tooling (project)"},
+            ("project", "testproj", "Project-specific tooling"),
+        ),
+        # Plugin skill
+        (
+            {"name": "myplug", "description": "From a plugin (plugin:myplug)"},
+            ("plugin:myplug", "myplug", "From a plugin"),
+        ),
+        # Built-in (no suffix)
+        (
+            {"name": "clear", "description": "Clear the chat"},
+            ("", "", ""),
+        ),
+        # Empty description — built-in / unrecognized
+        (
+            {"name": "noop", "description": ""},
+            ("", "", ""),
+        ),
+        # None description — handled by "or ''"
+        (
+            {"name": "noop2", "description": None},
+            ("", "", ""),
+        ),
+        # Edge: " (plugin:bar)" appears mid-string, description does NOT end
+        # with ")". Must NOT classify as plugin.
+        (
+            {"name": "foo", "description": "foo (plugin:bar) more text"},
+            ("", "", ""),
+        ),
+        # Edge: description ends with ")" but not the plugin marker.
+        (
+            {"name": "bar", "description": "does math (rounded)"},
+            ("", "", ""),
+        ),
+        # Edge: trailing whitespace before the suffix is rstripped.
+        (
+            {"name": "tidy", "description": "Trim trailing spaces   (user)"},
+            ("user", "tidy", "Trim trailing spaces"),
+        ),
+        # Edge: missing description key.
+        (
+            {"name": "anon"},
+            ("", "", ""),
+        ),
+    ],
+)
+def test_classify(cmd, expected):
+    assert _classify(cmd) == expected
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+# Mirrors the live-probe shape: 2 user + 1 project + 1 plugin + 3 built-ins.
+FIXTURE_COMMANDS = [
+    {"name": "crew", "description": "Multi-agent dev workflow (user)"},
+    {"name": "opc", "description": "One-person company workflow (user)"},
+    {"name": "testproj", "description": "Project helper (project)"},
+    {"name": "myplug", "description": "Plugin command (plugin:myplug)"},
+    {"name": "clear", "description": "Clear chat"},
+    {"name": "compact", "description": "Compact context"},
+    {"name": "init", "description": "Initialize project"},
+]
+FIXTURE_INFO = {"commands": FIXTURE_COMMANDS}
+
+
+def _make_interaction(*, channel_id: int = 4242, is_thread: bool = False) -> MagicMock:
+    if is_thread:
+        channel = MagicMock(spec=discord.Thread)
+        channel.id = 9999
+        channel.parent_id = channel_id
+    else:
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.id = channel_id
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = channel
+    interaction.channel_id = channel_id
+    interaction.client = None  # set per-test
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+
+    async def _defer(*_a, **_kw):
+        interaction.response.is_done.configure_mock(return_value=True)
+
+    interaction.response.defer = AsyncMock(side_effect=_defer)
+    interaction.response.send_message = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_bot(*, is_bound: bool, bridge=None) -> MagicMock:
+    bot = MagicMock(spec=ClaudedBot)
+    bot.project_manager = MagicMock()
+    bot.project_manager.get_path_or_default = MagicMock(
+        return_value=(Path("/tmp/fake-cwd"), is_bound)
+    )
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=bridge)
+    return bot
+
+
+class _FakeAsyncCtx:
+    """Async-context-manager fake returning ``client`` from ``__aenter__``."""
+
+    def __init__(self, client):
+        self._client = client
+
+    async def __aenter__(self):
+        return self._client
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Path A — active bridge piggyback
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_path_a_uses_bridge_client_and_does_not_spin_temp():
+    bridge_client = MagicMock()
+    bridge_client.get_server_info = AsyncMock(return_value=FIXTURE_INFO)
+    bridge = MagicMock()
+    bridge.is_active = True
+    bridge._client = bridge_client
+
+    bot = _make_bot(is_bound=True, bridge=bridge)
+    interaction = _make_interaction()
+    interaction.client = bot
+
+    with patch("clauded.cogs.skill.ClaudeSDKClient") as fake_ctor:
+        await skill_list.callback(interaction)
+
+    bridge_client.get_server_info.assert_awaited_once()
+    fake_ctor.assert_not_called()  # no Path B spin-up
+
+    # The embed shape: 4 skills total (2 user + 1 project + 1 plugin),
+    # built-ins filtered.
+    sent = interaction.followup.send.await_args
+    embed = sent.kwargs["embed"]
+    assert isinstance(embed, discord.Embed)
+    assert embed.title == "🧰 Skills (4)"
+    field_names = [f.name for f in embed.fields]
+    assert "Project" in field_names
+    assert "User (Global)" in field_names
+    assert "Plugin: myplug" in field_names
+    # Bound: no unbound-footer.
+    assert embed.footer.text in (None, discord.Embed.Empty if hasattr(discord.Embed, "Empty") else None)
+
+
+# ---------------------------------------------------------------------------
+# Path B — bound channel uses ["user", "project", "local"]
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_path_b_bound_uses_full_setting_sources():
+    bot = _make_bot(is_bound=True, bridge=None)
+    interaction = _make_interaction()
+    interaction.client = bot
+
+    fake_client = MagicMock()
+    fake_client.get_server_info = AsyncMock(return_value=FIXTURE_INFO)
+
+    with patch("clauded.cogs.skill.ClaudeSDKClient") as fake_ctor, patch(
+        "clauded.cogs.skill.ClaudeAgentOptions"
+    ) as fake_opts:
+        fake_ctor.return_value = _FakeAsyncCtx(fake_client)
+        await skill_list.callback(interaction)
+
+    fake_opts.assert_called_once()
+    kwargs = fake_opts.call_args.kwargs
+    assert kwargs["setting_sources"] == ["user", "project", "local"]
+    assert kwargs["cwd"] == "/tmp/fake-cwd"
+    fake_ctor.assert_called_once()
+    fake_client.get_server_info.assert_awaited_once()
+
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert embed.title == "🧰 Skills (4)"
+
+
+# ---------------------------------------------------------------------------
+# Path B — unbound channel uses ["user"] only + footer
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_path_b_unbound_uses_user_only_and_adds_footer():
+    bot = _make_bot(is_bound=False, bridge=None)
+    interaction = _make_interaction()
+    interaction.client = bot
+
+    # In an unbound channel the SDK would only return user + built-ins.
+    unbound_info = {
+        "commands": [
+            {"name": "crew", "description": "Multi-agent dev workflow (user)"},
+            {"name": "opc", "description": "One-person company workflow (user)"},
+            {"name": "clear", "description": "Clear chat"},
+        ]
+    }
+    fake_client = MagicMock()
+    fake_client.get_server_info = AsyncMock(return_value=unbound_info)
+
+    with patch("clauded.cogs.skill.ClaudeSDKClient") as fake_ctor, patch(
+        "clauded.cogs.skill.ClaudeAgentOptions"
+    ) as fake_opts:
+        fake_ctor.return_value = _FakeAsyncCtx(fake_client)
+        await skill_list.callback(interaction)
+
+    kwargs = fake_opts.call_args.kwargs
+    assert kwargs["setting_sources"] == ["user"]
+
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert embed.title == "🧰 Skills (2)"
+    # Footer presence is the key acceptance.
+    assert embed.footer.text is not None
+    assert "Unbound channel" in embed.footer.text
+    assert "/project bind" in embed.footer.text
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cli_connection_error_returns_red_embed():
+    from claude_agent_sdk import CLIConnectionError
+
+    bot = _make_bot(is_bound=True, bridge=None)
+    interaction = _make_interaction()
+    interaction.client = bot
+
+    class _Boom:
+        async def __aenter__(self):
+            raise CLIConnectionError("boom")
+
+        async def __aexit__(self, *a):
+            return False
+
+    with patch("clauded.cogs.skill.ClaudeSDKClient", return_value=_Boom()):
+        await skill_list.callback(interaction)
+
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert embed.title == "❌ Skills unavailable"
+    assert "CLIConnectionError" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_cli_not_found_error_returns_red_embed():
+    from claude_agent_sdk import CLINotFoundError
+
+    bot = _make_bot(is_bound=True, bridge=None)
+    interaction = _make_interaction()
+    interaction.client = bot
+
+    class _Boom:
+        async def __aenter__(self):
+            raise CLINotFoundError("no claude")
+
+        async def __aexit__(self, *a):
+            return False
+
+    with patch("clauded.cogs.skill.ClaudeSDKClient", return_value=_Boom()):
+        await skill_list.callback(interaction)
+
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert embed.title == "❌ Skills unavailable"
+    assert "CLINotFoundError" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_get_server_info_returns_none_yields_red_embed():
+    bot = _make_bot(is_bound=True, bridge=None)
+    interaction = _make_interaction()
+    interaction.client = bot
+
+    fake_client = MagicMock()
+    fake_client.get_server_info = AsyncMock(return_value=None)
+
+    with patch("clauded.cogs.skill.ClaudeSDKClient") as fake_ctor:
+        fake_ctor.return_value = _FakeAsyncCtx(fake_client)
+        await skill_list.callback(interaction)
+
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert embed.title == "❌ Skills unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Empty state
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_empty_commands_yields_empty_state_line():
+    bot = _make_bot(is_bound=True, bridge=None)
+    interaction = _make_interaction()
+    interaction.client = bot
+
+    fake_client = MagicMock()
+    fake_client.get_server_info = AsyncMock(
+        return_value={"commands": [{"name": "clear", "description": "Clear"}]}
+    )
+
+    with patch("clauded.cogs.skill.ClaudeSDKClient") as fake_ctor:
+        fake_ctor.return_value = _FakeAsyncCtx(fake_client)
+        await skill_list.callback(interaction)
+
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert embed.title == "🧰 Skills (0)"
+    assert embed.description == "No user or project skills installed."
+
+
+# ---------------------------------------------------------------------------
+# Pagination guard — 50 long user skills must not overflow Discord limits
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_many_skills_truncated_within_embed_budget():
+    bot = _make_bot(is_bound=True, bridge=None)
+    interaction = _make_interaction()
+    interaction.client = bot
+
+    # 50 user skills, each with a ~200-char description so we definitely
+    # blow past the per-field 1024-char cap if untruncated.
+    long_desc = "x" * 200
+    commands = [
+        {"name": f"skill{i:02d}", "description": f"{long_desc} (user)"}
+        for i in range(50)
+    ]
+    fake_client = MagicMock()
+    fake_client.get_server_info = AsyncMock(return_value={"commands": commands})
+
+    with patch("clauded.cogs.skill.ClaudeSDKClient") as fake_ctor:
+        fake_ctor.return_value = _FakeAsyncCtx(fake_client)
+        await skill_list.callback(interaction)
+
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+
+    # All fields stay within Discord's 1024-char value limit.
+    for field in embed.fields:
+        assert field.value is not None
+        assert len(field.value) <= 1024, f"field {field.name!r} too long: {len(field.value)}"
+
+    # Serialized embed stays within Discord's 6000-char total ceiling
+    # (and we aim much lower per the PRD's 4000-char budget).
+    assert len(embed) <= 6000
+
+    # If anything was dropped, the truncation footer is present.
+    truncation_present = any(
+        "more skills" in (f.value or "") for f in embed.fields
+    )
+    # With 50×~200-char rows in a single field we definitely drop rows.
+    assert truncation_present, "expected truncation notice with 50 long skills"
+
+
+# ---------------------------------------------------------------------------
+# Half-broken SKILL.md — empty description shows "_(no description)_"
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_empty_description_renders_no_description_placeholder():
+    bot = _make_bot(is_bound=True, bridge=None)
+    interaction = _make_interaction()
+    interaction.client = bot
+
+    fake_client = MagicMock()
+    fake_client.get_server_info = AsyncMock(
+        return_value={
+            "commands": [
+                {"name": "halfbroken", "description": " (user)"},
+            ]
+        }
+    )
+    with patch("clauded.cogs.skill.ClaudeSDKClient") as fake_ctor:
+        fake_ctor.return_value = _FakeAsyncCtx(fake_client)
+        await skill_list.callback(interaction)
+
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    # Empty stripped desc → "_(no description)_"
+    user_field = next(f for f in embed.fields if f.name == "User (Global)")
+    assert "_(no description)_" in user_field.value
+
+
+# ---------------------------------------------------------------------------
+# Thread channel resolves to parent_id
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_thread_channel_resolves_to_parent_id():
+    bot = _make_bot(is_bound=True, bridge=None)
+    interaction = _make_interaction(channel_id=4242, is_thread=True)
+    interaction.client = bot
+
+    fake_client = MagicMock()
+    fake_client.get_server_info = AsyncMock(return_value=FIXTURE_INFO)
+
+    with patch("clauded.cogs.skill.ClaudeSDKClient") as fake_ctor:
+        fake_ctor.return_value = _FakeAsyncCtx(fake_client)
+        await skill_list.callback(interaction)
+
+    # parent_id is 4242 — that's what should be passed to project_manager.
+    bot.project_manager.get_path_or_default.assert_called_with(4242)

--- a/tests/test_skill_list.py
+++ b/tests/test_skill_list.py
@@ -1,17 +1,10 @@
 """Tests for ``/skill list`` (PRD docs/prd/v1.13-skill-list.md, issue #109).
 
-Covers the PRD §Tests checklist:
-
-* ``_classify`` table-driven over (user), (project), (plugin:foo), no
-  suffix, and the edge case ``"foo (plugin:bar) more text"`` (must NOT
-  be classified as a plugin because the suffix is not at end-of-string).
-* Path A — active bridge piggyback.
-* Path B — temp ``ClaudeSDKClient`` for bound + unbound channels.
-* ``CLIConnectionError`` → red error embed.
-* ``get_server_info()`` returns ``None`` → red error embed.
-* Empty/built-in-only commands list → empty-state body.
-* 50 user skills with long descriptions → no field >1024 chars and the
-  truncation footer is appended when we have to drop rows.
+Classify tests live in ``tests/test_skill_parser.py`` (R1 #C5 — parser
+moved to ``clauded.skill_parser``). This file covers the cog wiring:
+Path A piggyback, Path A → Path B fallthrough, Path B bound/unbound,
+errors, empty state, truncation, half-broken descriptions, and channel
+resolution (thread + DM).
 """
 
 from __future__ import annotations
@@ -20,75 +13,10 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 import discord
 
 from clauded.bot import ClaudedBot
-from clauded.cogs.skill import _classify, skill_list
-
-
-# ---------------------------------------------------------------------------
-# _classify — table-driven
-# ---------------------------------------------------------------------------
-
-@pytest.mark.parametrize(
-    "cmd, expected",
-    [
-        # User skill
-        (
-            {"name": "crew", "description": "Multi-agent workflow (user)"},
-            ("user", "crew", "Multi-agent workflow"),
-        ),
-        # Project skill
-        (
-            {"name": "testproj", "description": "Project-specific tooling (project)"},
-            ("project", "testproj", "Project-specific tooling"),
-        ),
-        # Plugin skill
-        (
-            {"name": "myplug", "description": "From a plugin (plugin:myplug)"},
-            ("plugin:myplug", "myplug", "From a plugin"),
-        ),
-        # Built-in (no suffix)
-        (
-            {"name": "clear", "description": "Clear the chat"},
-            ("", "", ""),
-        ),
-        # Empty description — built-in / unrecognized
-        (
-            {"name": "noop", "description": ""},
-            ("", "", ""),
-        ),
-        # None description — handled by "or ''"
-        (
-            {"name": "noop2", "description": None},
-            ("", "", ""),
-        ),
-        # Edge: " (plugin:bar)" appears mid-string, description does NOT end
-        # with ")". Must NOT classify as plugin.
-        (
-            {"name": "foo", "description": "foo (plugin:bar) more text"},
-            ("", "", ""),
-        ),
-        # Edge: description ends with ")" but not the plugin marker.
-        (
-            {"name": "bar", "description": "does math (rounded)"},
-            ("", "", ""),
-        ),
-        # Edge: trailing whitespace before the suffix is rstripped.
-        (
-            {"name": "tidy", "description": "Trim trailing spaces   (user)"},
-            ("user", "tidy", "Trim trailing spaces"),
-        ),
-        # Edge: missing description key.
-        (
-            {"name": "anon"},
-            ("", "", ""),
-        ),
-    ],
-)
-def test_classify(cmd, expected):
-    assert _classify(cmd) == expected
+from clauded.cogs.skill import skill_list
 
 
 # ---------------------------------------------------------------------------
@@ -121,12 +49,7 @@ def _make_interaction(*, channel_id: int = 4242, is_thread: bool = False) -> Mag
     interaction.channel_id = channel_id
     interaction.client = None  # set per-test
     interaction.response = MagicMock()
-    interaction.response.is_done = MagicMock(return_value=False)
-
-    async def _defer(*_a, **_kw):
-        interaction.response.is_done.configure_mock(return_value=True)
-
-    interaction.response.defer = AsyncMock(side_effect=_defer)
+    interaction.response.defer = AsyncMock()
     interaction.response.send_message = AsyncMock()
     interaction.followup = MagicMock()
     interaction.followup.send = AsyncMock()
@@ -162,12 +85,9 @@ class _FakeAsyncCtx:
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_path_a_uses_bridge_client_and_does_not_spin_temp():
-    bridge_client = MagicMock()
-    bridge_client.get_server_info = AsyncMock(return_value=FIXTURE_INFO)
+async def test_path_a_uses_bridge_and_does_not_spin_temp() -> None:
     bridge = MagicMock()
-    bridge.is_active = True
-    bridge._client = bridge_client
+    bridge.get_server_info = AsyncMock(return_value=FIXTURE_INFO)
 
     bot = _make_bot(is_bound=True, bridge=bridge)
     interaction = _make_interaction()
@@ -176,21 +96,89 @@ async def test_path_a_uses_bridge_client_and_does_not_spin_temp():
     with patch("clauded.cogs.skill.ClaudeSDKClient") as fake_ctor:
         await skill_list.callback(interaction)
 
-    bridge_client.get_server_info.assert_awaited_once()
+    bridge.get_server_info.assert_awaited_once()
     fake_ctor.assert_not_called()  # no Path B spin-up
 
-    # The embed shape: 4 skills total (2 user + 1 project + 1 plugin),
-    # built-ins filtered.
     sent = interaction.followup.send.await_args
     embed = sent.kwargs["embed"]
     assert isinstance(embed, discord.Embed)
     assert embed.title == "🧰 Skills (4)"
     field_names = [f.name for f in embed.fields]
-    assert "Project" in field_names
-    assert "User (Global)" in field_names
-    assert "Plugin: myplug" in field_names
+    # Order pinned: Project → User (Global) → Plugin: <name> alphabetized.
+    assert field_names == ["Project", "User (Global)", "Plugin: myplug"]
     # Bound: no unbound-footer.
-    assert embed.footer.text in (None, discord.Embed.Empty if hasattr(discord.Embed, "Empty") else None)
+    assert not embed.footer.text
+
+
+# ---------------------------------------------------------------------------
+# C1 — Path A → Path B fallthrough coverage
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_path_a_get_server_info_raises_falls_through_to_path_b() -> None:
+    """If ``bridge.get_server_info()`` raises, Path B runs and renders."""
+    bridge = MagicMock()
+    bridge.get_server_info = AsyncMock(side_effect=RuntimeError("boom"))
+
+    bot = _make_bot(is_bound=True, bridge=bridge)
+    interaction = _make_interaction()
+    interaction.client = bot
+
+    fake_client = MagicMock()
+    fake_client.get_server_info = AsyncMock(return_value=FIXTURE_INFO)
+
+    with patch("clauded.cogs.skill.ClaudeSDKClient") as fake_ctor:
+        fake_ctor.return_value = _FakeAsyncCtx(fake_client)
+        await skill_list.callback(interaction)
+
+    bridge.get_server_info.assert_awaited_once()
+    fake_ctor.assert_called_once()  # Path B ran
+    fake_client.get_server_info.assert_awaited_once()
+
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert embed.title == "🧰 Skills (4)"
+
+
+@pytest.mark.asyncio
+async def test_path_a_inactive_bridge_skips_to_b() -> None:
+    """Bridge present but wrapper returns None (inactive) → Path B runs."""
+    bridge = MagicMock()
+    bridge.get_server_info = AsyncMock(return_value=None)
+
+    bot = _make_bot(is_bound=True, bridge=bridge)
+    interaction = _make_interaction()
+    interaction.client = bot
+
+    fake_client = MagicMock()
+    fake_client.get_server_info = AsyncMock(return_value=FIXTURE_INFO)
+
+    with patch("clauded.cogs.skill.ClaudeSDKClient") as fake_ctor:
+        fake_ctor.return_value = _FakeAsyncCtx(fake_client)
+        await skill_list.callback(interaction)
+
+    bridge.get_server_info.assert_awaited_once()
+    fake_ctor.assert_called_once()
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert embed.title == "🧰 Skills (4)"
+
+
+@pytest.mark.asyncio
+async def test_path_a_no_bridge_skips_to_b() -> None:
+    """No bridge in session_manager → Path B runs directly."""
+    bot = _make_bot(is_bound=True, bridge=None)
+    interaction = _make_interaction()
+    interaction.client = bot
+
+    fake_client = MagicMock()
+    fake_client.get_server_info = AsyncMock(return_value=FIXTURE_INFO)
+
+    with patch("clauded.cogs.skill.ClaudeSDKClient") as fake_ctor:
+        fake_ctor.return_value = _FakeAsyncCtx(fake_client)
+        await skill_list.callback(interaction)
+
+    fake_ctor.assert_called_once()
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert embed.title == "🧰 Skills (4)"
 
 
 # ---------------------------------------------------------------------------
@@ -198,7 +186,7 @@ async def test_path_a_uses_bridge_client_and_does_not_spin_temp():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_path_b_bound_uses_full_setting_sources():
+async def test_path_b_bound_uses_full_setting_sources() -> None:
     bot = _make_bot(is_bound=True, bridge=None)
     interaction = _make_interaction()
     interaction.client = bot
@@ -228,12 +216,11 @@ async def test_path_b_bound_uses_full_setting_sources():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_path_b_unbound_uses_user_only_and_adds_footer():
+async def test_path_b_unbound_uses_user_only_and_adds_footer() -> None:
     bot = _make_bot(is_bound=False, bridge=None)
     interaction = _make_interaction()
     interaction.client = bot
 
-    # In an unbound channel the SDK would only return user + built-ins.
     unbound_info = {
         "commands": [
             {"name": "crew", "description": "Multi-agent dev workflow (user)"},
@@ -255,19 +242,35 @@ async def test_path_b_unbound_uses_user_only_and_adds_footer():
 
     embed = interaction.followup.send.await_args.kwargs["embed"]
     assert embed.title == "🧰 Skills (2)"
-    # Footer presence is the key acceptance.
     assert embed.footer.text is not None
     assert "Unbound channel" in embed.footer.text
     assert "/project bind" in embed.footer.text
 
 
 # ---------------------------------------------------------------------------
-# Errors
+# C3 + I2 — Single parametrized error-path test (no message-body leak per I1)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_cli_connection_error_returns_red_embed():
-    from claude_agent_sdk import CLIConnectionError
+@pytest.mark.parametrize(
+    "exc",
+    [
+        # Imported lazily to avoid coupling collection to SDK module shape.
+        pytest.param("CLIConnectionError", id="cli-connection"),
+        pytest.param("CLINotFoundError", id="cli-not-found"),
+        pytest.param("RuntimeError", id="generic"),
+    ],
+)
+async def test_path_b_exception_yields_red_embed(exc: str) -> None:
+    if exc == "CLIConnectionError":
+        from claude_agent_sdk import CLIConnectionError as ExcCls
+        raised = ExcCls("/Users/operator/.claude/bin/claude exploded")
+    elif exc == "CLINotFoundError":
+        from claude_agent_sdk import CLINotFoundError as ExcCls
+        raised = ExcCls("no claude at /Users/operator/.claude/bin")
+    else:
+        ExcCls = RuntimeError  # type: ignore[assignment]
+        raised = RuntimeError("/Users/operator/secret-path")
 
     bot = _make_bot(is_bound=True, bridge=None)
     interaction = _make_interaction()
@@ -275,7 +278,7 @@ async def test_cli_connection_error_returns_red_embed():
 
     class _Boom:
         async def __aenter__(self):
-            raise CLIConnectionError("boom")
+            raise raised
 
         async def __aexit__(self, *a):
             return False
@@ -285,34 +288,15 @@ async def test_cli_connection_error_returns_red_embed():
 
     embed = interaction.followup.send.await_args.kwargs["embed"]
     assert embed.title == "❌ Skills unavailable"
-    assert "CLIConnectionError" in (embed.description or "")
+    # I1 — class name is shown for diagnostics.
+    assert ExcCls.__name__ in (embed.description or "")
+    # I1 — exception message body must NOT leak into the embed
+    # (it can contain cli_path / home dirs / env from SDK strings).
+    assert "/Users/operator" not in (embed.description or "")
 
 
 @pytest.mark.asyncio
-async def test_cli_not_found_error_returns_red_embed():
-    from claude_agent_sdk import CLINotFoundError
-
-    bot = _make_bot(is_bound=True, bridge=None)
-    interaction = _make_interaction()
-    interaction.client = bot
-
-    class _Boom:
-        async def __aenter__(self):
-            raise CLINotFoundError("no claude")
-
-        async def __aexit__(self, *a):
-            return False
-
-    with patch("clauded.cogs.skill.ClaudeSDKClient", return_value=_Boom()):
-        await skill_list.callback(interaction)
-
-    embed = interaction.followup.send.await_args.kwargs["embed"]
-    assert embed.title == "❌ Skills unavailable"
-    assert "CLINotFoundError" in (embed.description or "")
-
-
-@pytest.mark.asyncio
-async def test_get_server_info_returns_none_yields_red_embed():
+async def test_get_server_info_returns_none_yields_red_embed() -> None:
     bot = _make_bot(is_bound=True, bridge=None)
     interaction = _make_interaction()
     interaction.client = bot
@@ -333,7 +317,7 @@ async def test_get_server_info_returns_none_yields_red_embed():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_empty_commands_yields_empty_state_line():
+async def test_empty_commands_yields_empty_state_line() -> None:
     bot = _make_bot(is_bound=True, bridge=None)
     interaction = _make_interaction()
     interaction.client = bot
@@ -353,22 +337,29 @@ async def test_empty_commands_yields_empty_state_line():
 
 
 # ---------------------------------------------------------------------------
-# Pagination guard — 50 long user skills must not overflow Discord limits
+# C2 — Truncation: every field ≤1024; if budget blown, truncation notice
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_many_skills_truncated_within_embed_budget():
+async def test_truncates_when_many_skills() -> None:
     bot = _make_bot(is_bound=True, bridge=None)
     interaction = _make_interaction()
     interaction.client = bot
 
-    # 50 user skills, each with a ~200-char description so we definitely
-    # blow past the per-field 1024-char cap if untruncated.
+    # 8 plugin groups × 10 skills each, each row ~120 chars after the
+    # _DESC_TRUNCATE_AT slice. Per-group value ~1.2KB → trips per-field
+    # cap and across 8 groups blows the 5500-char total budget, so the
+    # drops notice MUST fire.
     long_desc = "x" * 200
-    commands = [
-        {"name": f"skill{i:02d}", "description": f"{long_desc} (user)"}
-        for i in range(50)
-    ]
+    commands = []
+    for plugin in "abcdefgh":
+        for i in range(10):
+            commands.append(
+                {
+                    "name": f"{plugin}{i:02d}",
+                    "description": f"{long_desc} (plugin:{plugin})",
+                }
+            )
     fake_client = MagicMock()
     fake_client.get_server_info = AsyncMock(return_value={"commands": commands})
 
@@ -378,21 +369,20 @@ async def test_many_skills_truncated_within_embed_budget():
 
     embed = interaction.followup.send.await_args.kwargs["embed"]
 
-    # All fields stay within Discord's 1024-char value limit.
+    # No field exceeds Discord's per-field 1024-char ceiling.
     for field in embed.fields:
         assert field.value is not None
         assert len(field.value) <= 1024, f"field {field.name!r} too long: {len(field.value)}"
 
-    # Serialized embed stays within Discord's 6000-char total ceiling
-    # (and we aim much lower per the PRD's 4000-char budget).
+    # Serialized embed comfortably under Discord's 6000-char ceiling.
     assert len(embed) <= 6000
 
-    # If anything was dropped, the truncation footer is present.
-    truncation_present = any(
-        "more skills" in (f.value or "") for f in embed.fields
+    # Truncation notice present as the final field.
+    assert embed.fields, "expected at least one field"
+    last = embed.fields[-1]
+    assert "more skills" in (last.value or ""), (
+        f"expected truncation notice in last field, got {last.name!r}={last.value!r}"
     )
-    # With 50×~200-char rows in a single field we definitely drop rows.
-    assert truncation_present, "expected truncation notice with 50 long skills"
 
 
 # ---------------------------------------------------------------------------
@@ -400,7 +390,7 @@ async def test_many_skills_truncated_within_embed_budget():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_empty_description_renders_no_description_placeholder():
+async def test_empty_description_renders_no_description_placeholder() -> None:
     bot = _make_bot(is_bound=True, bridge=None)
     interaction = _make_interaction()
     interaction.client = bot
@@ -418,17 +408,16 @@ async def test_empty_description_renders_no_description_placeholder():
         await skill_list.callback(interaction)
 
     embed = interaction.followup.send.await_args.kwargs["embed"]
-    # Empty stripped desc → "_(no description)_"
     user_field = next(f for f in embed.fields if f.name == "User (Global)")
     assert "_(no description)_" in user_field.value
 
 
 # ---------------------------------------------------------------------------
-# Thread channel resolves to parent_id
+# Channel resolution
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_thread_channel_resolves_to_parent_id():
+async def test_thread_channel_resolves_to_parent_id() -> None:
     bot = _make_bot(is_bound=True, bridge=None)
     interaction = _make_interaction(channel_id=4242, is_thread=True)
     interaction.client = bot
@@ -440,5 +429,22 @@ async def test_thread_channel_resolves_to_parent_id():
         fake_ctor.return_value = _FakeAsyncCtx(fake_client)
         await skill_list.callback(interaction)
 
-    # parent_id is 4242 — that's what should be passed to project_manager.
     bot.project_manager.get_path_or_default.assert_called_with(4242)
+
+
+@pytest.mark.asyncio
+async def test_dm_channel_yields_must_be_in_channel() -> None:
+    """C6: DM channel resolves to None → friendly error, no Path A/B."""
+    bot = _make_bot(is_bound=True, bridge=None)
+    interaction = _make_interaction()
+    interaction.client = bot
+    interaction.channel = MagicMock(spec=discord.DMChannel)
+
+    with patch("clauded.cogs.skill.ClaudeSDKClient") as fake_ctor:
+        await skill_list.callback(interaction)
+
+    fake_ctor.assert_not_called()
+    bot.project_manager.get_path_or_default.assert_not_called()
+    interaction.followup.send.assert_awaited_once()
+    sent_msg = interaction.followup.send.await_args.args[0]
+    assert "must be run in a channel" in sent_msg

--- a/tests/test_skill_parser.py
+++ b/tests/test_skill_parser.py
@@ -1,0 +1,81 @@
+"""Tests for ``clauded.skill_parser.classify_command``.
+
+Pinned by live probe on 2026-05-11 (see PRD docs/prd/v1.13-skill-list.md).
+The Claude CLI emits source-tag suffixes on the description field;
+this module is the canonical parser shared by ``/skill list`` and
+future ``/skill info``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clauded.skill_parser import classify_command
+
+
+@pytest.mark.parametrize(
+    "cmd, expected",
+    [
+        # User skill
+        (
+            {"name": "crew", "description": "Multi-agent workflow (user)"},
+            ("user", "crew", "Multi-agent workflow"),
+        ),
+        # Project skill
+        (
+            {"name": "testproj", "description": "Project-specific tooling (project)"},
+            ("project", "testproj", "Project-specific tooling"),
+        ),
+        # Plugin skill
+        (
+            {"name": "myplug", "description": "From a plugin (plugin:myplug)"},
+            ("plugin:myplug", "myplug", "From a plugin"),
+        ),
+        # Built-in (no suffix)
+        (
+            {"name": "clear", "description": "Clear the chat"},
+            ("", "", ""),
+        ),
+        # Empty description — built-in / unrecognized
+        (
+            {"name": "noop", "description": ""},
+            ("", "", ""),
+        ),
+        # None description — handled by "or ''"
+        (
+            {"name": "noop2", "description": None},
+            ("", "", ""),
+        ),
+        # Edge: " (plugin:bar)" appears mid-string, description does NOT end
+        # with ")". Must NOT classify as plugin.
+        (
+            {"name": "foo", "description": "foo (plugin:bar) more text"},
+            ("", "", ""),
+        ),
+        # Edge: description ends with ")" but not the plugin marker.
+        (
+            {"name": "bar", "description": "does math (rounded)"},
+            ("", "", ""),
+        ),
+        # Edge (I4, R1 engineer/tester): description ends with ")" AND
+        # contains " (plugin:" — but the slice between "(plugin:" and
+        # the trailing ")" is not a plain plugin name (extra paren).
+        # Pin: this is treated as built-in / unrecognized, NOT a plugin.
+        (
+            {"name": "weird", "description": "foo (plugin:p) extra)"},
+            ("", "", ""),
+        ),
+        # Edge: trailing whitespace before the suffix is rstripped.
+        (
+            {"name": "tidy", "description": "Trim trailing spaces   (user)"},
+            ("user", "tidy", "Trim trailing spaces"),
+        ),
+        # Edge: missing description key.
+        (
+            {"name": "anon"},
+            ("", "", ""),
+        ),
+    ],
+)
+def test_classify_command(cmd, expected) -> None:
+    assert classify_command(cmd) == expected

--- a/tests/test_unbound_handler.py
+++ b/tests/test_unbound_handler.py
@@ -120,10 +120,11 @@ async def test_reject_if_unbound_uses_followup_when_response_done() -> None:
 
 
 @pytest.mark.asyncio
-async def test_reject_if_unbound_when_channel_is_none_falls_back_to_channel_id() -> None:
-    """DM / cache miss → ``interaction.channel`` is None. Helper must NOT
-    crash with AttributeError; it should consult ``interaction.channel_id``
-    instead.
+async def test_reject_if_unbound_when_channel_is_none_treats_as_dm() -> None:
+    """DM / cache miss → ``interaction.channel`` is None. Per the unified
+    ``resolve_channel_id`` policy (architect R1 #C6), this is treated the
+    same as an explicit ``DMChannel`` and refused with ``NO_CHANNEL_MESSAGE``
+    — ``is_bound`` is never consulted.
     """
     interaction = _make_interaction(channel=None, channel_id=5555)
     bot = _make_bot(is_bound=False)
@@ -131,9 +132,9 @@ async def test_reject_if_unbound_when_channel_is_none_falls_back_to_channel_id()
     result = await reject_if_unbound(interaction, bot)
 
     assert result is True
-    bot.project_manager.is_bound.assert_called_once_with(5555)
+    bot.project_manager.is_bound.assert_not_called()
     interaction.response.send_message.assert_awaited_once_with(
-        UNBOUND_REFUSE_MESSAGE, ephemeral=True
+        NO_CHANNEL_MESSAGE, ephemeral=True
     )
 
 


### PR DESCRIPTION
Closes #109.

PRD: `docs/prd/v1.13-skill-list.md` (manager-approved).

## Implementation

New cog `src/clauded/cogs/skill.py` + 1-line registration in `bot.py`.

- **Path A** active-bridge piggyback (`bridge._client.get_server_info()`, 0-1 ms cached read)
- **Path B** temp `ClaudeSDKClient` fallback (~2-4s cold start)
- Filter to skill-backed commands by source-tag suffix (`(user)` / `(project)` / `(plugin:X)`); exclude built-ins
- Group by Project / User / Plugin sections in ephemeral blue embed
- Unbound channel: works with `setting_sources=[\"user\"]` + footer hint (no reject)
- 4000-char + per-field 1024-char truncation with separate notice field

## Tests (+20)

`tests/test_skill_list.py` covers all 9 PRD acceptance items + 2 bonus (DMChannel detection, Thread parent resolution).

pytest: **398 pass / 2 pre-existing P1**.

## Dev deviations from PRD (disclosed in commit)

1. Truncation notice in separate field (Discord field-value 1024 hard cap) — semantically identical
2. `info is None` synthesizes `NoServerInfo` pseudo-exception name for shape consistency
3. `isinstance(ch, discord.DMChannel)` added alongside `ch is None` (DM channel object exists but unbound)

## Out of scope

- `/skill info <name>`, `/skill enable/disable` — v1.14
- Pagination — defer until needed
- SDK `_client` public accessor — v1.14 upstream ask