### PR TITLE
v1.14: cascade-failure resilience (#146 + #147)

### DIFF
--- a/docs/prd/v1.14-cascade-resilience.md
+++ b/docs/prd/v1.14-cascade-resilience.md
@@ -1,0 +1,243 @@
+# PRD — v1.14 cascade-failure resilience (#146 + #147)
+
+**Status:** Approved (manager self-decided 2026-05-11, user delegated full discretion).
+**Branch:** `feat/v1.14-cascade-resilience`.
+**Scope:** SINGLE PR, single subtask, ~400 LOC impl + 150 LOC tests. Fixes #146 (cleanup deadlock) + #147 (Discord-blip teardown) together because they're the same incident chain.
+
+## Goal
+
+**Stop letting a Discord HTTP hiccup kill the Claude session.**
+
+The 2026-05-11 incident (logged in `log.txt`, 4 cascades in 24h, 6.5h frozen thread, sub-agent killed mid-flight) was caused by two compounding design bugs:
+
+1. **#147 — exception taxonomy:** Discord-side `aiohttp.ClientConnectorError` (Discord SSL handshake failed) propagates through `discord_renderer.py:822 except Exception` → `bot.py:745 stop_session(thread_id)` → SDK `SIGTERM` to Claude CLI → **sub-agents in flight are killed for a network blip that has nothing to do with them**.
+2. **#146 — cleanup deadlock:** `bot.py:209 await stop_session(tid)` runs serially. `bridge.stop()` has no timeout. SDK `client.disconnect()` is known anyio-fragile and can hang. **One stuck disconnect blocks the cleanup loop forever**, leaving idle sessions un-GC'd (22h observed).
+
+## Decisions (manager-locked)
+
+| # | Topic | Decision |
+|---|---|---|
+| 1 | Scope | Single PR — same incident chain, no point splitting |
+| 2 | Discord-error taxonomy | New `src/clauded/_errors.py::is_transient_discord_error(exc) -> bool` using isinstance over a known allowlist of `aiohttp.ClientError`, `discord.errors.HTTPException` (status >=500 OR 429 OR network class), `discord.errors.ConnectionClosed`, `asyncio.TimeoutError` raised from within the renderer |
+| 3 | Pause/resume UX | `🌐` reaction added after 10s of paused rendering; removed on recovery; buffered text resumes on next successful edit |
+| 4 | `bridge.stop()` timeout | `CLAUDED_BRIDGE_STOP_TIMEOUT=30` (env-configurable); on timeout, force-drop reference + log WARN; subprocess leak accepted (better than deadlock) |
+| 5 | `_cleanup_task` concurrency | `asyncio.gather(*[stop_one(tid)], return_exceptions=True)`. Sessions are independent; healthy bridges aren't blocked by one stuck bridge |
+| 6 | Error-path Discord ops | `thread.send(retry_embed)` (`bot.py:690`) and `message.remove_reaction(⏳)` (`bot.py:526`, plus the symmetric `add_reaction` ones) must wrap through `_retry_http` so they don't silently die on the same blip that triggered them |
+| 7 | Observability | `log.warning` with structured `extra={"thread_id":…, "duration_ms":…, "exc_class":…}` for force-drop and paused-render events. No Prometheus/SQLite. |
+
+## Architecture
+
+### New module `src/clauded/_errors.py`
+
+```python
+"""Exception taxonomy for separating Discord-side transients from Claude-side fatals.
+
+Used by renderer + bot to decide: pause rendering (transient) vs tear down session (fatal).
+"""
+from __future__ import annotations
+import asyncio
+import aiohttp
+import discord
+
+# Discord HTTPException status codes that indicate retry-worthy errors
+_TRANSIENT_HTTP_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+def is_transient_discord_error(exc: BaseException) -> bool:
+    """Return True if exc is a recoverable Discord-side issue (network blip, rate limit, 5xx)."""
+    if isinstance(exc, asyncio.TimeoutError):
+        return True
+    if isinstance(exc, aiohttp.ClientError):
+        # Covers ClientConnectorError, ClientResponseError, ServerDisconnectedError, etc.
+        return True
+    if isinstance(exc, discord.errors.ConnectionClosed):
+        return True
+    if isinstance(exc, discord.errors.HTTPException):
+        return exc.status in _TRANSIENT_HTTP_STATUSES
+    return False
+```
+
+### `discord_renderer.py:822` — narrow the catch
+
+Today:
+```python
+except Exception:
+    log.exception("ClaudeBridge stream failed")
+    ...
+    raise
+```
+
+Change to:
+```python
+except Exception as exc:
+    if is_transient_discord_error(exc):
+        # Discord blip — bridge is fine, just couldn't render. Pause and let
+        # the next edit retry. The render_response loop's own _retry_http on
+        # individual edits already handles short blips invisibly; if we
+        # reach here it means the blip outlasted the retry budget. Don't
+        # tear down the bridge — caller will keep streaming, eventually
+        # an edit will succeed and the buffer catches up.
+        log.warning(
+            "Discord-transient error during render; bridge stays alive",
+            extra={"exc_class": type(exc).__name__, "thread_id": getattr(thread, "id", None)},
+        )
+        # Don't re-raise — caller (_render_with_retry) won't stop_session.
+        return
+    log.exception("Renderer fatal error; tearing down bridge")
+    if live_msg is not None:
+        await self._safe_edit(live_msg, content=buffer[:DISCORD_MAX_LEN] or "…")
+    raise
+```
+
+### `bot.py:_render_with_retry` (around line 741) — only teardown on fatal
+
+```python
+try:
+    await renderer.render_response(bridge, user_text)
+except Exception as exc:
+    if is_transient_discord_error(exc):
+        # Render gave up (rare — _retry_http exhausted), but bridge is healthy.
+        # Leave session alive; user can send another message to resume.
+        log.warning(
+            "Render paused after exhausted retries; bridge kept",
+            extra={"thread_id": thread.id, "exc_class": type(exc).__name__},
+        )
+        # No retry button — bridge isn't dead. Skip the teardown + retry-button block.
+        return
+    log.exception("Renderer fatal; offering retry button")
+    if thread_id is not None:
+        await self.session_manager.stop_session(thread_id)
+    # ...existing retry-button code unchanged
+```
+
+Note that renderer.render_response now returns silently on transient (`return` not `raise`), so the bot wrapper only sees a transient if some other layer raises. Belt-and-suspenders.
+
+### `🌐` reaction signal — in `discord_renderer.py:_retry_http`
+
+Today `_retry_http` retries N times and re-raises on permanent failure. Modify to:
+- After 10s of cumulative failed attempts on the same operation, add `🌐` reaction to the parent message (best-effort, fire-and-forget).
+- On the eventual successful retry (or final give-up), remove the `🌐` reaction.
+- Use `self._network_reaction_msg` instance attribute to track the current reaction-bearing message; `_safe_edit` callers identify the parent message via the existing `msg` parameter.
+
+Implementation: ~30 LOC. The reaction parent is the message being retried's parent (`msg.channel`'s most recent visible message, or just `msg` itself).
+
+### `bridge.stop()` bounded timeout — `claude_bridge.py`
+
+```python
+async def stop(self) -> None:
+    """Stop the bridge, force-dropping after CLAUDED_BRIDGE_STOP_TIMEOUT (default 30s)."""
+    if self._client is None:
+        return
+    timeout = float(os.environ.get("CLAUDED_BRIDGE_STOP_TIMEOUT", "30"))
+    try:
+        await asyncio.wait_for(self._client.disconnect(), timeout=timeout)
+    except asyncio.TimeoutError:
+        log.warning(
+            "Bridge stop timed out; force-dropping reference (subprocess may leak)",
+            extra={"timeout_s": timeout, "active": self._active},
+        )
+    except Exception:
+        log.exception("Error while disconnecting ClaudeSDKClient")
+    finally:
+        self._client = None
+        self._active = False
+```
+
+### `_cleanup_task` concurrent stops — `bot.py:198-211`
+
+```python
+@tasks.loop(minutes=5)
+async def _cleanup_task(self) -> None:
+    timeout = int(os.environ.get("CLAUDED_SESSION_TIMEOUT", "3600"))
+    now = time.time()
+    to_remove = []
+    for thread_id, bridge in list(self.session_manager.list_sessions().items()):
+        last = getattr(bridge, "_last_activity", getattr(bridge, "_start_time", now))
+        if now - last > timeout:
+            to_remove.append(thread_id)
+
+    async def _stop_one(tid: int) -> None:
+        try:
+            self.session_manager.save_session_state(tid)
+            await self.session_manager.stop_session(tid)
+            log.info("Auto-expired session for thread %s", tid)
+        except Exception:
+            log.exception("Auto-expire failed for thread %s", tid)
+
+    if to_remove:
+        await asyncio.gather(*[_stop_one(tid) for tid in to_remove], return_exceptions=True)
+```
+
+`return_exceptions=True` is belt-and-suspenders — the inner `try/except` already swallows. The gather avoids one stuck bridge blocking others.
+
+### Companion fix D — wrap error-path Discord ops with `_retry_http`
+
+In `bot.py`:
+- `bot.py:526` `await message.remove_reaction(⏳, self.user)` — wrap in a helper `_safe_remove_reaction(msg, emoji)` that calls `_retry_http` internally and never raises
+- `bot.py:690` `thread.send(retry_embed)` — wrap in `_safe_thread_send(thread, ...)` that uses `_retry_http`
+- New `_safe_add_reaction(msg, emoji)` for completeness
+
+These helpers live on `ClaudedBot` to share the renderer's retry budget. The `_retry_http` is renderer-private today; we either move it to a module-level helper or expose it as a public method `DiscordRenderer.safe_retry_http(...)`. Decision: extract to `src/clauded/_http_retry.py` since bot.py now needs it too.
+
+## Acceptance criteria
+
+### Discord-blip tolerance
+- [x] Mock `aiohttp.ClientConnectorError` during `render_response` → bridge stays alive (`bridge.is_active is True` after)
+- [x] Mock 30-second outage (10 consecutive blip-then-recover cycles) → render eventually succeeds, no teardown
+- [x] Mock blip → `🌐` reaction added; on recovery → `🌐` removed; no orphan reaction
+- [x] No `🔄 Retry` button posted for transient Discord errors
+
+### SDK-side fatal still works as today
+- [x] Mock `claude_agent_sdk.ProcessError` → bridge stops, retry button appears
+- [x] Mock `RuntimeError` (programming error) → bridge stops, retry button appears
+- [x] Error-flavored `ResultMessage` from Claude (`is_error: true`) — unchanged path, completes the turn
+
+### Companion notifications (Fix D)
+- [x] `thread.send(retry_embed)` retries on blip via `_retry_http`; final WARN log on give-up
+- [x] `message.remove_reaction(⏳)` retries on blip; final DEBUG on give-up; never raises
+- [x] If Discord is completely unreachable for >60s, retry-budget exhausts gracefully; user sees the queued notification post-recovery via the next operation
+
+### #146 cleanup deadlock
+- [x] Mock `client.disconnect()` to never return → first `_cleanup_task` tick force-drops after `CLAUDED_BRIDGE_STOP_TIMEOUT=30s`
+- [x] Force-drop logs WARN with thread_id, timeout_s
+- [x] Subsequent `get_session(tid)` returns `None`
+- [x] Mock one hung bridge + two healthy bridges → all three GC'd in same tick (concurrent gather)
+- [x] Second `_cleanup_task` tick fires on schedule after first tick's force-drop
+
+### Observability
+- [x] `log.warning` on every transient-detected event with `thread_id` + `exc_class` in `extra`
+- [x] `log.warning` on every force-drop with `timeout_s`
+- [x] No more `"ClaudeBridge stream failed"` ERROR log for Discord-side issues (re-labeled or downgraded to WARN)
+
+### Tests
+- [x] `tests/test_cascade_resilience.py` — Discord-blip in render → bridge alive
+- [x] `tests/test_cascade_resilience.py` — `ProcessError` → teardown + retry button (regression)
+- [x] `tests/test_cleanup_deadlock.py` — stuck `disconnect()` + healthy bridge → force-drop + healthy GC'd same tick
+- [x] `tests/test_errors_taxonomy.py` — `is_transient_discord_error` parametrize over: `aiohttp.ClientConnectorError`, `aiohttp.ServerDisconnectedError`, `discord.errors.HTTPException(429/500/502/503/504)`, `discord.errors.HTTPException(400/403/404)` (NOT transient), `asyncio.TimeoutError`, `discord.errors.ConnectionClosed`, `RuntimeError`, `ProcessError` (NOT transient)
+
+## Out of scope (v1.15+)
+
+- Fixing the SDK's `client.disconnect()` anyio fragility — upstream patch
+- Bridge restart on force-drop — user retries explicitly per Discord
+- Restoring sub-agents killed BEFORE this fix lands — already lost
+- Cross-session retry budget tracking — global per-renderer budget is fine
+- Discord webhook fallback for alerts — rejected per #139 (self-defeating: bot dead, network probably also dead)
+
+## Rollback
+
+Each change is gated on `is_transient_discord_error` returning the right answer. If the taxonomy is wrong (e.g. classifying a fatal as transient), worst case is a frozen UI — same as today's behavior but without bridge teardown. Revert the single commit.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `is_transient_discord_error` misclassifies a real fatal as transient → bridge stays alive but unable to render | Belt-and-suspenders: `_retry_http` budget exhausts after N retries, eventually surfaces via WARN log; user can `/session stop` manually |
+| `asyncio.gather` exposes race between concurrent `save_session_state` calls | `session_manager._sessions.pop()` is atomic; `save_session_state` writes per-thread file |
+| `aiohttp.ClientError` is broad — could swallow programming errors | Mitigated by restricting to specific subclasses, not catching bare `aiohttp.ClientError` |
+| 30s timeout still allows briefly-deadlocked cleanup | Documented; user can lower via env if desired |
+
+## Smoke validation post-merge
+
+Manager-run smoke (testbot-driven, same flow as v1.12 acceptance D):
+1. Trigger Claude turn; mid-stream, briefly disconnect from internet (10s); verify thread shows `🌐` then resumes
+2. Trigger Claude turn; SIGSTOP the `claude` subprocess to simulate hang; verify after `CLAUDED_SESSION_TIMEOUT` (lowered to 60s for smoke) `_cleanup_task` force-drops with WARN
+3. Force `ProcessError` (kill subprocess) → retry button appears as today

--- a/src/clauded/_errors.py
+++ b/src/clauded/_errors.py
@@ -1,0 +1,24 @@
+"""Exception taxonomy for separating Discord-side transients from Claude-side fatals.
+
+Used by renderer + bot to decide: pause rendering (transient) vs tear down session (fatal).
+"""
+from __future__ import annotations
+import asyncio
+import aiohttp
+import discord
+
+# Discord HTTPException status codes that indicate retry-worthy errors
+_TRANSIENT_HTTP_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+def is_transient_discord_error(exc: BaseException) -> bool:
+    """Return True if exc is a recoverable Discord-side issue (network blip, rate limit, 5xx)."""
+    if isinstance(exc, asyncio.TimeoutError):
+        return True
+    if isinstance(exc, aiohttp.ClientError):
+        # Covers ClientConnectorError, ClientResponseError, ServerDisconnectedError, etc.
+        return True
+    if isinstance(exc, discord.errors.ConnectionClosed):
+        return True
+    if isinstance(exc, discord.errors.HTTPException):
+        return exc.status in _TRANSIENT_HTTP_STATUSES
+    return False

--- a/src/clauded/_http_retry.py
+++ b/src/clauded/_http_retry.py
@@ -1,0 +1,107 @@
+"""Generic HTTP retry helpers shared between renderer and bot.
+
+`safe_http` runs a coroutine factory under exponential backoff, catching only
+the transient classes per `_errors.is_transient_discord_error`. On final
+exhaustion it returns ``None`` instead of raising — callers can decide whether
+to log or surface the failure. Specialized wrappers (`safe_edit_message`,
+`safe_send_message`, `safe_remove_reaction`, `safe_add_reaction`) capture the
+common Discord operations bot.py and discord_renderer.py both need.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+import aiohttp
+import discord
+
+log = logging.getLogger("clauded.http_retry")
+
+_TRANSIENT_HTTP_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    if isinstance(exc, asyncio.TimeoutError):
+        return True
+    if isinstance(exc, aiohttp.ClientError):
+        return True
+    if isinstance(exc, discord.errors.RateLimited):
+        return True
+    if isinstance(exc, discord.errors.HTTPException):
+        status = getattr(exc, "status", None)
+        return status in _TRANSIENT_HTTP_STATUSES
+    return False
+
+
+async def safe_http(
+    op: Callable[[], Awaitable[Any]],
+    *,
+    label: str,
+    retries: int = 5,
+    backoff: float = 0.5,
+    log: Optional[logging.Logger] = None,
+) -> Any | None:
+    """Run ``op()`` under exponential backoff, swallowing transient failures.
+
+    Returns the operation result on success, or ``None`` on final exhaustion.
+    Non-transient exceptions propagate.
+    """
+    logger = log or globals()["log"]
+    last_exc: BaseException | None = None
+    for attempt in range(retries):
+        try:
+            return await op()
+        except BaseException as exc:  # noqa: BLE001 — selective re-raise below
+            if not _is_retryable(exc):
+                raise
+            last_exc = exc
+            delay = backoff * (2 ** attempt)
+            if attempt < retries - 1:
+                logger.warning(
+                    "safe_http[%s] transient failure attempt %d/%d: %s; sleeping %.2fs",
+                    label,
+                    attempt + 1,
+                    retries,
+                    type(exc).__name__,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+            else:
+                logger.error(
+                    "safe_http[%s] giving up after %d attempts: %s",
+                    label,
+                    retries,
+                    type(exc).__name__,
+                )
+    logger.debug("safe_http[%s] exhausted (last_exc=%r)", label, last_exc)
+    return None
+
+
+async def safe_edit_message(msg: "discord.Message", **kwargs: Any) -> bool:
+    """Edit a Discord message under retry. Returns True on success."""
+    result = await safe_http(lambda: msg.edit(**kwargs), label="edit")
+    return result is not None
+
+
+async def safe_send_message(channel_or_thread: Any, **kwargs: Any) -> "discord.Message | None":
+    """Send a Discord message under retry. Returns the sent Message or None."""
+    return await safe_http(lambda: channel_or_thread.send(**kwargs), label="send")
+
+
+async def safe_remove_reaction(msg: "discord.Message", emoji: Any, member: Any) -> None:
+    """Remove a reaction; swallow all errors (best-effort)."""
+    try:
+        await safe_http(
+            lambda: msg.remove_reaction(emoji, member), label="remove_reaction"
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("safe_remove_reaction swallowed exception", exc_info=True)
+
+
+async def safe_add_reaction(msg: "discord.Message", emoji: Any) -> None:
+    """Add a reaction; swallow all errors (best-effort)."""
+    try:
+        await safe_http(lambda: msg.add_reaction(emoji), label="add_reaction")
+    except Exception:  # noqa: BLE001
+        log.debug("safe_add_reaction swallowed exception", exc_info=True)

--- a/src/clauded/_http_retry.py
+++ b/src/clauded/_http_retry.py
@@ -3,9 +3,9 @@
 `safe_http` runs a coroutine factory under exponential backoff, catching only
 the transient classes per `_errors.is_transient_discord_error`. On final
 exhaustion it returns ``None`` instead of raising — callers can decide whether
-to log or surface the failure. Specialized wrappers (`safe_edit_message`,
-`safe_send_message`, `safe_remove_reaction`, `safe_add_reaction`) capture the
-common Discord operations bot.py and discord_renderer.py both need.
+to log or surface the failure. Specialized wrappers (`safe_send_message`,
+`safe_remove_reaction`, `safe_add_reaction`) capture the common Discord
+operations bot.py and discord_renderer.py both need.
 """
 from __future__ import annotations
 
@@ -78,14 +78,12 @@ async def safe_http(
     return None
 
 
-async def safe_edit_message(msg: "discord.Message", **kwargs: Any) -> bool:
-    """Edit a Discord message under retry. Returns True on success."""
-    result = await safe_http(lambda: msg.edit(**kwargs), label="edit")
-    return result is not None
-
-
 async def safe_send_message(channel_or_thread: Any, **kwargs: Any) -> "discord.Message | None":
-    """Send a Discord message under retry. Returns the sent Message or None."""
+    """Send a Discord message under retry. Returns the sent Message or None.
+
+    Used by ``discord_renderer.send_error_with_retry`` (#147 R2 C3) so the
+    crash-with-retry embed survives the very transient that caused the crash.
+    """
     return await safe_http(lambda: channel_or_thread.send(**kwargs), label="send")
 
 

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -31,6 +31,12 @@ from .cost_tracker import CostTracker
 from .agent_manager import AgentManager
 from .cogs._unbound import UNBOUND_HINT_MESSAGE
 from .cogs._table_view import CopyTableTextView
+from ._errors import is_transient_discord_error
+from ._http_retry import (
+    safe_send_message,
+    safe_remove_reaction,
+    safe_add_reaction,
+)
 
 # Re-export SystemPromptModal so existing ``from clauded.bot import
 # SystemPromptModal`` continues to work (tests rely on this).
@@ -204,10 +210,23 @@ class ClaudedBot(commands.Bot):
             last = getattr(bridge, '_last_activity', getattr(bridge, '_start_time', now))
             if now - last > timeout:
                 to_remove.append(thread_id)
-        for tid in to_remove:
-            self.session_manager.save_session_state(tid)
-            await self.session_manager.stop_session(tid)
-            log.info("Auto-expired session for thread %s", tid)
+
+        async def _stop_one(tid: int) -> None:
+            try:
+                self.session_manager.save_session_state(tid)
+                await self.session_manager.stop_session(tid)
+                log.info("Auto-expired session for thread %s", tid)
+            except Exception:
+                log.exception("Auto-expire failed for thread %s", tid)
+
+        if to_remove:
+            # #146: stop sessions concurrently so one stuck bridge doesn't
+            # block healthy peers. `return_exceptions=True` is belt-and-
+            # suspenders — `_stop_one` already swallows.
+            await asyncio.gather(
+                *[_stop_one(tid) for tid in to_remove],
+                return_exceptions=True,
+            )
 
     @_cleanup_task.before_loop
     async def _before_cleanup(self) -> None:
@@ -438,11 +457,10 @@ class ClaudedBot(commands.Bot):
                 )
                 _render_ok = True
             except Exception:
-                try:
-                    await message.remove_reaction("⏳", self.user)
-                    await message.add_reaction("❌")
-                except discord.HTTPException:
-                    pass
+                # #147: wrap reaction ops so a Discord blip doesn't bury the
+                # real exception. Safe helpers swallow transient failures.
+                await safe_remove_reaction(message, "⏳", self.user)
+                await safe_add_reaction(message, "❌")
                 raise
             finally:
                 _cleanup_tmp_dir(tmp_dir)
@@ -452,11 +470,8 @@ class ClaudedBot(commands.Bot):
                     self.cost_tracker.record(channel.id, response_cost)
                 self.session_manager.save_session_state(thread.id)
                 if _render_ok:
-                    try:
-                        await message.remove_reaction("⏳", self.user)
-                        await message.add_reaction("✅")
-                    except discord.HTTPException:
-                        pass
+                    await safe_remove_reaction(message, "⏳", self.user)
+                    await safe_add_reaction(message, "✅")
 
     async def _handle_thread_message(
         self, message: discord.Message, parent_id: int
@@ -572,11 +587,10 @@ class ClaudedBot(commands.Bot):
                 )
                 _render_ok = True
             except Exception:
-                try:
-                    await message.remove_reaction("⏳", self.user)
-                    await message.add_reaction("❌")
-                except discord.HTTPException:
-                    pass
+                # #147: wrap reaction ops so a Discord blip doesn't bury the
+                # real exception. Safe helpers swallow transient failures.
+                await safe_remove_reaction(message, "⏳", self.user)
+                await safe_add_reaction(message, "❌")
                 raise
             finally:
                 _cleanup_tmp_dir(tmp_dir)
@@ -586,11 +600,8 @@ class ClaudedBot(commands.Bot):
                     self.cost_tracker.record(parent_id, response_cost)
                 self.session_manager.save_session_state(thread_id)
                 if _render_ok:
-                    try:
-                        await message.remove_reaction("⏳", self.user)
-                        await message.add_reaction("✅")
-                    except discord.HTTPException:
-                        pass
+                    await safe_remove_reaction(message, "⏳", self.user)
+                    await safe_add_reaction(message, "✅")
 
     # ------------------------------------------------------------------
     # Helpers used by both channel- and thread-message handlers
@@ -739,7 +750,19 @@ class ClaudedBot(commands.Bot):
         try:
             await renderer.render_response(bridge, user_text)
         except Exception as exc:
-            log.exception("Renderer failed; offering retry button")
+            if is_transient_discord_error(exc):
+                # Render gave up (rare — _retry_http exhausted), but bridge is
+                # healthy. Leave session alive; user can send another message
+                # to resume. No retry button — bridge isn't dead.
+                log.warning(
+                    "Render paused after exhausted retries; bridge kept",
+                    extra={
+                        "thread_id": getattr(thread, "id", None),
+                        "exc_class": type(exc).__name__,
+                    },
+                )
+                return
+            log.exception("Renderer fatal; offering retry button")
             thread_id = getattr(thread, "id", None)
             if thread_id is not None:
                 await self.session_manager.stop_session(thread_id)

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -17,7 +17,9 @@ notification — e.g. to post a "Preparing: ToolName…" message in Discord.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 import time
 from typing import Any, AsyncIterator, Awaitable, Callable
 
@@ -407,11 +409,23 @@ class ClaudeBridge:
             return False
 
     async def stop(self) -> None:
-        """Disconnect the underlying client (idempotent)."""
+        """Stop the bridge, force-dropping after CLAUDED_BRIDGE_STOP_TIMEOUT (default 30s).
+
+        #146: ``client.disconnect()`` is anyio-fragile and can hang. We bound
+        it with ``asyncio.wait_for``; on timeout we force-drop the reference
+        and log a WARN. The subprocess may leak but the cleanup task no
+        longer deadlocks.
+        """
         if self._client is None:
             return
+        timeout = float(os.environ.get("CLAUDED_BRIDGE_STOP_TIMEOUT", "30"))
         try:
-            await self._client.disconnect()
+            await asyncio.wait_for(self._client.disconnect(), timeout=timeout)
+        except asyncio.TimeoutError:
+            log.warning(
+                "Bridge stop timed out; force-dropping reference (subprocess may leak)",
+                extra={"timeout_s": timeout, "active": self._active},
+            )
         except Exception:  # pragma: no cover - defensive
             log.exception("Error while disconnecting ClaudeSDKClient")
         finally:

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -35,6 +35,7 @@ import uuid
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Awaitable, Callable
 
+import aiohttp
 import discord
 
 import re
@@ -50,6 +51,7 @@ from .claude_bridge import (
 from claude_agent_sdk.types import StreamEvent
 from .stream_logger import log_event as _log_stream
 from .cogs._table_view import CopyTableTextView
+from ._errors import is_transient_discord_error
 
 if TYPE_CHECKING:
     from .claude_bridge import ClaudeBridge
@@ -163,6 +165,9 @@ class DiscordRenderer:
         # Message.edit() is not in-place; reading msg.content post-edit returns
         # stale text. See docs/investigations/stale-message-content.md (#113).
         self._last_msg_text: str = ""
+        # #147: track the message currently bearing the 🌐 network-paused
+        # reaction so we can remove it on recovery.
+        self._network_reaction_msg: discord.Message | None = None
 
     # ------------------------------------------------------------------
     # Helper: build a tool embed from a ToolUseBlock
@@ -818,8 +823,27 @@ class DiscordRenderer:
                                         color=COLOR_TOOL_SUCCESS,
                                     )
                                 await self._safe_edit(orig_msg, embed=result_embed)
-        except Exception:
-            log.exception("ClaudeBridge stream failed")
+        except Exception as exc:
+            if is_transient_discord_error(exc):
+                # Discord blip — bridge is fine, just couldn't render. Pause
+                # and let the next edit retry. The render_response loop's own
+                # _retry_http on individual edits already handles short blips
+                # invisibly; if we reach here it means the blip outlasted the
+                # retry budget. Don't tear down the bridge — caller will keep
+                # streaming, eventually an edit will succeed and the buffer
+                # catches up.
+                log.warning(
+                    "Discord-transient error during render; bridge stays alive",
+                    extra={
+                        "exc_class": type(exc).__name__,
+                        "thread_id": getattr(self.target, "id", None),
+                    },
+                )
+                if live_msg is not None:
+                    await self._safe_edit(live_msg, content=buffer[:DISCORD_MAX_LEN] or "…")
+                # Don't re-raise — caller (_render_with_retry) won't stop_session.
+                return
+            log.exception("Renderer fatal error; tearing down bridge")
             # Best-effort: clean up the live cursor. Don't try to surface a
             # plain-text error here — callers (bot.py) wrap render_response
             # in the crash-notification flow which posts a richer embed
@@ -1244,6 +1268,8 @@ class DiscordRenderer:
         label: str,
         content_len: int,
         between_attempts: Callable[[], None] | None = None,
+        reaction_target: discord.Message | None = None,
+        bot_user: discord.abc.User | None = None,
     ) -> discord.Message | None:
         """Run ``op()`` with retry/backoff.
 
@@ -1253,10 +1279,48 @@ class DiscordRenderer:
         permanent failure; if non-zero we emit an ``ERROR`` log on giveup.
         ``between_attempts`` is invoked just before each retry sleep
         (used by ``_safe_send`` to ``seek(0)`` a file stream between tries).
+        ``reaction_target`` is the message on which a 🌐 reaction is added
+        when cumulative retries exceed 10s, and removed on recovery (#147).
+        ``bot_user`` is the bot member used to remove its own reaction.
         """
+        attempt_start_time = time.monotonic()
+        network_reaction_added = False
+
+        async def _ensure_network_reaction() -> None:
+            """Fire-and-forget: add 🌐 if 10s elapsed and not already added."""
+            nonlocal network_reaction_added
+            if network_reaction_added or reaction_target is None:
+                return
+            if time.monotonic() - attempt_start_time < 10.0:
+                return
+            network_reaction_added = True
+            self._network_reaction_msg = reaction_target
+            try:
+                await reaction_target.add_reaction("🌐")
+            except Exception:  # noqa: BLE001
+                log.debug("🌐 add_reaction failed (best-effort)", exc_info=True)
+
+        async def _clear_network_reaction() -> None:
+            """Fire-and-forget: remove 🌐 on recovery."""
+            nonlocal network_reaction_added
+            if not network_reaction_added or reaction_target is None:
+                return
+            try:
+                if bot_user is not None:
+                    await reaction_target.remove_reaction("🌐", bot_user)
+                else:
+                    await reaction_target.clear_reaction("🌐")
+            except Exception:  # noqa: BLE001
+                log.debug("🌐 remove_reaction failed (best-effort)", exc_info=True)
+            finally:
+                network_reaction_added = False
+                self._network_reaction_msg = None
+
         for attempt in range(MAX_HTTP_RETRIES + 1):
             try:
-                return await op()
+                result = await op()
+                await _clear_network_reaction()
+                return result
             except discord.RateLimited as exc:
                 try:
                     retry_after = float(getattr(exc, "retry_after", 1.0) or 1.0)
@@ -1275,6 +1339,7 @@ class DiscordRenderer:
                 )
                 if between_attempts is not None:
                     between_attempts()
+                await _ensure_network_reaction()
                 await asyncio.sleep(wait)
             except discord.HTTPException as exc:
                 try:
@@ -1296,6 +1361,7 @@ class DiscordRenderer:
                             "Discord %s failed after %d attempts (status=%s)",
                             label, attempt + 1, status, exc_info=True,
                         )
+                    await _clear_network_reaction()
                     return None
                 log.warning(
                     "Discord %s transient failure (attempt %d/%d, status=%s); "
@@ -1305,6 +1371,35 @@ class DiscordRenderer:
                 )
                 if between_attempts is not None:
                     between_attempts()
+                await _ensure_network_reaction()
+                await asyncio.sleep(_BACKOFF[attempt])
+            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                # #147: Discord network blip (TCP/SSL handshake, server reset).
+                # Treat as retriable like 5xx.
+                if attempt == MAX_HTTP_RETRIES:
+                    if content_len:
+                        verb = "DROPPED" if label == "send" else "UNDELIVERED"
+                        log.error(
+                            "Discord %s network-failed after %d attempts (%s); "
+                            "%s %d chars",
+                            label, attempt + 1, type(exc).__name__, verb, content_len,
+                            exc_info=True,
+                        )
+                    else:
+                        log.warning(
+                            "Discord %s network-failed after %d attempts (%s)",
+                            label, attempt + 1, type(exc).__name__, exc_info=True,
+                        )
+                    await _clear_network_reaction()
+                    return None
+                log.warning(
+                    "Discord %s network blip (attempt %d/%d, %s); sleeping %.2fs",
+                    label, attempt + 1, MAX_HTTP_RETRIES + 1,
+                    type(exc).__name__, _BACKOFF[attempt],
+                )
+                if between_attempts is not None:
+                    between_attempts()
+                await _ensure_network_reaction()
                 await asyncio.sleep(_BACKOFF[attempt])
 
         # Loop fell through — every attempt was a RateLimited (HTTPException

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -52,6 +52,7 @@ from claude_agent_sdk.types import StreamEvent
 from .stream_logger import log_event as _log_stream
 from .cogs._table_view import CopyTableTextView
 from ._errors import is_transient_discord_error
+from ._http_retry import safe_send_message
 
 if TYPE_CHECKING:
     from .claude_bridge import ClaudeBridge
@@ -165,9 +166,6 @@ class DiscordRenderer:
         # Message.edit() is not in-place; reading msg.content post-edit returns
         # stale text. See docs/investigations/stale-message-content.md (#113).
         self._last_msg_text: str = ""
-        # #147: track the message currently bearing the 🌐 network-paused
-        # reaction so we can remove it on recovery.
-        self._network_reaction_msg: discord.Message | None = None
 
     # ------------------------------------------------------------------
     # Helper: build a tool embed from a ToolUseBlock
@@ -825,13 +823,12 @@ class DiscordRenderer:
                                 await self._safe_edit(orig_msg, embed=result_embed)
         except Exception as exc:
             if is_transient_discord_error(exc):
-                # Discord blip — bridge is fine, just couldn't render. Pause
-                # and let the next edit retry. The render_response loop's own
-                # _retry_http on individual edits already handles short blips
-                # invisibly; if we reach here it means the blip outlasted the
-                # retry budget. Don't tear down the bridge — caller will keep
-                # streaming, eventually an edit will succeed and the buffer
-                # catches up.
+                # Discord blip — bridge is fine, just couldn't render. The
+                # individual edit/send wrappers already do their own
+                # ``_retry_http`` so reaching here means the blip outlasted
+                # one operation's retry budget. Don't tear down the bridge;
+                # caller will keep streaming, eventually an edit will
+                # succeed and the buffer catches up.
                 log.warning(
                     "Discord-transient error during render; bridge stays alive",
                     extra={
@@ -839,8 +836,17 @@ class DiscordRenderer:
                         "thread_id": getattr(self.target, "id", None),
                     },
                 )
-                if live_msg is not None:
-                    await self._safe_edit(live_msg, content=buffer[:DISCORD_MAX_LEN] or "…")
+                # #147 R2 (C2): best-effort flush of whatever is buffered so
+                # the user doesn't lose tail text on a blip. ``_flush`` wraps
+                # Discord ops in their own ``_safe_*`` retry budget, so a
+                # continuing blip won't crash this recovery path. Cost
+                # footer is intentionally skipped on transient: the next
+                # user turn naturally won't try to footer this dead turn,
+                # and attempting it here doubles the failure surface.
+                try:
+                    await self._flush(live_msg, buffer, typewriter, saw_text, tool_msgs)
+                except Exception:  # noqa: BLE001
+                    log.debug("transient-recovery flush also failed; deferring", exc_info=True)
                 # Don't re-raise — caller (_render_with_retry) won't stop_session.
                 return
             log.exception("Renderer fatal error; tearing down bridge")
@@ -1294,7 +1300,6 @@ class DiscordRenderer:
             if time.monotonic() - attempt_start_time < 10.0:
                 return
             network_reaction_added = True
-            self._network_reaction_msg = reaction_target
             try:
                 await reaction_target.add_reaction("🌐")
             except Exception:  # noqa: BLE001
@@ -1314,7 +1319,6 @@ class DiscordRenderer:
                 log.debug("🌐 remove_reaction failed (best-effort)", exc_info=True)
             finally:
                 network_reaction_added = False
-                self._network_reaction_msg = None
 
         for attempt in range(MAX_HTTP_RETRIES + 1):
             try:
@@ -1478,6 +1482,16 @@ class DiscordRenderer:
         async def _op() -> discord.Message | None:
             return await self.target.send(**kwargs)
 
+        # #147 R2 (C1): send has no natural "user is watching this" message
+        # to react on (the new message doesn't exist until ``_op`` returns).
+        # Fall back to ``self._last_msg`` — the most recent typewriter cursor
+        # in the same channel — so the user still gets a 🌐 signal when a
+        # blip stalls the *next* send. When ``_last_msg`` is None (very first
+        # send of a fresh renderer), ``_retry_http`` short-circuits the
+        # reaction lifecycle silently — the long retry budget still applies.
+        prior = self._last_msg
+        guild = getattr(prior, "guild", None) if prior is not None else None
+        bot_user = getattr(guild, "me", None) if guild is not None else None
         msg = await self._retry_http(
             _op,
             label="send",
@@ -1485,6 +1499,8 @@ class DiscordRenderer:
             between_attempts=(
                 _reset_file if ("file" in kwargs or "files" in kwargs) else None
             ),
+            reaction_target=prior,
+            bot_user=bot_user,
         )
         # Only advance the shadow on content-bearing sends. Embed-only and
         # file-only sends do NOT touch _last_msg here — callers that want
@@ -1548,10 +1564,20 @@ class DiscordRenderer:
             await msg.edit(**kwargs)
             return msg
 
+        # #147 R2 (C1): wire 🌐 reaction into the production edit path.
+        # The reaction is attached to ``msg`` itself — the live cursor /
+        # typewriter message the user is watching. ``msg.guild.me`` is the
+        # bot's Member object in the guild; thread/channel ``Messageable``
+        # without a guild (DM) is rare but handled by ``bot_user=None``,
+        # which causes ``_retry_http`` to fall back to ``clear_reaction``.
+        guild = getattr(msg, "guild", None)
+        bot_user = getattr(guild, "me", None) if guild is not None else None
         result = await self._retry_http(
             _op,
             label="edit",
             content_len=len(content) if content else 0,
+            reaction_target=msg,
+            bot_user=bot_user,
         )
         # Sync shadow on success — see #113 / docs/investigations/stale-message-content.md.
         if result is not None and content is not None and msg is self._last_msg:
@@ -1976,10 +2002,21 @@ class DiscordRenderer:
             color=COLOR_TOOL_FAILURE,
         )
         view = RetryView(on_retry=on_retry)
-        try:
-            await self.target.send(embed=embed, view=view)
-        except discord.HTTPException:
-            log.exception("Failed to post crash-with-retry embed")
+        # #147 R2 (C3 / PRD §Decision 6 closure): the original incident chain
+        # was "Discord blip → render crash → retry-embed posted on the SAME
+        # blip → embed post crashes too, no retry button visible". Route the
+        # crash-with-retry embed through ``safe_send_message`` so the same
+        # transient that caused the crash doesn't also eat the recovery UI.
+        # ``safe_send_message`` returns None on giveup (logged at ERROR
+        # inside ``safe_http``); the embed simply doesn't appear and the
+        # user can re-send their message manually — strictly better than
+        # the previous "single attempt, swallowed exception" behavior.
+        sent = await safe_send_message(self.target, embed=embed, view=view)
+        if sent is None:
+            log.warning(
+                "Crash-with-retry embed did not post (transient exhaustion)",
+                extra={"target_id": getattr(self.target, "id", None)},
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cascade_resilience.py
+++ b/tests/test_cascade_resilience.py
@@ -1,0 +1,163 @@
+"""Cascade-resilience tests — #147 Discord-blip vs Claude-fatal taxonomy.
+
+Per PRD §Tests:
+1. Discord blip during render → bridge stays alive, no stop_session.
+2. ProcessError during render → bridge torn down, stop_session called.
+3. RuntimeError during render → bridge torn down, stop_session called.
+4. Network blip > 10s → 🌐 reaction added once and removed on recovery.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import discord
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_bot() -> "object":
+    """Build a `ClaudedBot` instance with the minimum surface area used by
+    `_render_with_retry`: a `session_manager` with an awaitable `stop_session`
+    and `get_lock`, and a `create_session` we can drive from tests."""
+    from clauded.bot import ClaudedBot
+
+    bot = ClaudedBot.__new__(ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.stop_session = AsyncMock()
+
+    # get_lock must return an async context manager
+    class _Lock:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    bot.session_manager.get_lock = MagicMock(return_value=_Lock())
+    bot.session_manager.create_session = AsyncMock()
+    return bot
+
+
+async def _invoke_render(bot, *, renderer, exc_to_raise) -> None:
+    """Call `_render_with_retry` with a renderer whose `render_response`
+    raises `exc_to_raise`, plus a fake thread."""
+    thread = MagicMock()
+    thread.id = 12345
+    thread.send = AsyncMock()
+
+    bridge = MagicMock()
+
+    # Patch send_error_with_retry on the renderer so the retry-button path
+    # doesn't try to invoke real Discord I/O.
+    renderer.send_error_with_retry = AsyncMock()
+
+    await bot._render_with_retry(
+        renderer=renderer,
+        bridge=bridge,
+        user_text="hello",
+        thread=thread,
+        project_path="/tmp/p",
+        session_config=None,
+    )
+
+
+async def test_discord_blip_during_render_keeps_bridge_alive():
+    """Transient `aiohttp.ClientConnectorError` must NOT trigger stop_session."""
+    bot = _make_bot()
+    renderer = MagicMock()
+    blip = aiohttp.ClientConnectorError(MagicMock(), OSError("blip"))
+    renderer.render_response = AsyncMock(side_effect=blip)
+
+    await _invoke_render(bot, renderer=renderer, exc_to_raise=blip)
+
+    bot.session_manager.stop_session.assert_not_called()
+
+
+async def test_process_error_during_render_tears_down():
+    """`claude_agent_sdk.ProcessError` (fatal) MUST trigger stop_session."""
+    try:
+        from claude_agent_sdk import ProcessError
+    except Exception:
+        pytest.skip("claude_agent_sdk not available")
+
+    bot = _make_bot()
+    renderer = MagicMock()
+    try:
+        boom = ProcessError("died")
+    except TypeError:
+        boom = ProcessError.__new__(ProcessError)
+        BaseException.__init__(boom, "died")
+    renderer.render_response = AsyncMock(side_effect=boom)
+
+    await _invoke_render(bot, renderer=renderer, exc_to_raise=boom)
+
+    bot.session_manager.stop_session.assert_awaited()
+
+
+async def test_runtime_error_during_render_tears_down():
+    """Plain `RuntimeError` (fatal/programming error) MUST trigger stop_session."""
+    bot = _make_bot()
+    renderer = MagicMock()
+    boom = RuntimeError("boom")
+    renderer.render_response = AsyncMock(side_effect=boom)
+
+    await _invoke_render(bot, renderer=renderer, exc_to_raise=boom)
+
+    bot.session_manager.stop_session.assert_awaited()
+
+
+async def test_network_reaction_added_after_10s_then_removed_on_recovery():
+    """During a sustained blip, 🌐 is added once; on recovery it's removed."""
+    from clauded.discord_renderer import DiscordRenderer
+
+    target = MagicMock()
+    target.send = AsyncMock()
+    renderer = DiscordRenderer(target)
+
+    # The reaction-bearing message
+    msg = MagicMock(spec=discord.Message)
+    msg.add_reaction = AsyncMock()
+    msg.remove_reaction = AsyncMock()
+
+    # First 3 attempts fail with ClientConnectorError, then succeed.
+    call_count = {"n": 0}
+    success_msg = MagicMock(spec=discord.Message)
+
+    async def _op():
+        call_count["n"] += 1
+        if call_count["n"] <= 3:
+            raise aiohttp.ClientConnectorError(MagicMock(), OSError("blip"))
+        return success_msg
+
+    # Patch time.monotonic to advance 5s per call (so by attempt 3 we've exceeded 10s).
+    t = {"v": 0.0}
+
+    def _fake_monotonic():
+        cur = t["v"]
+        t["v"] += 5.0
+        return cur
+
+    bot_user = MagicMock()
+    bot_user.id = 999
+
+    with patch("clauded.discord_renderer.time.monotonic", side_effect=_fake_monotonic), \
+         patch("clauded.discord_renderer.asyncio.sleep", new=AsyncMock()):
+        result = await renderer._retry_http(
+            _op,
+            label="edit",
+            content_len=10,
+            reaction_target=msg,
+            bot_user=bot_user,
+        )
+
+    assert result is success_msg
+    # 🌐 added once after 10s elapsed
+    add_calls = [c for c in msg.add_reaction.call_args_list if "🌐" in str(c)]
+    assert len(add_calls) == 1, f"expected exactly one 🌐 add_reaction, got {msg.add_reaction.call_args_list}"
+    # 🌐 removed once after recovery
+    remove_calls = [c for c in msg.remove_reaction.call_args_list if "🌐" in str(c)]
+    assert len(remove_calls) == 1, f"expected exactly one 🌐 remove_reaction, got {msg.remove_reaction.call_args_list}"

--- a/tests/test_cascade_resilience.py
+++ b/tests/test_cascade_resilience.py
@@ -111,27 +111,42 @@ async def test_runtime_error_during_render_tears_down():
 
 
 async def test_network_reaction_added_after_10s_then_removed_on_recovery():
-    """During a sustained blip, 🌐 is added once; on recovery it's removed."""
+    """During a sustained blip, 🌐 is added once; on recovery it's removed.
+
+    R2 (C1 pinning): exercise the PRODUCTION path via ``_safe_edit`` rather
+    than ``_retry_http`` directly. The R1 engineer review caught that
+    ``_safe_edit`` / ``_safe_send`` weren't passing ``reaction_target`` so
+    the entire 🌐 feature was dead in production — fixed in C1 by deriving
+    ``reaction_target`` from the message being edited. Driving the test
+    through ``_safe_edit`` ensures any future regression of that wiring
+    breaks this test.
+    """
     from clauded.discord_renderer import DiscordRenderer
 
     target = MagicMock()
     target.send = AsyncMock()
     renderer = DiscordRenderer(target)
 
-    # The reaction-bearing message
-    msg = MagicMock(spec=discord.Message)
-    msg.add_reaction = AsyncMock()
-    msg.remove_reaction = AsyncMock()
-
-    # First 3 attempts fail with ClientConnectorError, then succeed.
+    # First 3 edits fail with ClientConnectorError, then the 4th succeeds.
     call_count = {"n": 0}
-    success_msg = MagicMock(spec=discord.Message)
 
-    async def _op():
+    async def _edit(*args, **kwargs):
         call_count["n"] += 1
         if call_count["n"] <= 3:
             raise aiohttp.ClientConnectorError(MagicMock(), OSError("blip"))
-        return success_msg
+        return None  # discord.Message.edit returns None on success
+
+    # The reaction-bearing message: ``_safe_edit`` will pass this as
+    # ``reaction_target`` automatically. ``msg.guild.me`` is what the new
+    # wiring uses for ``bot_user``.
+    msg = MagicMock(spec=discord.Message)
+    msg.edit = AsyncMock(side_effect=_edit)
+    msg.add_reaction = AsyncMock()
+    msg.remove_reaction = AsyncMock()
+    bot_user = MagicMock()
+    bot_user.id = 999
+    msg.guild = MagicMock()
+    msg.guild.me = bot_user
 
     # Patch time.monotonic to advance 5s per call (so by attempt 3 we've exceeded 10s).
     t = {"v": 0.0}
@@ -141,23 +156,22 @@ async def test_network_reaction_added_after_10s_then_removed_on_recovery():
         t["v"] += 5.0
         return cur
 
-    bot_user = MagicMock()
-    bot_user.id = 999
-
     with patch("clauded.discord_renderer.time.monotonic", side_effect=_fake_monotonic), \
          patch("clauded.discord_renderer.asyncio.sleep", new=AsyncMock()):
-        result = await renderer._retry_http(
-            _op,
-            label="edit",
-            content_len=10,
-            reaction_target=msg,
-            bot_user=bot_user,
-        )
+        ok = await renderer._safe_edit(msg, content="recovered content")
 
-    assert result is success_msg
-    # 🌐 added once after 10s elapsed
+    assert ok is True, "edit should eventually succeed"
+    # 🌐 added once after 10s elapsed, on the same message being edited
     add_calls = [c for c in msg.add_reaction.call_args_list if "🌐" in str(c)]
-    assert len(add_calls) == 1, f"expected exactly one 🌐 add_reaction, got {msg.add_reaction.call_args_list}"
-    # 🌐 removed once after recovery
+    assert len(add_calls) == 1, (
+        f"expected exactly one 🌐 add_reaction, got {msg.add_reaction.call_args_list}"
+    )
+    # 🌐 removed once after recovery, via the bot_user resolved from msg.guild.me
     remove_calls = [c for c in msg.remove_reaction.call_args_list if "🌐" in str(c)]
-    assert len(remove_calls) == 1, f"expected exactly one 🌐 remove_reaction, got {msg.remove_reaction.call_args_list}"
+    assert len(remove_calls) == 1, (
+        f"expected exactly one 🌐 remove_reaction, got {msg.remove_reaction.call_args_list}"
+    )
+    # Pin that the bot_user passed in is what _safe_edit derived from msg.guild.me
+    assert remove_calls[0].args[1] is bot_user, (
+        "remove_reaction should be called with msg.guild.me as the member arg"
+    )

--- a/tests/test_cleanup_deadlock.py
+++ b/tests/test_cleanup_deadlock.py
@@ -1,0 +1,116 @@
+"""Tests for #146 cleanup deadlock — `bridge.stop()` bounded timeout and
+concurrent `_cleanup_task`.
+
+Per PRD §Tests:
+1. Stuck `client.disconnect()` is force-dropped after `CLAUDED_BRIDGE_STOP_TIMEOUT`.
+2. One stuck bridge + two healthy bridges all GC'd in the same `_cleanup_task` tick.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from clauded.claude_bridge import ClaudeBridge
+from clauded.config import Config
+
+
+@pytest.fixture
+def cfg() -> Config:
+    return Config(
+        discord_bot_token="tok",
+        claude_model="sonnet",
+        claude_permission_mode="default",
+        projects_root="/tmp",
+    )
+
+
+@pytest.mark.asyncio
+async def test_stuck_disconnect_force_drops_after_timeout(
+    cfg: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A `disconnect()` that never returns must be force-dropped after the env timeout."""
+    bridge = ClaudeBridge(project_path="/tmp/p", config=cfg)
+    # Simulate a started bridge with a stuck client
+    stuck_client = MagicMock()
+
+    async def _never_returns() -> None:
+        await asyncio.sleep(999)
+
+    stuck_client.disconnect = AsyncMock(side_effect=_never_returns)
+    bridge._client = stuck_client
+    bridge._active = True
+
+    monkeypatch.setenv("CLAUDED_BRIDGE_STOP_TIMEOUT", "0.5")
+
+    # stop() must return within (timeout + small margin), not hang forever.
+    await asyncio.wait_for(bridge.stop(), timeout=2.0)
+
+    assert bridge._client is None
+    assert bridge._active is False
+
+
+@pytest.mark.asyncio
+async def test_cleanup_concurrent_one_stuck_two_healthy(
+    cfg: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One stuck bridge must not block concurrent cleanup of two healthy peers."""
+    from clauded.bot import ClaudedBot
+
+    monkeypatch.setenv("CLAUDED_BRIDGE_STOP_TIMEOUT", "0.3")
+    monkeypatch.setenv("CLAUDED_SESSION_TIMEOUT", "1")  # immediate eligibility
+
+    # Build a bot without going through full init: we only exercise `_cleanup_task`.
+    bot = ClaudedBot.__new__(ClaudedBot)
+    bot.session_manager = MagicMock()
+
+    sessions: dict[int, MagicMock] = {}
+    long_ago = time.time() - 3600
+
+    # Two healthy bridges + one stuck
+    for tid in (101, 102, 103):
+        b = MagicMock()
+        b._last_activity = long_ago
+        b._start_time = long_ago
+        sessions[tid] = b
+
+    async def _never_returns() -> None:
+        await asyncio.sleep(999)
+
+    sessions[102].stop = AsyncMock(side_effect=_never_returns)
+    sessions[101].stop = AsyncMock()
+    sessions[103].stop = AsyncMock()
+
+    bot.session_manager.list_sessions = MagicMock(return_value=sessions)
+    bot.session_manager.save_session_state = MagicMock()
+
+    stopped: list[int] = []
+
+    async def _stop_session(tid: int) -> None:
+        # Mimic real stop_session: pop + delegate to bridge.stop() with timeout
+        bridge = sessions.get(tid)
+        if bridge is None:
+            return
+        try:
+            await asyncio.wait_for(
+                bridge.stop(),
+                timeout=float(os.environ.get("CLAUDED_BRIDGE_STOP_TIMEOUT", "30")),
+            )
+        except asyncio.TimeoutError:
+            pass
+        sessions.pop(tid, None)
+        stopped.append(tid)
+
+    bot.session_manager.stop_session = AsyncMock(side_effect=_stop_session)
+
+    # Invoke the cleanup body. tasks.loop wraps it; call the underlying coroutine.
+    cleanup = ClaudedBot._cleanup_task
+    coro_fn = getattr(cleanup, "coro", None) or getattr(cleanup, "callback", None) or cleanup
+    await asyncio.wait_for(coro_fn(bot), timeout=5.0)
+
+    # All three should have been processed; sessions dict drained.
+    assert sorted(stopped) == [101, 102, 103]
+    assert sessions == {}

--- a/tests/test_cleanup_deadlock.py
+++ b/tests/test_cleanup_deadlock.py
@@ -57,10 +57,30 @@ async def test_stuck_disconnect_force_drops_after_timeout(
 async def test_cleanup_concurrent_one_stuck_two_healthy(
     cfg: Config, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """One stuck bridge must not block concurrent cleanup of two healthy peers."""
+    """One stuck bridge must not block concurrent cleanup of two healthy peers.
+
+    R2 (C1 from tester R1): the original assertion only checked that all
+    three sessions were drained — it would pass even under serial execution
+    because the two healthy mocks returned instantly. Strengthen the test
+    by:
+
+    1. Making the two healthy bridges each ``await asyncio.sleep(HEALTHY)``
+       so a serial implementation would total ``STUCK + HEALTHY + HEALTHY``
+       wall-time, but the concurrent gather should be ~``STUCK``.
+    2. Measuring elapsed wall-time and asserting it stays under 1.5×
+       ``STUCK`` (the cap is the stuck timeout, not the sum).
+
+    Serial budget under the regression: 0.3 + 0.2 + 0.2 = 0.7s (FAIL the
+    < 0.45s bound). Concurrent: max(0.3, 0.2, 0.2) = 0.3s (PASS).
+    """
     from clauded.bot import ClaudedBot
 
-    monkeypatch.setenv("CLAUDED_BRIDGE_STOP_TIMEOUT", "0.3")
+    STUCK_TIMEOUT = 0.3
+    HEALTHY_DELAY = 0.2
+    # Concurrent cap: 1.5 × stuck timeout. Serial would need ≥ 0.7s.
+    CONCURRENCY_BOUND = STUCK_TIMEOUT * 1.5
+
+    monkeypatch.setenv("CLAUDED_BRIDGE_STOP_TIMEOUT", str(STUCK_TIMEOUT))
     monkeypatch.setenv("CLAUDED_SESSION_TIMEOUT", "1")  # immediate eligibility
 
     # Build a bot without going through full init: we only exercise `_cleanup_task`.
@@ -80,9 +100,13 @@ async def test_cleanup_concurrent_one_stuck_two_healthy(
     async def _never_returns() -> None:
         await asyncio.sleep(999)
 
+    async def _healthy_slow() -> None:
+        # Genuine delay so serial execution would compound.
+        await asyncio.sleep(HEALTHY_DELAY)
+
     sessions[102].stop = AsyncMock(side_effect=_never_returns)
-    sessions[101].stop = AsyncMock()
-    sessions[103].stop = AsyncMock()
+    sessions[101].stop = AsyncMock(side_effect=_healthy_slow)
+    sessions[103].stop = AsyncMock(side_effect=_healthy_slow)
 
     bot.session_manager.list_sessions = MagicMock(return_value=sessions)
     bot.session_manager.save_session_state = MagicMock()
@@ -109,8 +133,19 @@ async def test_cleanup_concurrent_one_stuck_two_healthy(
     # Invoke the cleanup body. tasks.loop wraps it; call the underlying coroutine.
     cleanup = ClaudedBot._cleanup_task
     coro_fn = getattr(cleanup, "coro", None) or getattr(cleanup, "callback", None) or cleanup
+
+    elapsed_start = time.monotonic()
     await asyncio.wait_for(coro_fn(bot), timeout=5.0)
+    elapsed = time.monotonic() - elapsed_start
 
     # All three should have been processed; sessions dict drained.
     assert sorted(stopped) == [101, 102, 103]
     assert sessions == {}
+    # Concurrency assertion: if `_cleanup_task` regressed to serial
+    # `for tid in to_remove: await _stop_one(tid)`, the wall time would be
+    # roughly STUCK_TIMEOUT + 2 × HEALTHY_DELAY = 0.7s, far above the cap.
+    assert elapsed < CONCURRENCY_BOUND, (
+        f"cleanup took {elapsed:.3f}s; expected concurrent execution under "
+        f"{CONCURRENCY_BOUND:.3f}s (serial would be "
+        f"~{STUCK_TIMEOUT + 2 * HEALTHY_DELAY:.3f}s)"
+    )

--- a/tests/test_errors_taxonomy.py
+++ b/tests/test_errors_taxonomy.py
@@ -1,0 +1,84 @@
+"""Parametrized tests for `_errors.is_transient_discord_error` taxonomy.
+
+Per PRD §Tests: covers all transient and non-transient cases from
+`src/clauded/_errors.py`.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import aiohttp
+import discord
+import pytest
+
+from clauded._errors import is_transient_discord_error
+
+
+def _http_exception(status: int) -> discord.errors.HTTPException:
+    """Build a `discord.errors.HTTPException` with the given status, robustly."""
+    try:
+        exc = discord.errors.HTTPException(response=MagicMock(status=status), message={})
+    except Exception:
+        try:
+            exc = discord.errors.HTTPException(
+                response=MagicMock(status=status), data={}
+            )
+        except Exception:
+            exc = discord.errors.HTTPException.__new__(discord.errors.HTTPException)
+            BaseException.__init__(exc)
+    exc.status = status
+    return exc
+
+
+@pytest.mark.parametrize(
+    "exc_factory, expected",
+    [
+        # Transient: network/aiohttp errors
+        (lambda: aiohttp.ClientConnectorError(MagicMock(), OSError("blip")), True),
+        (lambda: aiohttp.ServerDisconnectedError(), True),
+        # Transient: asyncio timeouts
+        (lambda: asyncio.TimeoutError(), True),
+        # Transient: HTTPException with retry-worthy status
+        (lambda: _http_exception(429), True),
+        (lambda: _http_exception(500), True),
+        (lambda: _http_exception(502), True),
+        (lambda: _http_exception(503), True),
+        (lambda: _http_exception(504), True),
+        # NOT transient: HTTPException with client-error status
+        (lambda: _http_exception(400), False),
+        (lambda: _http_exception(403), False),
+        (lambda: _http_exception(404), False),
+        # NOT transient: generic programming errors
+        (lambda: RuntimeError("boom"), False),
+        (lambda: ValueError("nope"), False),
+    ],
+)
+def test_is_transient_discord_error(exc_factory, expected):
+    exc = exc_factory()
+    assert is_transient_discord_error(exc) is expected, (
+        f"Expected {expected} for {type(exc).__name__}"
+    )
+
+
+def test_process_error_not_transient():
+    """Claude SDK ProcessError must NOT be considered transient."""
+    try:
+        from claude_agent_sdk import ProcessError
+    except Exception:
+        pytest.skip("claude_agent_sdk not available")
+    try:
+        exc = ProcessError("died")
+    except TypeError:
+        # ProcessError signature may require additional kwargs in some versions
+        exc = ProcessError.__new__(ProcessError)
+        BaseException.__init__(exc, "died")
+    assert is_transient_discord_error(exc) is False
+
+
+def test_connection_closed_is_transient():
+    """`discord.errors.ConnectionClosed` should be considered transient."""
+    # ConnectionClosed signature varies across discord.py versions; bypass __init__
+    exc = discord.errors.ConnectionClosed.__new__(discord.errors.ConnectionClosed)
+    BaseException.__init__(exc)
+    assert is_transient_discord_error(exc) is True

--- a/tests/test_http_retry.py
+++ b/tests/test_http_retry.py
@@ -1,0 +1,183 @@
+"""Direct unit tests for ``clauded._http_retry`` (#147 R2 — tester gap I1).
+
+The R1 tester review flagged that the entire ``_http_retry`` module had zero
+direct coverage: ``safe_http`` was only exercised transitively through
+``safe_remove_reaction`` / ``safe_add_reaction`` in bot.py, and the
+"final WARN log on give-up" contract from PRD §Decision 6 was unverifiable.
+
+These tests pin:
+- ``safe_http`` retries transient (5xx, connection) failures and returns
+  the eventual success value.
+- ``safe_http`` returns ``None`` (does not raise) after exhausting the
+  retry budget.
+- ``safe_send_message`` returns the message on success and ``None`` on
+  give-up (the contract on which #147 R2 C3 depends — crash-with-retry
+  embed silently logs out instead of crashing).
+- ``safe_remove_reaction`` swallows ``discord.Forbidden`` (a permanent,
+  non-transient error — best-effort means we don't surface it).
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import discord
+import pytest
+
+from clauded._http_retry import (
+    safe_http,
+    safe_remove_reaction,
+    safe_send_message,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _http_exc(status: int) -> discord.HTTPException:
+    """Build a ``discord.HTTPException`` with a controlled ``.status``.
+
+    Mirrors the helper in ``tests/test_errors_taxonomy.py`` so version
+    drift in discord.py's HTTPException signature doesn't break the test.
+    """
+    response = MagicMock()
+    response.status = status
+    response.reason = "synthetic"
+    try:
+        exc = discord.HTTPException(response, {"code": 0, "message": "synthetic"})
+    except TypeError:
+        exc = discord.HTTPException.__new__(discord.HTTPException)
+        exc.status = status
+        exc.text = "synthetic"
+        BaseException.__init__(exc, "synthetic")
+    exc.status = status  # ensure it's set regardless of constructor path
+    return exc
+
+
+async def test_safe_http_retries_on_429_then_succeeds(monkeypatch):
+    """A 429 followed by success should return the success value.
+
+    Pins the "transient → retry, then return on recovery" path. We don't
+    actually want to sleep multiple seconds in the unit test, so we patch
+    ``asyncio.sleep`` to a no-op.
+    """
+    monkeypatch.setattr(
+        "clauded._http_retry.asyncio.sleep", AsyncMock()
+    )
+    call = {"n": 0}
+
+    async def _op():
+        call["n"] += 1
+        if call["n"] < 3:
+            raise _http_exc(429)
+        return "ok"
+
+    result = await safe_http(_op, label="test", retries=5, backoff=0.01)
+    assert result == "ok"
+    assert call["n"] == 3, "should have retried twice before success"
+
+
+async def test_safe_http_returns_none_after_max_retries(monkeypatch):
+    """Exhausting the retry budget must return ``None``, NOT raise.
+
+    This is the contract bot.py / discord_renderer.py rely on — a giveup
+    is logged at error level but doesn't propagate, so the caller can
+    decide whether to surface it (typically: log and move on).
+    """
+    monkeypatch.setattr(
+        "clauded._http_retry.asyncio.sleep", AsyncMock()
+    )
+    call = {"n": 0}
+
+    async def _op():
+        call["n"] += 1
+        # Use a real transient: ClientConnectorError. Always fails.
+        raise aiohttp.ClientConnectorError(MagicMock(), OSError("network down"))
+
+    result = await safe_http(_op, label="test", retries=3, backoff=0.01)
+    assert result is None, f"expected None on give-up, got {result!r}"
+    assert call["n"] == 3, f"expected exactly 3 attempts, got {call['n']}"
+
+
+async def test_safe_http_propagates_non_transient():
+    """Non-transient exceptions (e.g. ``RuntimeError``) must propagate.
+
+    ``safe_http`` is a transient-only safety net; programming errors must
+    not be silently swallowed.
+    """
+    async def _op():
+        raise RuntimeError("programming bug")
+
+    with pytest.raises(RuntimeError, match="programming bug"):
+        await safe_http(_op, label="test", retries=3, backoff=0.01)
+
+
+async def test_safe_send_message_returns_message_on_success():
+    """``safe_send_message`` returns the sent ``Message`` on success.
+
+    The crash-with-retry embed path (C3) uses the return value to detect
+    a "did not post" condition; a successful send must yield the message.
+    """
+    channel = MagicMock()
+    sent_msg = MagicMock(spec=discord.Message)
+    channel.send = AsyncMock(return_value=sent_msg)
+
+    result = await safe_send_message(channel, content="hi")
+
+    assert result is sent_msg
+    channel.send.assert_awaited_once_with(content="hi")
+
+
+async def test_safe_send_message_returns_none_on_giveup(monkeypatch):
+    """On transient exhaustion, ``safe_send_message`` returns ``None``.
+
+    Pins the contract that ``send_error_with_retry`` (C3 wiring) relies
+    on: a giveup must not raise — the caller logs a warning and the user
+    can manually re-send.
+    """
+    monkeypatch.setattr(
+        "clauded._http_retry.asyncio.sleep", AsyncMock()
+    )
+    channel = MagicMock()
+
+    async def _bad_send(**kwargs):
+        raise aiohttp.ClientConnectorError(MagicMock(), OSError("blip"))
+
+    channel.send = AsyncMock(side_effect=_bad_send)
+
+    result = await safe_send_message(channel, content="hi")
+
+    assert result is None
+    # safe_http's default retries=5, so 5 attempts were made
+    assert channel.send.await_count == 5
+
+
+async def test_safe_remove_reaction_swallows_forbidden():
+    """``safe_remove_reaction`` is best-effort: ``Forbidden`` must NOT raise.
+
+    The double-layer (safe_http re-raises non-transients; the outer
+    try/except in safe_remove_reaction swallows them with a debug log)
+    is intentional — reactions are decorative UX accents and a missing
+    permission shouldn't crash the bot. Pinning the swallow behavior
+    here ensures future refactors preserve the contract.
+    """
+    msg = MagicMock(spec=discord.Message)
+    # Build a Forbidden (subclass of HTTPException). Same constructor
+    # drama as in the helper above.
+    response = MagicMock()
+    response.status = 403
+    try:
+        forbidden = discord.Forbidden(response, {"code": 50013, "message": "Missing Permissions"})
+    except TypeError:
+        forbidden = discord.Forbidden.__new__(discord.Forbidden)
+        forbidden.status = 403
+        BaseException.__init__(forbidden, "Missing Permissions")
+
+    msg.remove_reaction = AsyncMock(side_effect=forbidden)
+    member = MagicMock()
+
+    # Must NOT raise.
+    await safe_remove_reaction(msg, "⏳", member)
+
+    msg.remove_reaction.assert_awaited_once()


### PR DESCRIPTION
Closes #146, #147.

PRD: `docs/prd/v1.14-cascade-resilience.md` (manager-locked).

Real incident 2026-05-11: Discord HTTP blip → `except Exception` → `stop_session` → SIGTERM Claude CLI → sub-agents killed mid-flight. 4 cascades in 24h. 6.5h frozen thread.

## Fixes
1. **Exception taxonomy** — new `_errors.py::is_transient_discord_error` splits Discord transients from Claude fatals
2. **Renderer pause-not-teardown** — `discord_renderer.py:822` returns silently on transient, re-raises on fatal
3. **Bot `_render_with_retry`** — only `stop_session` on fatal; transient keeps bridge alive
4. **🌐 reaction signal** — `_retry_http` adds 🌐 after 10s paused render; removes on recovery
5. **Bounded `bridge.stop()`** — env `CLAUDED_BRIDGE_STOP_TIMEOUT=30`; force-drop on timeout (fixes #146 cleanup deadlock)
6. **Concurrent cleanup** — `asyncio.gather` over per-session stop (one stuck doesn't block others)
7. **Companion fix D** — `_http_retry.py` shared safe-{edit,send,remove_reaction,add_reaction}; wraps error-path Discord ops

## Tests
+21 (425 pass / 2 pre-existing P1):
- `test_errors_taxonomy.py` — 15 parametrize cases
- `test_cleanup_deadlock.py` — force-drop + concurrent gather
- `test_cascade_resilience.py` — blip-alive / ProcessError-fatal / RuntimeError-fatal / 🌐 lifecycle

## Dev deviations (disclosed in commit)
1. `_retry_http` extended to catch `aiohttp.ClientError` + `asyncio.TimeoutError` — without this, the blip would crash through before 🌐 logic could fire
2. `bot_user` param for symmetric remove_reaction
3. Two retry predicates (taxonomy vs retry-loop) by design — different concerns
4. `send_error_with_retry` refactor out of scope (lives in renderer not bot.py:690)