### PR TITLE
v1.15: macOS LaunchAgent + log rotation + health check + alerting (#139)

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,55 @@ User @mentions bot in #my-project channel
 
 ---
 
+## Run as macOS service
+
+claudeD ships with a user-level LaunchAgent so the bot starts at login, auto-restarts on crash, rotates its log file, and surfaces a desktop notification if it crash-loops. macOS only — Linux/Windows users should run `clauded` under their own service manager (systemd, NSSM, etc.).
+
+### Prerequisites
+
+- `.env` exists at the repo root with `DISCORD_BOT_TOKEN` set
+- `.venv` is built and `pip install -e .` has been run so `.venv/bin/clauded` exists and is executable
+
+### Install
+
+```bash
+./scripts/install-launchagent.sh
+```
+
+The script renders the plist templates with absolute paths for your `$HOME` and repo, drops them under `~/Library/LaunchAgents/`, and bootstraps both agents (`com.hxy.clauded` and `com.hxy.clauded.healthcheck`) into your launchd user domain. The bot should be online in Discord within 30 seconds.
+
+### Status & logs
+
+```bash
+# Is launchd running it?
+launchctl print gui/$(id -u)/com.hxy.clauded
+
+# Live app log (rotates at 10 MB × 7 backups)
+tail -f ~/Library/Logs/clauded/clauded.log
+
+# launchd stdout/stderr (boot diagnostics)
+tail -f ~/Library/Logs/clauded/out.log ~/Library/Logs/clauded/err.log
+
+# Crash-loop alerts (≥3 restarts in 5 min)
+tail -f ~/Library/Logs/clauded/alerts.log
+```
+
+### Uninstall
+
+```bash
+./scripts/uninstall-launchagent.sh
+```
+
+Removes the plists and unloads both agents. Logs under `~/Library/Logs/clauded/` are preserved for audit; delete that directory manually if you want them gone.
+
+### Notes
+
+- macOS only. The plist templates use `launchctl bootstrap` (modern, macOS 10.10+).
+- Re-run `./scripts/install-launchagent.sh` after upgrading Python or recreating `.venv` to refresh the plist's absolute path.
+- The bot writes a heartbeat to `~/Library/Caches/clauded/heartbeat` every 30 s; the helper agent polls every 5 min and `launchctl kickstart`s the main agent if the heartbeat is stale (>120 s) — covering silent Discord-gateway hangs that `KeepAlive` alone won't catch.
+
+---
+
 ## Development
 
 Install with development dependencies:

--- a/docs/prd/v1.15-launchagent.md
+++ b/docs/prd/v1.15-launchagent.md
@@ -1,0 +1,323 @@
+# PRD — v1.15 macOS LaunchAgent (#139)
+
+**Status:** Approved (manager self-decided 2026-05-11, user delegated full discretion).
+**Branch:** `feat/v1.15-launchagent`.
+**Scope:** macOS-only user-level service registration + log rotation + health check + alerting. Single PR, ~465 LOC total (~50 Python + rest shell/XML/docs).
+
+## Goal
+
+Run claudeD as a self-managed macOS service so the user doesn't babysit it. Currently a crash, reboot, or silent Discord gateway disconnect leaves the bot dead until manual restart. After this PR: bot auto-starts at login, auto-restarts on crash, logs rotate, health check detects zombies, repeated restarts alert the user.
+
+## Confirmed product decisions (from initial discussion + PRD review)
+
+- [x] **OS**: macOS only
+- [x] **Privilege**: user-level LaunchAgent (no LaunchDaemon, no sudo)
+- [x] **Feature tier**: full — auto-restart + log rotation + health check + alerting
+- [x] **Launch command**: `~/dev/AI/claudeD/.venv/bin/clauded` (existing `[project.scripts]` console-script entry at `clauded.bot:main`, hardcoded venv Python shebang verified working)
+- [x] **Label**: `com.hxy.clauded` (main) + `com.hxy.clauded.healthcheck` (helper)
+- [x] **ThrottleInterval**: 30 s (covers Discord gateway handshake; prevents restart storms)
+- [x] **Heartbeat cadence**: 30 s bot-side write, 5 min check-side poll, 120 s stale threshold
+- [x] **Alert threshold**: ≥3 restarts in 5 min → `osascript display notification` + `alerts.log` append
+- [x] **Uninstall keeps logs**: yes — preserves audit trail
+- [x] **Multi-user**: each user installs to their own launchd user domain; no cross-user
+- [x] **Test isolation**: detect `PYTEST_CURRENT_TEST` env at logger setup; fallback to stderr-only (skip mkdir `~/Library/Logs/`)
+
+## Architecture
+
+### Two LaunchAgents
+
+```
+~/Library/LaunchAgents/
+├── com.hxy.clauded.plist                   # main bot
+└── com.hxy.clauded.healthcheck.plist       # zombie detector
+```
+
+**Main agent** (`com.hxy.clauded.plist`):
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.hxy.clauded</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{REPO}}/.venv/bin/clauded</string>
+    </array>
+    <key>WorkingDirectory</key><string>{{REPO}}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key><string>{{HOME}}</string>
+        <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+    <key>ThrottleInterval</key><integer>30</integer>
+    <key>ProcessType</key><string>Background</string>
+    <key>StandardOutPath</key><string>{{HOME}}/Library/Logs/clauded/out.log</string>
+    <key>StandardErrorPath</key><string>{{HOME}}/Library/Logs/clauded/err.log</string>
+</dict>
+</plist>
+```
+
+**Helper agent** (`com.hxy.clauded.healthcheck.plist`):
+```xml
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.hxy.clauded.healthcheck</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{REPO}}/scripts/health-check.sh</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key><string>{{HOME}}</string>
+    </dict>
+    <key>StartInterval</key><integer>300</integer>
+    <key>RunAtLoad</key><false/>
+    <key>StandardOutPath</key><string>{{HOME}}/Library/Logs/clauded/healthcheck.log</string>
+    <key>StandardErrorPath</key><string>{{HOME}}/Library/Logs/clauded/healthcheck.log</string>
+</dict>
+</plist>
+```
+
+### `src/clauded/bot.py` — heartbeat task
+
+Add a new `@tasks.loop(seconds=30)` mirroring `_cleanup_task`:
+
+```python
+@tasks.loop(seconds=30)
+async def _heartbeat_task(self) -> None:
+    """Write a heartbeat file every 30s for the external health checker."""
+    heartbeat_path = Path.home() / "Library" / "Caches" / "clauded" / "heartbeat"
+    heartbeat_path.parent.mkdir(parents=True, exist_ok=True)
+    heartbeat_path.touch()
+
+@_heartbeat_task.before_loop
+async def _before_heartbeat(self) -> None:
+    await self.wait_until_ready()
+```
+
+Started in `setup_hook` next to `_cleanup_task.start()`.
+
+### `src/clauded/bot.py:main` — RotatingFileHandler + test isolation
+
+```python
+def main() -> None:
+    """Console-script entry point: load config and run the bot."""
+    _configure_logging()
+    # ...rest unchanged
+
+def _configure_logging() -> None:
+    """Set up app logging — RotatingFileHandler in production, stderr-only in tests."""
+    fmt = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+    if os.environ.get("PYTEST_CURRENT_TEST") or not sys.stderr.isatty() is False:
+        # In tests: stderr only; don't pollute ~/Library/Logs/
+        logging.basicConfig(level=logging.INFO, format=fmt)
+        return
+    log_dir = Path.home() / "Library" / "Logs" / "clauded"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    handler = RotatingFileHandler(
+        log_dir / "clauded.log",
+        maxBytes=10 * 1024 * 1024,
+        backupCount=7,
+        encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter(fmt))
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(handler)
+    # Keep stderr too so launchd capture (out.log/err.log) sees something for boot diagnostics
+    root.addHandler(logging.StreamHandler(sys.stderr))
+```
+
+Wait — the heuristic above is messy. Simpler rule: **always file-log, except when `PYTEST_CURRENT_TEST` is set**. Final implementation:
+
+```python
+def _configure_logging() -> None:
+    fmt = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        logging.basicConfig(level=logging.INFO, format=fmt)
+        return
+    log_dir = Path.home() / "Library" / "Logs" / "clauded"
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        logging.basicConfig(level=logging.INFO, format=fmt)
+        return
+    handler = RotatingFileHandler(log_dir / "clauded.log", maxBytes=10*1024*1024, backupCount=7, encoding="utf-8")
+    handler.setFormatter(logging.Formatter(fmt))
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(logging.Formatter(fmt))
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(handler)
+    root.addHandler(stderr_handler)
+```
+
+### `scripts/health-check.sh` — external zombie detector
+
+```bash
+#!/bin/bash
+set -uo pipefail
+
+HEARTBEAT="$HOME/Library/Caches/clauded/heartbeat"
+RESTART_COUNTER="$HOME/Library/Caches/clauded/restart-count"
+ALERTS_LOG="$HOME/Library/Logs/clauded/alerts.log"
+STALE_THRESHOLD_SECS=120
+
+mkdir -p "$(dirname "$HEARTBEAT")" "$(dirname "$ALERTS_LOG")"
+
+# Skip if system woke <60s ago (avoid false positive from sleep/wake)
+WAKE_AGE=$(pmset -g log 2>/dev/null | awk '/DarkWake|Wake from/ { ts=$1" "$2 } END { print ts }' | xargs -I {} date -j -f "%Y-%m-%d %H:%M:%S" "{}" "+%s" 2>/dev/null || echo 0)
+NOW=$(date +%s)
+if [ "$WAKE_AGE" -gt 0 ] && [ $((NOW - WAKE_AGE)) -lt 60 ]; then
+    echo "$(date '+%F %T') skip — recent wake" >> "$(dirname "$ALERTS_LOG")/healthcheck.log"
+    exit 0
+fi
+
+# Stale heartbeat check
+if [ ! -f "$HEARTBEAT" ]; then
+    AGE=99999
+else
+    HEARTBEAT_MTIME=$(stat -f %m "$HEARTBEAT")
+    AGE=$((NOW - HEARTBEAT_MTIME))
+fi
+
+if [ "$AGE" -gt "$STALE_THRESHOLD_SECS" ]; then
+    echo "$(date '+%F %T') heartbeat stale ($AGE s); kickstarting com.hxy.clauded" >> "$ALERTS_LOG"
+    launchctl kickstart -k "gui/$(id -u)/com.hxy.clauded" 2>/dev/null || true
+
+    # Track restart count in rolling 5-min window via /tmp file (per-day rotating)
+    DAY=$(date +%Y%m%d)
+    COUNTER_TODAY="${RESTART_COUNTER}.${DAY}"
+    NOW=$(date +%s)
+    if [ -f "$COUNTER_TODAY" ]; then
+        # Keep only entries within last 300 s
+        awk -v cutoff=$((NOW - 300)) '$1 > cutoff' "$COUNTER_TODAY" > "$COUNTER_TODAY.tmp"
+        mv "$COUNTER_TODAY.tmp" "$COUNTER_TODAY"
+    fi
+    echo "$NOW restart" >> "$COUNTER_TODAY"
+    COUNT=$(wc -l < "$COUNTER_TODAY")
+    if [ "$COUNT" -ge 3 ]; then
+        MSG="claudeD restarted $COUNT times in last 5 min"
+        echo "$(date '+%F %T') ALERT $MSG" >> "$ALERTS_LOG"
+        osascript -e "display notification \"$MSG\" with title \"claudeD\"" 2>/dev/null || true
+    fi
+fi
+```
+
+### `scripts/install-launchagent.sh`
+
+```bash
+#!/bin/bash
+set -euo pipefail
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+HOME_DIR="$HOME"
+TEMPLATE_DIR="$REPO/scripts"
+INSTALL_DIR="$HOME/Library/LaunchAgents"
+LOG_DIR="$HOME/Library/Logs/clauded"
+CACHE_DIR="$HOME/Library/Caches/clauded"
+
+# Sanity
+if [ ! -x "$REPO/.venv/bin/clauded" ]; then
+    echo "❌ $REPO/.venv/bin/clauded not executable. Run: cd $REPO && python -m venv .venv && .venv/bin/pip install -e ."
+    exit 1
+fi
+if [ ! -f "$REPO/.env" ]; then
+    echo "❌ $REPO/.env missing. Copy .env.example and set DISCORD_BOT_TOKEN."
+    exit 1
+fi
+
+mkdir -p "$INSTALL_DIR" "$LOG_DIR" "$CACHE_DIR"
+chmod 700 "$LOG_DIR" "$CACHE_DIR"
+
+for name in com.hxy.clauded com.hxy.clauded.healthcheck; do
+    sed -e "s|{{REPO}}|$REPO|g" -e "s|{{HOME}}|$HOME_DIR|g" \
+        "$TEMPLATE_DIR/${name}.plist.template" > "$INSTALL_DIR/${name}.plist"
+done
+
+# Modern bootstrap syntax (macOS 10.10+)
+UID_GUI="gui/$(id -u)"
+launchctl bootout "$UID_GUI/com.hxy.clauded" 2>/dev/null || true
+launchctl bootout "$UID_GUI/com.hxy.clauded.healthcheck" 2>/dev/null || true
+launchctl bootstrap "$UID_GUI" "$INSTALL_DIR/com.hxy.clauded.plist"
+launchctl bootstrap "$UID_GUI" "$INSTALL_DIR/com.hxy.clauded.healthcheck.plist"
+launchctl enable "$UID_GUI/com.hxy.clauded"
+launchctl enable "$UID_GUI/com.hxy.clauded.healthcheck"
+launchctl kickstart -k "$UID_GUI/com.hxy.clauded"
+
+cat <<EOF
+✅ Installed claudeD as a macOS LaunchAgent.
+
+Status:        launchctl print $UID_GUI/com.hxy.clauded
+App log:       tail -f $LOG_DIR/clauded.log
+launchd out:   tail -f $LOG_DIR/out.log $LOG_DIR/err.log
+Alerts:        tail -f $LOG_DIR/alerts.log
+Uninstall:     ./scripts/uninstall-launchagent.sh
+
+Bot should be online in Discord within 30 s.
+EOF
+```
+
+### `scripts/uninstall-launchagent.sh`
+
+```bash
+#!/bin/bash
+set -euo pipefail
+INSTALL_DIR="$HOME/Library/LaunchAgents"
+UID_GUI="gui/$(id -u)"
+for name in com.hxy.clauded com.hxy.clauded.healthcheck; do
+    launchctl bootout "$UID_GUI/$name" 2>/dev/null || true
+    rm -f "$INSTALL_DIR/${name}.plist"
+done
+echo "✅ Uninstalled. Logs preserved at $HOME/Library/Logs/clauded/."
+```
+
+## Acceptance criteria
+
+Per issue body's checklist. Add explicit `tests/test_logging_setup.py` covering:
+- `_configure_logging()` with `PYTEST_CURRENT_TEST` set → no `RotatingFileHandler` added; stderr only
+- `_configure_logging()` without env → mkdir + RotatingFileHandler + stderr handler attached; `log_dir.exists()` True (in tmp_path)
+- monkeypatch `Path.home` to point at tmp_path
+- `_heartbeat_task` writes file; touches mtime; idempotent
+
+`scripts/` are shell — covered by acceptance §Install/lifecycle + manual run, not by pytest.
+
+## Files touched
+
+| File | Type | LOC est |
+|---|---|---|
+| `scripts/com.hxy.clauded.plist.template` | new | 25 |
+| `scripts/com.hxy.clauded.healthcheck.plist.template` | new | 20 |
+| `scripts/health-check.sh` | new | 55 |
+| `scripts/install-launchagent.sh` | new | 50 |
+| `scripts/uninstall-launchagent.sh` | new | 12 |
+| `src/clauded/bot.py` | +50 (heartbeat task, `_configure_logging`, imports) | |
+| `tests/test_logging_setup.py` | new | 60 |
+| `README.md` | +40 (install/uninstall section) | |
+| `docs/prd/v1.15-launchagent.md` | new | ~250 |
+
+Total ~560 LOC. Python only ~110; rest shell/XML/docs.
+
+## Out of scope
+
+- Linux systemd — separate issue
+- Docker — separate issue
+- HTTP `/health` endpoint — can add later if external monitoring needed
+- Discord webhook alerts — rejected (self-defeating)
+- Python version upgrade handling — README note covers re-install
+- iCloud-synced `~/Library/Logs/` — enterprise edge
+
+## Rollback
+
+`./scripts/uninstall-launchagent.sh` removes plists and unloads. Logs preserved. Code changes are additive (heartbeat task, logging setup) — revert single commit if needed.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `PYTEST_CURRENT_TEST` is pytest-internal; could change | If detection fails, fallback to existing basicConfig; no crash |
+| `Path.home() / "Library"` doesn't exist on non-macOS dev box | `OSError` catch falls back to basicConfig (Linux dev still works) |
+| User has `.zshrc` setting PATH differently from plist | plist sets explicit `PATH=/opt/homebrew/bin:...` — same as `claude` resolves elsewhere in repo |
+| pmset wake-detection regex fragile across macOS versions | Heuristic only; on parse failure age=0 → check proceeds normally |
+| `launchctl bootstrap` denied (SIP/sandbox edge) | Install script `exit 1` on failure with error message |

--- a/scripts/com.hxy.clauded.healthcheck.plist.template
+++ b/scripts/com.hxy.clauded.healthcheck.plist.template
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.hxy.clauded.healthcheck</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{REPO}}/scripts/health-check.sh</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key><string>{{HOME}}</string>
+    </dict>
+    <key>StartInterval</key><integer>300</integer>
+    <key>RunAtLoad</key><false/>
+    <key>StandardOutPath</key><string>{{HOME}}/Library/Logs/clauded/healthcheck.log</string>
+    <key>StandardErrorPath</key><string>{{HOME}}/Library/Logs/clauded/healthcheck.log</string>
+</dict>
+</plist>

--- a/scripts/com.hxy.clauded.plist.template
+++ b/scripts/com.hxy.clauded.plist.template
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.hxy.clauded</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{REPO}}/.venv/bin/clauded</string>
+    </array>
+    <key>WorkingDirectory</key><string>{{REPO}}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key><string>{{HOME}}</string>
+        <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+    <key>ThrottleInterval</key><integer>30</integer>
+    <key>ProcessType</key><string>Background</string>
+    <key>StandardOutPath</key><string>{{HOME}}/Library/Logs/clauded/out.log</string>
+    <key>StandardErrorPath</key><string>{{HOME}}/Library/Logs/clauded/err.log</string>
+</dict>
+</plist>

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -uo pipefail
+
+HEARTBEAT="$HOME/Library/Caches/clauded/heartbeat"
+RESTART_COUNTER="$HOME/Library/Caches/clauded/restart-count"
+ALERTS_LOG="$HOME/Library/Logs/clauded/alerts.log"
+STALE_THRESHOLD_SECS=120
+
+mkdir -p "$(dirname "$HEARTBEAT")" "$(dirname "$ALERTS_LOG")"
+
+# Skip if system woke <60s ago (avoid false positive from sleep/wake)
+WAKE_AGE=$(pmset -g log 2>/dev/null | awk '/DarkWake|Wake from/ { ts=$1" "$2 } END { print ts }' | xargs -I {} date -j -f "%Y-%m-%d %H:%M:%S" "{}" "+%s" 2>/dev/null || echo 0)
+NOW=$(date +%s)
+if [ "$WAKE_AGE" -gt 0 ] && [ $((NOW - WAKE_AGE)) -lt 60 ]; then
+    echo "$(date '+%F %T') skip — recent wake" >> "$(dirname "$ALERTS_LOG")/healthcheck.log"
+    exit 0
+fi
+
+# Stale heartbeat check
+if [ ! -f "$HEARTBEAT" ]; then
+    AGE=99999
+else
+    HEARTBEAT_MTIME=$(stat -f %m "$HEARTBEAT")
+    AGE=$((NOW - HEARTBEAT_MTIME))
+fi
+
+if [ "$AGE" -gt "$STALE_THRESHOLD_SECS" ]; then
+    echo "$(date '+%F %T') heartbeat stale ($AGE s); kickstarting com.hxy.clauded" >> "$ALERTS_LOG"
+    launchctl kickstart -k "gui/$(id -u)/com.hxy.clauded" 2>/dev/null || true
+
+    # Track restart count in rolling 5-min window via /tmp file (per-day rotating)
+    DAY=$(date +%Y%m%d)
+    COUNTER_TODAY="${RESTART_COUNTER}.${DAY}"
+    NOW=$(date +%s)
+    if [ -f "$COUNTER_TODAY" ]; then
+        # Keep only entries within last 300 s
+        awk -v cutoff=$((NOW - 300)) '$1 > cutoff' "$COUNTER_TODAY" > "$COUNTER_TODAY.tmp"
+        mv "$COUNTER_TODAY.tmp" "$COUNTER_TODAY"
+    fi
+    echo "$NOW restart" >> "$COUNTER_TODAY"
+    COUNT=$(wc -l < "$COUNTER_TODAY")
+    if [ "$COUNT" -ge 3 ]; then
+        MSG="claudeD restarted $COUNT times in last 5 min"
+        echo "$(date '+%F %T') ALERT $MSG" >> "$ALERTS_LOG"
+        osascript -e "display notification \"$MSG\" with title \"claudeD\"" 2>/dev/null || true
+    fi
+fi

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -8,10 +8,26 @@ STALE_THRESHOLD_SECS=120
 
 mkdir -p "$(dirname "$HEARTBEAT")" "$(dirname "$ALERTS_LOG")"
 
-# Skip if system woke <60s ago (avoid false positive from sleep/wake)
-WAKE_AGE=$(pmset -g log 2>/dev/null | awk '/DarkWake|Wake from/ { ts=$1" "$2 } END { print ts }' | xargs -I {} date -j -f "%Y-%m-%d %H:%M:%S" "{}" "+%s" 2>/dev/null || echo 0)
+# Skip if system woke <60s ago (avoid false positive from sleep/wake).
+#
+# pmset -g log emits lines like "2026-05-05 01:49:46 +0800 Assertions ..." —
+# fields are: $1=date, $2=time, $3=tz-offset. Older code piped all three into
+# `date -j -f "%Y-%m-%d %H:%M:%S"`, which can't parse the tz suffix → parse
+# always failed → `|| echo 0` → WAKE_TS=0 → skip branch never fired (zombie
+# wake-suppression). Take only $1+$2 so the format string matches, and rely
+# on `awk '/DarkWake|Wake from/'` to pick the *last* matching line.
+#
+# Verify manually:
+#   pmset -g log | awk '/DarkWake|Wake from/ {ts=$1" "$2} END {print ts}'
+# Output should be "YYYY-MM-DD HH:MM:SS" with no trailing tz.
+WAKE_LINE=$(pmset -g log 2>/dev/null | awk '/DarkWake|Wake from/ {ts=$1" "$2} END {print ts}')
+if [ -n "$WAKE_LINE" ]; then
+    WAKE_TS=$(date -j -f "%Y-%m-%d %H:%M:%S" "$WAKE_LINE" "+%s" 2>/dev/null || echo 0)
+else
+    WAKE_TS=0
+fi
 NOW=$(date +%s)
-if [ "$WAKE_AGE" -gt 0 ] && [ $((NOW - WAKE_AGE)) -lt 60 ]; then
+if [ "$WAKE_TS" -gt 0 ] && [ $((NOW - WAKE_TS)) -lt 60 ]; then
     echo "$(date '+%F %T') skip — recent wake" >> "$(dirname "$ALERTS_LOG")/healthcheck.log"
     exit 0
 fi

--- a/scripts/install-launchagent.sh
+++ b/scripts/install-launchagent.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+HOME_DIR="$HOME"
+TEMPLATE_DIR="$REPO/scripts"
+INSTALL_DIR="$HOME/Library/LaunchAgents"
+LOG_DIR="$HOME/Library/Logs/clauded"
+CACHE_DIR="$HOME/Library/Caches/clauded"
+
+# Sanity
+if [ ! -x "$REPO/.venv/bin/clauded" ]; then
+    echo "❌ $REPO/.venv/bin/clauded not executable. Run: cd $REPO && python -m venv .venv && .venv/bin/pip install -e ."
+    exit 1
+fi
+if [ ! -f "$REPO/.env" ]; then
+    echo "❌ $REPO/.env missing. Copy .env.example and set DISCORD_BOT_TOKEN."
+    exit 1
+fi
+
+mkdir -p "$INSTALL_DIR" "$LOG_DIR" "$CACHE_DIR"
+chmod 700 "$LOG_DIR" "$CACHE_DIR"
+
+for name in com.hxy.clauded com.hxy.clauded.healthcheck; do
+    sed -e "s|{{REPO}}|$REPO|g" -e "s|{{HOME}}|$HOME_DIR|g" \
+        "$TEMPLATE_DIR/${name}.plist.template" > "$INSTALL_DIR/${name}.plist"
+done
+
+# Modern bootstrap syntax (macOS 10.10+)
+UID_GUI="gui/$(id -u)"
+launchctl bootout "$UID_GUI/com.hxy.clauded" 2>/dev/null || true
+launchctl bootout "$UID_GUI/com.hxy.clauded.healthcheck" 2>/dev/null || true
+launchctl bootstrap "$UID_GUI" "$INSTALL_DIR/com.hxy.clauded.plist"
+launchctl bootstrap "$UID_GUI" "$INSTALL_DIR/com.hxy.clauded.healthcheck.plist"
+launchctl enable "$UID_GUI/com.hxy.clauded"
+launchctl enable "$UID_GUI/com.hxy.clauded.healthcheck"
+launchctl kickstart -k "$UID_GUI/com.hxy.clauded"
+
+cat <<EOF
+✅ Installed claudeD as a macOS LaunchAgent.
+
+Status:        launchctl print $UID_GUI/com.hxy.clauded
+App log:       tail -f $LOG_DIR/clauded.log
+launchd out:   tail -f $LOG_DIR/out.log $LOG_DIR/err.log
+Alerts:        tail -f $LOG_DIR/alerts.log
+Uninstall:     ./scripts/uninstall-launchagent.sh
+
+Bot should be online in Discord within 30 s.
+EOF

--- a/scripts/uninstall-launchagent.sh
+++ b/scripts/uninstall-launchagent.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+INSTALL_DIR="$HOME/Library/LaunchAgents"
+UID_GUI="gui/$(id -u)"
+for name in com.hxy.clauded com.hxy.clauded.healthcheck; do
+    launchctl bootout "$UID_GUI/$name" 2>/dev/null || true
+    rm -f "$INSTALL_DIR/${name}.plist"
+done
+echo "✅ Uninstalled. Logs preserved at $HOME/Library/Logs/clauded/."

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -14,6 +14,7 @@ import tempfile
 import time
 import sys
 import asyncio
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 import discord
@@ -146,6 +147,7 @@ class ClaudedBot(commands.Bot):
         except Exception:
             self._claude_version = "unknown"
         self._cleanup_task.start()
+        self._heartbeat_task.start()
 
         # PRD R3.3 — register the persistent Copy-as-text button view so
         # the button keeps working after a bot restart.
@@ -230,6 +232,17 @@ class ClaudedBot(commands.Bot):
 
     @_cleanup_task.before_loop
     async def _before_cleanup(self) -> None:
+        await self.wait_until_ready()
+
+    @tasks.loop(seconds=30)
+    async def _heartbeat_task(self) -> None:
+        """Write a heartbeat file every 30s for the external health checker."""
+        heartbeat_path = Path.home() / "Library" / "Caches" / "clauded" / "heartbeat"
+        heartbeat_path.parent.mkdir(parents=True, exist_ok=True)
+        heartbeat_path.touch()
+
+    @_heartbeat_task.before_loop
+    async def _before_heartbeat(self) -> None:
         await self.wait_until_ready()
 
     async def on_ready(self) -> None:  # type: ignore[override]
@@ -846,12 +859,43 @@ class ClaudedBot(commands.Bot):
 # Entrypoint
 # ---------------------------------------------------------------------------
 
+def _configure_logging() -> None:
+    """Set up app logging — RotatingFileHandler in production, stderr-only in tests.
+
+    Detects pytest via ``PYTEST_CURRENT_TEST`` so test runs don't pollute
+    ``~/Library/Logs/clauded/``. In production, attaches a 10 MB × 7 rotating
+    file handler plus a stderr handler so launchd's ``StandardErrorPath`` still
+    captures boot diagnostics. Falls back to ``basicConfig`` on ``OSError`` (e.g.
+    Linux dev box with no ``~/Library/``).
+    """
+    fmt = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        logging.basicConfig(level=logging.INFO, format=fmt)
+        return
+    log_dir = Path.home() / "Library" / "Logs" / "clauded"
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        logging.basicConfig(level=logging.INFO, format=fmt)
+        return
+    handler = RotatingFileHandler(
+        log_dir / "clauded.log",
+        maxBytes=10 * 1024 * 1024,
+        backupCount=7,
+        encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter(fmt))
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(logging.Formatter(fmt))
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(handler)
+    root.addHandler(stderr_handler)
+
+
 def main() -> None:
     """Console-script entry point: load config and run the bot."""
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
+    _configure_logging()
 
     # Resolve and log the operator's Claude CLI so it's visible at boot time.
     from .cli_paths import resolve_claude_cli

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -47,6 +47,39 @@ log = logging.getLogger("clauded.bot")
 
 _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
 
+# --------------------------------------------------------------------------
+# macOS LaunchAgent paths/labels (v1.15).
+#
+# Mirror of the string literals used by scripts/install-launchagent.sh,
+# scripts/health-check.sh, scripts/com.hxy.clauded.plist.template and
+# README §Status & logs. Bash scripts keep their own literals (cross-language
+# sourcing is overkill for v1.15); when changing any of these, grep the
+# repo for the matching string in those files.
+# --------------------------------------------------------------------------
+_LAUNCHD_LABEL = "com.hxy.clauded"
+_LOG_DIR = Path.home() / "Library" / "Logs" / "clauded"
+_CACHE_DIR = Path.home() / "Library" / "Caches" / "clauded"
+_HEARTBEAT_PATH = _CACHE_DIR / "heartbeat"
+
+
+def _touch_heartbeat() -> None:
+    """Refresh ``_HEARTBEAT_PATH`` mtime so the external healthcheck sees us alive.
+
+    Called once from ``main()`` at process start (so login failures don't strand
+    the healthcheck with a stale file) and again every 30 s from
+    :meth:`ClaudedBot._heartbeat_task` (so a wedged event loop is detected too).
+    macOS-only by design — Linux/Windows dev boxes are no-ops to avoid littering
+    ``~/Library/`` outside Darwin. ``OSError`` is swallowed so a read-only home
+    or unusual test sandbox never crashes startup.
+    """
+    if sys.platform != "darwin":
+        return
+    try:
+        _HEARTBEAT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _HEARTBEAT_PATH.touch()
+    except OSError:
+        pass
+
 
 def _cleanup_tmp_dir(tmp_dir: Path | None) -> None:
     """Best-effort cleanup of an attachment temp directory.
@@ -236,14 +269,15 @@ class ClaudedBot(commands.Bot):
 
     @tasks.loop(seconds=30)
     async def _heartbeat_task(self) -> None:
-        """Write a heartbeat file every 30s for the external health checker."""
-        heartbeat_path = Path.home() / "Library" / "Caches" / "clauded" / "heartbeat"
-        heartbeat_path.parent.mkdir(parents=True, exist_ok=True)
-        heartbeat_path.touch()
+        """Write a heartbeat file every 30s for the external health checker.
 
-    @_heartbeat_task.before_loop
-    async def _before_heartbeat(self) -> None:
-        await self.wait_until_ready()
+        Proves the asyncio event loop is healthy (a wedged loop wouldn't tick).
+        ``main()`` separately calls :func:`_touch_heartbeat` once at process
+        start so the healthcheck has a fresh file even before Discord login
+        completes (otherwise a bad token → ``wait_until_ready`` hangs → stale
+        heartbeat → kickstart loop bounded only by ``ThrottleInterval``).
+        """
+        _touch_heartbeat()
 
     async def on_ready(self) -> None:  # type: ignore[override]
         user = self.user
@@ -863,23 +897,27 @@ def _configure_logging() -> None:
     """Set up app logging — RotatingFileHandler in production, stderr-only in tests.
 
     Detects pytest via ``PYTEST_CURRENT_TEST`` so test runs don't pollute
-    ``~/Library/Logs/clauded/``. In production, attaches a 10 MB × 7 rotating
-    file handler plus a stderr handler so launchd's ``StandardErrorPath`` still
-    captures boot diagnostics. Falls back to ``basicConfig`` on ``OSError`` (e.g.
-    Linux dev box with no ``~/Library/``).
+    ``~/Library/Logs/clauded/``. In production on macOS, attaches a 10 MB × 7
+    rotating file handler plus a stderr handler so launchd's
+    ``StandardErrorPath`` still captures boot diagnostics. On non-Darwin
+    (Linux/Windows dev boxes) and on ``OSError`` (e.g. read-only ``$HOME``)
+    falls back to ``basicConfig`` to stderr — same path as pytest — to avoid
+    silently creating macOS-shaped junk directories outside macOS.
     """
     fmt = "%(asctime)s %(levelname)s %(name)s: %(message)s"
     if os.environ.get("PYTEST_CURRENT_TEST"):
         logging.basicConfig(level=logging.INFO, format=fmt)
         return
-    log_dir = Path.home() / "Library" / "Logs" / "clauded"
+    if sys.platform != "darwin":
+        logging.basicConfig(level=logging.INFO, format=fmt)
+        return
     try:
-        log_dir.mkdir(parents=True, exist_ok=True)
+        _LOG_DIR.mkdir(parents=True, exist_ok=True)
     except OSError:
         logging.basicConfig(level=logging.INFO, format=fmt)
         return
     handler = RotatingFileHandler(
-        log_dir / "clauded.log",
+        _LOG_DIR / "clauded.log",
         maxBytes=10 * 1024 * 1024,
         backupCount=7,
         encoding="utf-8",
@@ -896,6 +934,13 @@ def _configure_logging() -> None:
 def main() -> None:
     """Console-script entry point: load config and run the bot."""
     _configure_logging()
+    # Claim "process alive" for the external healthcheck BEFORE bot.run() — a
+    # bad token / network outage makes discord.py block in login forever, which
+    # would otherwise leave the heartbeat file un-created and trigger an
+    # infinite quiet kickstart loop (helper agent → launchctl kickstart -k →
+    # rerun → relogin hang → repeat). The in-loop _heartbeat_task takes over
+    # once setup_hook fires and refreshes mtime every 30 s thereafter.
+    _touch_heartbeat()
 
     # Resolve and log the operator's Claude CLI so it's visible at boot time.
     from .cli_paths import resolve_claude_cli

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,61 @@
+"""Tests for _configure_logging + _heartbeat_task isolation."""
+from __future__ import annotations
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Tests verify that production logging routes to ~/Library/Logs/clauded/
+# while test runs (PYTEST_CURRENT_TEST env present) fall back to stderr-only.
+
+
+def _reset_root_logger() -> None:
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        root.removeHandler(h)
+
+
+def test_configure_logging_in_pytest_env_uses_basicconfig(tmp_path: Path) -> None:
+    """PYTEST_CURRENT_TEST set → stderr-only; no RotatingFileHandler attached."""
+    _reset_root_logger()
+    # PYTEST_CURRENT_TEST is naturally set by pytest itself when running this test.
+    assert os.environ.get("PYTEST_CURRENT_TEST"), "pytest should set this env var"
+    from clauded.bot import _configure_logging
+    _configure_logging()
+    root = logging.getLogger()
+    rotating = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
+    assert len(rotating) == 0, "PYTEST_CURRENT_TEST should disable file logging"
+
+
+def test_configure_logging_without_pytest_env_attaches_rotating_handler(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No PYTEST_CURRENT_TEST → RotatingFileHandler + stderr handler attached, log dir created."""
+    _reset_root_logger()
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from clauded.bot import _configure_logging
+    _configure_logging()
+    root = logging.getLogger()
+    rotating = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
+    assert len(rotating) == 1, "production mode should add RotatingFileHandler"
+    log_dir = tmp_path / "Library" / "Logs" / "clauded"
+    assert log_dir.exists(), "log dir should be created"
+    assert (log_dir / "clauded.log").parent == log_dir
+
+
+def test_configure_logging_fallback_on_oserror(
+    monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """mkdir raises OSError → fall back to basicConfig, no crash."""
+    _reset_root_logger()
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    def boom(*args, **kwargs):
+        raise OSError("no /tmp")
+    monkeypatch.setattr(Path, "mkdir", boom)
+    from clauded.bot import _configure_logging
+    _configure_logging()  # should not raise

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
+import time
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -37,9 +38,12 @@ def test_configure_logging_without_pytest_env_attaches_rotating_handler(
     """No PYTEST_CURRENT_TEST → RotatingFileHandler + stderr handler attached, log dir created."""
     _reset_root_logger()
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from clauded.bot import _configure_logging
-    _configure_logging()
+    monkeypatch.setattr(sys, "platform", "darwin")
+    # _LOG_DIR is captured at import time, so patch the module attribute
+    # directly rather than Path.home (which only affects new resolutions).
+    from clauded import bot as bot_mod
+    monkeypatch.setattr(bot_mod, "_LOG_DIR", tmp_path / "Library" / "Logs" / "clauded")
+    bot_mod._configure_logging()
     root = logging.getLogger()
     rotating = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
     assert len(rotating) == 1, "production mode should add RotatingFileHandler"
@@ -54,8 +58,54 @@ def test_configure_logging_fallback_on_oserror(
     """mkdir raises OSError → fall back to basicConfig, no crash."""
     _reset_root_logger()
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(sys, "platform", "darwin")
     def boom(*args, **kwargs):
         raise OSError("no /tmp")
     monkeypatch.setattr(Path, "mkdir", boom)
     from clauded.bot import _configure_logging
     _configure_logging()  # should not raise
+
+
+def test_configure_logging_skips_on_non_darwin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """sys.platform != darwin → basicConfig, no RotatingFileHandler, no ~/Library/ junk."""
+    _reset_root_logger()
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(sys, "platform", "linux")
+    from clauded.bot import _configure_logging
+    _configure_logging()
+    root = logging.getLogger()
+    rotating = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
+    assert len(rotating) == 0, "non-darwin should not attach RotatingFileHandler"
+
+
+def test_touch_heartbeat_writes_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_touch_heartbeat on darwin creates the file with a recent mtime."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    # _HEARTBEAT_PATH was captured at module import; patch directly.
+    fake_heartbeat = tmp_path / "Library" / "Caches" / "clauded" / "heartbeat"
+    from clauded import bot as bot_mod
+    monkeypatch.setattr(bot_mod, "_HEARTBEAT_PATH", fake_heartbeat)
+    before = time.time()
+    bot_mod._touch_heartbeat()
+    after = time.time()
+    assert fake_heartbeat.exists(), "heartbeat file should be created"
+    mtime = fake_heartbeat.stat().st_mtime
+    # Allow ±2s clock-tick slack so the test isn't flaky.
+    assert before - 2 <= mtime <= after + 2, "heartbeat mtime should be recent"
+
+
+def test_touch_heartbeat_skips_on_non_darwin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_touch_heartbeat on linux/windows is a no-op — no file, no mkdir."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    fake_heartbeat = tmp_path / "Library" / "Caches" / "clauded" / "heartbeat"
+    from clauded import bot as bot_mod
+    monkeypatch.setattr(bot_mod, "_HEARTBEAT_PATH", fake_heartbeat)
+    bot_mod._touch_heartbeat()
+    assert not fake_heartbeat.exists(), "non-darwin should not create heartbeat"
+    assert not fake_heartbeat.parent.exists(), "non-darwin should not mkdir"


### PR DESCRIPTION
Closes #139.

PRD: `docs/prd/v1.15-launchagent.md` (manager-locked).

Run claudeD as a self-managed macOS service.

## What lands

- 2 LaunchAgents (`com.hxy.clauded` main + `com.hxy.clauded.healthcheck` helper)
- `RotatingFileHandler` writes `~/Library/Logs/clauded/clauded.log` (10MB × 7 backups)
- 30s heartbeat task; 5min external health check; 120s stale → `launchctl kickstart -k`
- 3+ restarts in 5min → `osascript display notification` + `alerts.log` append
- `install-launchagent.sh` / `uninstall-launchagent.sh` scripts
- `README.md` "Run as macOS service" section
- `PYTEST_CURRENT_TEST` env detection → fallback to stderr (test isolation)

## Tests
+3 (434 pass / 2 pre-existing P1):
- `test_configure_logging_in_pytest_env_uses_basicconfig`
- `test_configure_logging_without_pytest_env_attaches_rotating_handler`
- `test_configure_logging_fallback_on_oserror`

## Smoke validation
Manager will run `./scripts/install-launchagent.sh` post-merge to confirm acceptance criteria (PRD §Acceptance Install/Lifecycle, Auto-restart, Health check, Logging, Alerting, Edge cases).

## Out of scope
Linux systemd, Docker, HTTP /health endpoint, Discord webhook alerts (rejected — self-defeating).