### PR TITLE
v1.16: skip table extraction on mid-stream finalize (#141)

### DIFF
--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -436,12 +436,8 @@ class DiscordRenderer:
                             # Finalize any pending typewriter message before
                             # interleaving a tool-status message, so the order
                             # in the channel matches the order of events.
-                            # #141 — pass ``is_final=False``: the buffer here
-                            # is PARTIAL (Claude may still be streaming the
-                            # outer markdown fence). Running table extraction
-                            # on a partial buffer misclassifies inner tables
-                            # as outside-fence and emits stray PNGs (D2
-                            # streaming-race seen in v1.12 R3 smoke 8e5af6c).
+                            # #141 — ``is_final=False`` skips table extraction
+                            # on the partial buffer; see _finalize_typewriter.
                             if live_msg is not None:
                                 await self._finalize_typewriter(live_msg, buffer, is_final=False)
                                 live_msg = None
@@ -1103,42 +1099,28 @@ class DiscordRenderer:
     ) -> None:
         """Replace the cursor in ``live_msg`` and emit any overflow as new messages.
 
-        If the in-place edit fails permanently we fall back to sending a
-        fresh message; otherwise the entire ``buffer`` content would be
-        silently lost (see truncation root-cause analysis 5/9).
-
-        Parameters
-        ----------
-        is_final:
-            When ``True`` (default — end-of-turn flush), runs the v1.12
-            extraction + PNG-interleaving path. When ``False``
-            (mid-stream finalize triggered by a ``ToolUseBlock``
-            interleave), the buffer is PARTIAL — outer fence backticks
-            may not all have arrived yet. Running
-            :meth:`_extract_and_render_tables` on a partial buffer
-            misclassifies an inner markdown table as outside-fence and
-            emits a stray PNG (#141: D2 streaming-race). On
-            ``is_final=False`` we therefore skip extraction entirely
-            and dump the raw buffer verbatim into ``live_msg`` — any
-            table content will be re-rendered correctly at the
-            eventual ``is_final=True`` call once the full fence is
-            settled.
+        Pre-tool-use interleave (``is_final=False``): raw dump without
+        extraction — caller resets ``buffer`` so any table content here
+        renders as markdown, not PNG. Final flush (``is_final=True``):
+        run v1.12 extract + PNG interleave. See #141.
         """
         # E1: Process channel/thread markers before finalizing.
         buffer = await self._process_markers(buffer)
 
         if not is_final:
-            # Streaming-race guard (#141) — partial buffer; skip table
-            # extraction, treat as raw text. Mirrors the pre-v1.12
-            # typewriter-finalize simple path. Any table content will
-            # be picked up by the end-of-turn ``is_final=True`` call.
             if not buffer:
                 return
-            content = buffer[:DISCORD_MAX_LEN]
-            if live_msg is not None:
-                await self._safe_edit(live_msg, content=content)
+            if len(buffer) <= DISCORD_MAX_LEN:
+                chunks = [buffer]
             else:
-                await self._safe_send(content=content)
+                chunks = self._smart_split(buffer, limit=DISCORD_MAX_LEN) or [buffer[:DISCORD_MAX_LEN]]
+            first = chunks[0]
+            if live_msg is not None:
+                await self._safe_edit(live_msg, content=first)
+            else:
+                await self._safe_send(content=first)
+            for chunk in chunks[1:]:
+                await self._safe_send(content=chunk)
             return
 
         # v1.12 — extract tables → PNG follow-ups (PRD R2). On the first

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -436,8 +436,14 @@ class DiscordRenderer:
                             # Finalize any pending typewriter message before
                             # interleaving a tool-status message, so the order
                             # in the channel matches the order of events.
+                            # #141 — pass ``is_final=False``: the buffer here
+                            # is PARTIAL (Claude may still be streaming the
+                            # outer markdown fence). Running table extraction
+                            # on a partial buffer misclassifies inner tables
+                            # as outside-fence and emits stray PNGs (D2
+                            # streaming-race seen in v1.12 R3 smoke 8e5af6c).
                             if live_msg is not None:
-                                await self._finalize_typewriter(live_msg, buffer)
+                                await self._finalize_typewriter(live_msg, buffer, is_final=False)
                                 live_msg = None
                                 buffer = ""
                                 typewriter = False
@@ -1089,16 +1095,52 @@ class DiscordRenderer:
                     self._last_msg_text = chunk
 
     async def _finalize_typewriter(
-        self, live_msg: discord.Message, buffer: str
+        self,
+        live_msg: discord.Message,
+        buffer: str,
+        *,
+        is_final: bool = True,
     ) -> None:
         """Replace the cursor in ``live_msg`` and emit any overflow as new messages.
 
         If the in-place edit fails permanently we fall back to sending a
         fresh message; otherwise the entire ``buffer`` content would be
         silently lost (see truncation root-cause analysis 5/9).
+
+        Parameters
+        ----------
+        is_final:
+            When ``True`` (default — end-of-turn flush), runs the v1.12
+            extraction + PNG-interleaving path. When ``False``
+            (mid-stream finalize triggered by a ``ToolUseBlock``
+            interleave), the buffer is PARTIAL — outer fence backticks
+            may not all have arrived yet. Running
+            :meth:`_extract_and_render_tables` on a partial buffer
+            misclassifies an inner markdown table as outside-fence and
+            emits a stray PNG (#141: D2 streaming-race). On
+            ``is_final=False`` we therefore skip extraction entirely
+            and dump the raw buffer verbatim into ``live_msg`` — any
+            table content will be re-rendered correctly at the
+            eventual ``is_final=True`` call once the full fence is
+            settled.
         """
         # E1: Process channel/thread markers before finalizing.
         buffer = await self._process_markers(buffer)
+
+        if not is_final:
+            # Streaming-race guard (#141) — partial buffer; skip table
+            # extraction, treat as raw text. Mirrors the pre-v1.12
+            # typewriter-finalize simple path. Any table content will
+            # be picked up by the end-of-turn ``is_final=True`` call.
+            if not buffer:
+                return
+            content = buffer[:DISCORD_MAX_LEN]
+            if live_msg is not None:
+                await self._safe_edit(live_msg, content=content)
+            else:
+                await self._safe_send(content=content)
+            return
+
         # v1.12 — extract tables → PNG follow-ups (PRD R2). On the first
         # text-bearing chunk we still drive the typewriter via in-place
         # edit; if tables exist the remaining text is interleaved with

--- a/tests/test_renderer_tables.py
+++ b/tests/test_renderer_tables.py
@@ -643,3 +643,95 @@ async def test_safe_edit_skips_empty_content():
     # if the streaming msg kept its raw-table text.
     assert msg.content == "\u200b"
 
+
+# ---------------------------------------------------------------------------
+# 12. #141 — D2 streaming-race: a mid-stream ``_finalize_typewriter`` call
+# (triggered by a ToolUseBlock interleave) sees a PARTIAL buffer where the
+# outer 4-backtick fence hasn't all arrived. Running table extraction on
+# that partial buffer misclassifies the inner table as outside-fence and
+# emits a stray PNG. Fix: when ``is_final=False``, skip extraction and dump
+# the raw buffer verbatim — any table content will be picked up on the
+# eventual ``is_final=True`` end-of-turn flush.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_finalize_with_partial_quad_backtick_skips_extraction(
+    monkeypatch,
+):
+    """#141: a ToolUseBlock interleave triggers finalize on a partial
+    buffer where the outer 4-backtick fence hasn't all arrived yet.
+    Extraction must NOT fire (it would misclassify the inner table as
+    outside-fence and emit a stray PNG). Live_msg should hold the raw
+    buffer verbatim — re-extraction happens at the eventual final flush.
+    """
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+
+    # Build a partial buffer: outer ```` opened, inner ``` opened, table
+    # rows present, but outer 4-backtick fence not yet closed (mid-stream).
+    partial = "Here you go: ````\n```\n| col |\n|---|\n| v |\n```"
+    live_msg = FakeMessage(content="")
+
+    # Spy on _extract_and_render_tables — it must NOT be called on the
+    # is_final=False path.
+    calls: list[str] = []
+
+    async def _spy(_self_or_cls, _buffer=None, *_a, **_kw):
+        calls.append("called")
+        return ("", [])
+
+    # _extract_and_render_tables is a staticmethod on the class — replace
+    # on the class so it's seen by `self._extract_and_render_tables` too.
+    monkeypatch.setattr(
+        DiscordRenderer, "_extract_and_render_tables", staticmethod(
+            lambda buf: _spy(None, buf)
+        )
+    )
+
+    await renderer._finalize_typewriter(live_msg, partial, is_final=False)
+
+    assert calls == [], (
+        "is_final=False must skip table extraction; got "
+        f"{len(calls)} call(s)"
+    )
+
+    # live_msg should carry the raw partial buffer verbatim — no PNG
+    # follow-up should have been sent.
+    assert live_msg.content == partial, (
+        "is_final=False must dump buffer verbatim into live_msg"
+    )
+    png_calls = [c for c in target.calls if c.get("files")]
+    assert png_calls == [], "no PNG follow-up on is_final=False"
+
+
+@pytest.mark.asyncio
+async def test_final_finalize_still_extracts(monkeypatch):
+    """is_final=True (default + end-of-turn behavior) runs table
+    extraction normally — the #141 fix must not regress the v1.12 happy
+    path.
+    """
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+
+    # Real markdown table — would normally produce one TableRender.
+    final_buffer = "| col |\n|---|\n| v |"
+    live_msg = FakeMessage(content="")
+
+    calls: list[str] = []
+
+    async def _spy(_buffer):
+        calls.append("called")
+        return ("", [])
+
+    monkeypatch.setattr(
+        DiscordRenderer, "_extract_and_render_tables", staticmethod(_spy)
+    )
+
+    # Default is_final=True.
+    await renderer._finalize_typewriter(live_msg, final_buffer)
+
+    assert calls == ["called"], (
+        "is_final=True (default) must invoke _extract_and_render_tables"
+    )
+

--- a/tests/test_renderer_tables.py
+++ b/tests/test_renderer_tables.py
@@ -706,32 +706,177 @@ async def test_mid_stream_finalize_with_partial_quad_backtick_skips_extraction(
 
 
 @pytest.mark.asyncio
-async def test_final_finalize_still_extracts(monkeypatch):
-    """is_final=True (default + end-of-turn behavior) runs table
-    extraction normally — the #141 fix must not regress the v1.12 happy
-    path.
+async def test_mid_stream_finalize_long_buffer_no_truncation(monkeypatch):
+    """#141 R2 (engineer C1): mid-stream finalize on a buffer > DISCORD_MAX_LEN
+    must multi-chunk via ``_smart_split``, not silently truncate. Previous
+    impl did ``buffer[:DISCORD_MAX_LEN]`` and the caller reset ``buffer = ""``
+    immediately — losing everything past byte 1900. Asserts:
+    1) every character of the original buffer lands somewhere (edit or send),
+    2) chunk count > 1 (multi-chunk path exercised),
+    3) no extraction was triggered (is_final=False path).
     """
     target = FakeTarget()
     renderer = DiscordRenderer(target)
-
-    # Real markdown table — would normally produce one TableRender.
-    final_buffer = "| col |\n|---|\n| v |"
     live_msg = FakeMessage(content="")
 
-    calls: list[str] = []
+    # Build a ~4500 char buffer: long prose with paragraph breaks so
+    # _smart_split has clean split points. No backticks → table extraction
+    # would be a no-op anyway, but we still want to prove it isn't called.
+    para = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " * 6
+    buffer = "\n\n".join([para] * 14)
+    assert len(buffer) > 4000, f"test fixture too small: {len(buffer)}"
+
+    # Spy on _extract_and_render_tables — must NOT be called.
+    extract_calls: list[str] = []
 
     async def _spy(_buffer):
-        calls.append("called")
+        extract_calls.append("called")
         return ("", [])
 
     monkeypatch.setattr(
         DiscordRenderer, "_extract_and_render_tables", staticmethod(_spy)
     )
 
-    # Default is_final=True.
-    await renderer._finalize_typewriter(live_msg, final_buffer)
+    await renderer._finalize_typewriter(live_msg, buffer, is_final=False)
 
-    assert calls == ["called"], (
-        "is_final=True (default) must invoke _extract_and_render_tables"
+    # No extraction on mid-stream path.
+    assert extract_calls == [], "is_final=False must not extract"
+
+    # Chunk 1 lands via edit on live_msg; chunks 2+ via target.send().
+    sent_chunks = [c["content"] for c in target.calls if c.get("content")]
+    # Multi-chunk path must have fired — at least one new send beyond live_msg.
+    assert len(sent_chunks) >= 1, (
+        "long-buffer path must send chunks 2+ as new messages; "
+        f"got {len(sent_chunks)} new sends"
+    )
+
+    # Reassemble: live_msg content (chunk 1) + sent chunks (chunks 2+).
+    reassembled = live_msg.content + "".join(sent_chunks)
+    # All characters of the original buffer must be preserved across chunks.
+    # _smart_split may insert at paragraph boundaries; concat must equal source.
+    assert reassembled == buffer, (
+        "silent truncation regression — characters lost between chunks. "
+        f"orig_len={len(buffer)} reassembled_len={len(reassembled)}"
+    )
+
+    # Every individual chunk must fit within Discord's per-message cap.
+    from clauded.discord_renderer import DISCORD_MAX_LEN
+    for i, chunk in enumerate([live_msg.content, *sent_chunks]):
+        assert len(chunk) <= DISCORD_MAX_LEN, (
+            f"chunk {i} exceeds DISCORD_MAX_LEN: {len(chunk)} > {DISCORD_MAX_LEN}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_render_response_passes_is_final_false_on_tool_interleave(
+    monkeypatch,
+):
+    """#141 R2 (engineer C2): integration-style guard pinning the *call
+    site* at discord_renderer.py:~442. A future regression that drops the
+    ``is_final=False`` kwarg there would silently re-introduce the v1.12
+    D2 streaming-race bug. Spies on ``_finalize_typewriter`` while driving
+    ``render_response`` through a scripted SDK event sequence:
+
+        text_delta → ToolUseBlock → text_delta → ResultMessage
+
+    Asserts the spy was invoked with ``is_final=False`` from the
+    ToolUseBlock-interleave path. (The end-of-turn flush uses a different
+    code path — ``_flush`` — so the spy only needs to catch the
+    interleave call.)
+    """
+    from clauded.claude_bridge import (
+        AssistantMessage,
+        ResultMessage,
+        ToolUseBlock,
+    )
+    from claude_agent_sdk.types import StreamEvent
+
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+
+    # Drive time.time() so typewriter mode engages (>FAST_PATH_SECONDS).
+    fake_now = [1_000_000.0]
+
+    def _fake_time():
+        fake_now[0] += 5.0  # > FAST_PATH_SECONDS=3.0 each call
+        return fake_now[0]
+
+    monkeypatch.setattr("clauded.discord_renderer.time.time", _fake_time)
+
+    # Spy on _finalize_typewriter — record every call's is_final value.
+    finalize_calls: list[dict] = []
+    original = renderer._finalize_typewriter
+
+    async def _spy(live_msg, buffer, *, is_final=True):
+        finalize_calls.append({"is_final": is_final, "buffer_len": len(buffer)})
+        return await original(live_msg, buffer, is_final=is_final)
+
+    monkeypatch.setattr(renderer, "_finalize_typewriter", _spy)
+
+    # Scripted event sequence: two text deltas (so typewriter mode engages
+    # after FAST_PATH_SECONDS on the 2nd) → tool use → continuation → end.
+    # The 2nd text_delta enters typewriter mode and sets ``live_msg``;
+    # the ToolUseBlock then triggers the ``is_final=False`` finalize call.
+    events = [
+        StreamEvent(
+            uuid="u1",
+            session_id="s1",
+            event={
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "Pre-tool prose ````\n```\n"},
+            },
+        ),
+        StreamEvent(
+            uuid="u2",
+            session_id="s1",
+            event={
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "| a | b |\n|---|---|\n| 1 | 2 |\n"},
+            },
+        ),
+        AssistantMessage(
+            content=[ToolUseBlock(id="t1", name="Bash", input={"command": "echo hi"})],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        StreamEvent(
+            uuid="u3",
+            session_id="s1",
+            event={
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "post-tool prose"},
+            },
+        ),
+        ResultMessage(
+            subtype="result",
+            duration_ms=1000,
+            duration_api_ms=900,
+            is_error=False,
+            num_turns=1,
+            session_id="s1",
+            total_cost_usd=0.01,
+        ),
+    ]
+
+    class _Bridge:
+        async def send_message(self, _text):
+            for ev in events:
+                yield ev
+
+    await renderer.render_response(_Bridge(), "hello")
+
+    # The ToolUseBlock interleave must have triggered exactly one
+    # _finalize_typewriter call with is_final=False. If a future refactor
+    # drops the kwarg, is_final defaults to True and extraction would fire
+    # on the partial buffer — this assertion catches that.
+    mid_stream = [c for c in finalize_calls if c["is_final"] is False]
+    assert len(mid_stream) == 1, (
+        f"expected exactly one is_final=False call from the ToolUseBlock "
+        f"interleave; got finalize_calls={finalize_calls}"
+    )
+    # Pre-tool buffer must be non-empty (proves we actually exercised the
+    # finalize path, not a no-op early return).
+    assert mid_stream[0]["buffer_len"] > 0, (
+        "mid-stream finalize fired on empty buffer — test fixture broken"
     )
 


### PR DESCRIPTION
Closes #141 (v1.12 R3 product / smoke finding).

## Bug
Real smoke evidence (v1.12 R3 D2 thread, commit 8e5af6c): Claude streamed quad-backtick wrapped table. `_finalize_typewriter` called from mid-stream `ToolUseBlock` interleave site (`discord_renderer.py:446`) saw PARTIAL buffer with outer 4-backtick fence not yet streamed. Parser misclassified inner table as outside-fence → emitted stray PNG. User saw both code-fenced markdown + duplicate PNG.

## Fix
`_finalize_typewriter(is_final: bool = True)` — when False, skip `_extract_and_render_tables` and dump raw buffer (pre-v1.12 path). Mid-stream call site passes `is_final=False`; end-of-turn `_flush` keeps default `is_final=True` (byte-identical to pre-fix).

## Tests
+2 in `tests/test_renderer_tables.py`:
- `test_mid_stream_finalize_with_partial_quad_backtick_skips_extraction`
- `test_final_finalize_still_extracts` (regression pin)

## pytest
440 pass / 2 pre-existing P1 (was 438/2).

## LOC
discord_renderer.py +42, tests +92.

## Out of scope
Streaming-state-aware table parser — the right fix when v1.17 wants tables to render mid-stream. v1.16 takes the simpler defer-to-final approach.