### PR TITLE
v1.16: table-rendering cleanups (#142 + #143)

### DIFF
--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -65,11 +65,65 @@ log = logging.getLogger("clauded.discord_renderer")
 # crashing the renderer. ``PILLOW_AVAILABLE`` is consulted at the top of
 # :meth:`DiscordRenderer._extract_and_render_tables` for a fast-fail.
 try:
-    from .table_png import render_table_png, MAX_COLS, MAX_ROWS, MAX_TABLE_PIXELS
+    from .table_png import render_table_png
     PILLOW_AVAILABLE = True
 except ImportError:
     PILLOW_AVAILABLE = False
     log.warning("Pillow not installed; tables fall back to code-fence rendering")
+
+
+# ---------------------------------------------------------------------------
+# CommonMark §4.5 fenced code-block state machine (v1.16 #142 §A2).
+# ---------------------------------------------------------------------------
+
+
+def _advance_fence_state(line: str, fence_count: int) -> int:
+    """Return the new fence depth after consuming ``line``.
+
+    Implements the CommonMark §4.5 fence rule: a fence opens with a run of
+    N≥3 backticks at the start of an otherwise unindented line; it only
+    closes on a line whose leading backtick run is ≥N. Inner runs shorter
+    than the opener do NOT close the fence (this is the v1.12 bug-D
+    regression case — an inner ```` ``` ```` inside a ```` ```` ```` outer
+    fence must be preserved verbatim).
+
+    Args:
+        line: the input line (not yet stripped — leading whitespace ignored).
+        fence_count: ``0`` if we are not currently inside a fence, otherwise
+            the opener's backtick run length (so a ≥N closer is recognised).
+
+    Returns:
+        The new fence_count. ``0`` means we are not in a fence after this
+        line; any positive value means we are. The caller decides how to
+        emit ``line`` (typically: if either the new or old count is >0,
+        the line is "fence-owned" — emit verbatim and skip parsing).
+
+    The helper is intentionally pure / module-level so both the legacy
+    :meth:`DiscordRenderer._format_tables` path (no-Pillow fallback) and
+    the production :meth:`DiscordRenderer._extract_and_render_tables`
+    path share one state machine. Before the v1.16 extraction these
+    paths used *different* trackers (legacy used a bool toggle that was
+    wrong for quad-backtick fences); routing both through this helper
+    closes that latent gap now that the fallback is reachable via the
+    Pillow-missing branch (#135 / PRD R6).
+    """
+    stripped = line.lstrip()
+    if not stripped.startswith("`"):
+        return fence_count
+    j = 0
+    while j < len(stripped) and stripped[j] == "`":
+        j += 1
+    ticks = j
+    if ticks < 3:
+        return fence_count
+    if fence_count == 0:
+        # Opens a fence whose closer must be ≥``ticks`` backticks.
+        return ticks
+    # Already inside a fence — only a ≥fence_count run closes it.
+    if ticks >= fence_count:
+        return 0
+    # Inner shorter run — fence remains open (CommonMark §4.5).
+    return fence_count
 
 
 # ---------------------------------------------------------------------------
@@ -1150,22 +1204,33 @@ class DiscordRenderer:
         # placeholders. The first text segment (before the first table)
         # replaces the cursor in ``live_msg``; subsequent segments and PNG
         # follow-ups are sent fresh. If the first segment is empty (table
-        # at the very start of the buffer), edit the cursor away with the
-        # empty string so the cursor is gone before the PNG arrives.
+        # at the very start of the buffer), clear the cursor to a U+200B
+        # placeholder via ``_clear_cursor_msg`` so the cursor is visibly
+        # gone before the PNG arrives (Discord rejects ``content=""`` with
+        # HTTP 50006; #142 §A3).
         first_seg, _, rest_text = stripped_text.partition(table_renders[0].placeholder)
         if first_seg.strip():
             first_chunks = self._smart_split(first_seg, limit=DISCORD_MAX_LEN) or [first_seg[:DISCORD_MAX_LEN]]
+            first = await self._typewriter_apply(live_msg, first_chunks[0])
+            if first is not None:
+                self._last_msg = first
+                self._last_msg_text = first_chunks[0]
+            for chunk in first_chunks[1:]:
+                sent = await self._safe_send(content=chunk)
+                if sent is not None:
+                    self._last_msg = sent
+                    self._last_msg_text = chunk
         else:
-            first_chunks = [""]
-        first = await self._typewriter_apply(live_msg, first_chunks[0])
-        if first is not None:
-            self._last_msg = first
-            self._last_msg_text = first_chunks[0]
-        for chunk in first_chunks[1:]:
-            sent = await self._safe_send(content=chunk)
-            if sent is not None:
-                self._last_msg = sent
-                self._last_msg_text = chunk
+            # Empty first segment — keep the existing cursor msg identity
+            # but replace its content with ZWS. If the edit fails the
+            # cursor stays with its previous (raw-markdown) content; we
+            # accept that degraded outcome rather than send a fresh empty
+            # message (which would itself fail with 50006).
+            if live_msg is not None:
+                ok = await self._clear_cursor_msg(live_msg)
+                if ok:
+                    self._last_msg = live_msg
+                    self._last_msg_text = "\u200b"
 
         # First PNG, then the rest of the interleave (text-then-PNG pairs +
         # final tail). ``_send_text_and_tables`` handles the residual.
@@ -1558,24 +1623,18 @@ class DiscordRenderer:
         on a stale message fails permanently — otherwise the live cursor
         message is forever stuck at its previous content while the buffer
         keeps growing in memory.
+
+        v1.16 (#142 §A3) — pure transport. The empty-content → U+200B
+        substitution previously inlined here was a single-caller concern
+        (cursor-clear from ``_finalize_typewriter``); callers that need
+        to "clear" a message with Discord-acceptable content must call
+        :meth:`_clear_cursor_msg` instead. Passing ``content=""`` or
+        whitespace-only content to this method will now hit Discord
+        50006 ("Cannot send an empty message") as the underlying API
+        always intended.
         """
         kwargs: dict = {}
         if content is not None:
-            # v1.12 bug D-2 — Discord rejects both ``content=""`` AND
-            # ``content=" "`` (single space) with HTTP 400 code 50006
-            # "Cannot send an empty message" — whitespace-only content
-            # is treated as empty by Discord's validator. This bites
-            # the streaming-cursor cleanup path in
-            # ``_finalize_typewriter`` where the buffer is entirely a
-            # table placeholder and the pre-table segment is empty.
-            # Substitute U+200B (zero-width space): Discord accepts it
-            # as non-empty content and it renders invisibly so the
-            # user sees the live_msg as "cleared" rather than
-            # retaining the leaked raw markdown table text alongside
-            # the PNG follow-up (Bug C symptom in the v1.12 smoke run).
-            if not content.strip():
-                log.debug("_safe_edit: empty content; substituting U+200B to clear cursor msg without Discord 50006")
-                content = "\u200b"
             kwargs["content"] = content
         if embed is not None:
             kwargs["embed"] = embed
@@ -1608,6 +1667,27 @@ class DiscordRenderer:
             self._last_msg_text = content
         return result is not None
 
+    async def _clear_cursor_msg(self, msg: discord.Message) -> bool:
+        """Edit ``msg`` to U+200B so it renders as invisible whitespace.
+
+        Used when the cursor message is now logically empty — typically
+        the v1.12 streaming-cursor cleanup path in ``_finalize_typewriter``
+        where the entire buffer was a table placeholder and the
+        pre-table segment is empty. Discord rejects ``content=""`` and
+        any all-whitespace string with HTTP 400 code 50006
+        ("Cannot send an empty message"); U+200B (zero-width space) is
+        accepted as non-empty content and renders invisibly so the
+        user sees the cursor as cleared rather than retaining the raw
+        markdown text alongside the PNG follow-up (Bug C symptom in
+        the v1.12 smoke run).
+
+        v1.16 (#142 §A3) — extracted from ``_safe_edit`` so that
+        method stays pure transport. ``_safe_edit`` no longer performs
+        the empty → ZWS substitution; callers that need cursor-clear
+        semantics must call this helper explicitly.
+        """
+        return await self._safe_edit(msg, content="\u200b")
+
     # ------------------------------------------------------------------
     # Markdown table → code block conversion (legacy) / PNG extraction
     # ------------------------------------------------------------------
@@ -1629,25 +1709,30 @@ class DiscordRenderer:
         lines_in = text.split("\n")
         result: list[str] = []
         in_table = False
-        in_code_fence = False
+        # v1.16 (#142 §A2) — share the CommonMark §4.5 fence tracker with
+        # the production extractor. The pre-refactor bool toggle here was
+        # latent-wrong for quad-backtick outer fences (an inner triple
+        # toggled it off prematurely) — never reached in practice because
+        # this method was the legacy-only path, but the Pillow-missing
+        # fallback (#135 / PRD R6) now routes real traffic through it.
+        fence_count = 0
         table_lines: list[str] = []
 
         for line in lines_in:
             stripped = line.strip()
 
-            # Track existing code fences
-            if stripped.startswith("```"):
-                in_code_fence = not in_code_fence
-                if in_table and table_lines:
+            prev_fence = fence_count
+            fence_count = _advance_fence_state(line, fence_count)
+            if fence_count > 0 or prev_fence > 0:
+                # Either we just opened a fence, are inside one, or just
+                # closed one — emit verbatim and never table-parse the line.
+                # On a fence-open line we also flush any pending table.
+                if prev_fence == 0 and fence_count > 0 and in_table and table_lines:
                     result.append("```")
                     result.extend(table_lines)
                     result.append("```")
                     in_table = False
                     table_lines = []
-                result.append(line)
-                continue
-
-            if in_code_fence:
                 result.append(line)
                 continue
 
@@ -1746,19 +1831,14 @@ class DiscordRenderer:
         # the inner ``\u0060\u0060\u0060`` line was treated as a fence
         # toggle and the markdown table inside leaked back out to PNG
         # extraction, violating PRD R5 (code fences preserved verbatim).
+        # v1.16 (#142 §A2) — the state-machine is now the module-level
+        # ``_advance_fence_state`` helper, shared with ``_format_tables``.
         fence_count = 0  # 0 ⇒ not in a fence; otherwise the opener's backtick run
         i = 0
         n = len(lines_in)
 
         def _is_table_line(s: str) -> bool:
             return s.startswith("|") and s.endswith("|")
-
-        def _leading_backtick_run(s: str) -> int:
-            """Return the count of leading backticks on ``s`` (already stripped)."""
-            j = 0
-            while j < len(s) and s[j] == "`":
-                j += 1
-            return j
 
         def _is_separator_line(s: str) -> bool:
             # e.g. ``|---|---|`` or ``| :--- | ---: |`` — only ``|``, ``-``,
@@ -1781,23 +1861,15 @@ class DiscordRenderer:
             line = lines_in[i]
             stripped = line.strip()
 
-            # Track code fences first — anything inside is opaque.
-            # CommonMark §4.5: a fence opens with N≥3 consecutive backticks
-            # at line start; it only closes on a line whose backtick run
-            # length is ≥N (so a ``\u0060\u0060\u0060\u0060`` outer fence
-            # is NOT closed by an inner ``\u0060\u0060\u0060``). v1.12
-            # bug D — see comment block above.
-            ticks = _leading_backtick_run(stripped)
-            if fence_count == 0:
-                if ticks >= 3:
-                    fence_count = ticks
-                    result.append(line)
-                    i += 1
-                    continue
-            else:
-                # Currently inside a fence — only a ≥fence_count run closes it.
-                if ticks >= fence_count:
-                    fence_count = 0
+            # Track code fences first — anything inside (or on the fence
+            # boundary line itself) is opaque to table extraction. The
+            # state machine lives in ``_advance_fence_state``; here we
+            # only decide whether the current line is fence-owned.
+            prev_fence = fence_count
+            fence_count = _advance_fence_state(line, fence_count)
+            if fence_count > 0 or prev_fence > 0:
+                # Either we are inside a fence, just opened one, or just
+                # closed one (the closer line itself belongs to the fence).
                 result.append(line)
                 i += 1
                 continue

--- a/tests/test_renderer_tables.py
+++ b/tests/test_renderer_tables.py
@@ -595,20 +595,22 @@ async def test_finalize_typewriter_clears_streaming_msg_of_leaked_table():
 
 
 # ---------------------------------------------------------------------------
-# 11. Bug D-2 (v1.12 smoke): _safe_edit must not pass content="" — or
-# content=" " — to Discord; both return HTTP 400 code 50006 ("Cannot
-# send an empty message"). Substitute U+200B (zero-width space) so the
-# edit succeeds and the streaming cursor msg actually gets cleared.
+# 11. Bug D-2 (v1.12 smoke) / v1.16 #142 §A3 — clearing a cursor msg must
+# substitute U+200B (zero-width space). Discord rejects both ``""`` and
+# ``" "`` with HTTP 400 code 50006 ("Cannot send an empty message"); the
+# ZWS is the canonical invisible-but-non-empty substitute. v1.16 moved
+# the substitution out of ``_safe_edit`` (pure transport) and into
+# ``_clear_cursor_msg``; this test now pins the new helper.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_safe_edit_skips_empty_content():
-    """Calling ``_safe_edit(msg, content="")`` must substitute U+200B
-    (zero-width space) before edit — Discord rejects both ``""`` and
-    ``" "`` (single space) with HTTP 400 code 50006. U+200B is the
-    canonical non-empty-but-invisible substitute so the streaming msg
-    gets cleared rather than stuck at its prior content.
+async def test_clear_cursor_msg_substitutes_zws():
+    """Calling ``_clear_cursor_msg(msg)`` must edit ``msg`` to U+200B —
+    Discord rejects both ``""`` and ``" "`` (single space) with HTTP
+    400 code 50006. U+200B is the canonical non-empty-but-invisible
+    substitute so the streaming msg gets cleared rather than stuck at
+    its prior content (#142 §A3).
     """
     target = FakeTarget()
     renderer = DiscordRenderer(target)
@@ -625,7 +627,7 @@ async def test_safe_edit_skips_empty_content():
 
     msg = RecordingMessage("prior content")
 
-    ok = await renderer._safe_edit(msg, content="")
+    ok = await renderer._clear_cursor_msg(msg)
     assert ok is True
 
     # Exactly one edit happened, and the content sent to Discord was

--- a/tests/test_table_extraction.py
+++ b/tests/test_table_extraction.py
@@ -10,6 +10,10 @@ rejection (R1.4), empty-body cell preservation (R6.4), and current
 
 ``_extract_and_render_tables`` is async (dispatches PNG render through
 ``asyncio.to_thread`` — review I3), so tests run under ``pytest.mark.asyncio``.
+
+v1.16 (#143 R3 high-priority): parametric cursor-clear ZWS test +
+extractor edge-case coverage (5-backtick fence, info-string fence,
+unclosed-fence-at-EOF, single-column relaxed-shape no-separator-leak).
 """
 from __future__ import annotations
 
@@ -341,3 +345,187 @@ async def test_triple_backtick_fence_still_works():
     out, renders = await DiscordRenderer._extract_and_render_tables(text)
     assert renders == [], "triple-fence inner table must NOT be extracted"
     assert out == text, "returned text must equal input verbatim"
+
+
+# ---------------------------------------------------------------------------
+# v1.16 #143 coverage gaps — high-priority subset from v1.12 R3 tester
+# review. Each test pins a behaviour that was previously only exercised
+# implicitly via integration tests or not at all.
+# ---------------------------------------------------------------------------
+
+
+# Minimal Discord-message fake for the ``_clear_cursor_msg`` ZWS test.
+# Keeps the deps in this file self-contained (no FakeTarget import from
+# ``test_renderer_tables`` — those fakes are integration-scoped).
+class _ZWSFakeMessage:
+    """Records every ``edit`` call so the test can assert the substitute."""
+
+    def __init__(self, content: str = "prior") -> None:
+        self.content = content
+        self.edit_calls: list[dict] = []
+        self.guild = None  # _safe_edit pulls guild.me; None is fine.
+
+    async def edit(self, *, content=None, **kw):
+        self.edit_calls.append({"content": content, **kw})
+        if content is not None:
+            self.content = content
+        return self
+
+
+class _ZWSFakeTarget:
+    def __init__(self) -> None:
+        self.guild = None
+        self.parent = None
+        self.id = 1
+        self.name = "fake"
+
+    async def send(self, **_kw):  # pragma: no cover — not exercised
+        raise AssertionError("send must not be called in clear-cursor tests")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "input_content",
+    ["", " ", "\t", "\n", "  \n  "],
+    ids=["empty", "single_space", "tab", "newline", "mixed_ws"],
+)
+async def test_clear_cursor_msg_parametric_whitespace_to_zws(input_content):
+    """v1.16 #143 — pin that ``_clear_cursor_msg`` always edits to U+200B
+    regardless of the cursor's prior content. The substitution is the
+    sole purpose of the helper; whether the prior content was empty,
+    a space, a tab, a newline, or mixed-whitespace, the user-visible
+    state must end up "cleared" (ZWS) so Discord's 50006 guard never
+    fires (#142 §A3 invariant).
+
+    Note: the input parameter is the *prior* cursor content, NOT an
+    argument to ``_clear_cursor_msg`` (the helper takes no content
+    argument by design — it always writes ZWS). Callers that pass
+    ``""`` to ``_safe_edit`` directly will now hit 50006 in real
+    Discord; this test pins the helper path that explicitly avoids
+    that.
+    """
+    renderer = DiscordRenderer(_ZWSFakeTarget())
+    msg = _ZWSFakeMessage(content=input_content)
+
+    ok = await renderer._clear_cursor_msg(msg)
+
+    assert ok is True
+    # Exactly one edit happened, and the content sent to Discord was
+    # the U+200B zero-width space.
+    content_edits = [e for e in msg.edit_calls if e.get("content") is not None]
+    assert len(content_edits) == 1, (
+        f"expected one content-bearing edit; got {len(content_edits)}"
+    )
+    assert content_edits[0]["content"] == "\u200b", (
+        "must substitute U+200B; got "
+        f"{content_edits[0]['content']!r}"
+    )
+    assert msg.content == "\u200b"
+
+
+@pytest.mark.asyncio
+async def test_single_column_relaxed_no_synthesized_separator_leak():
+    """v1.16 #143 — single-column input with NO separator row must not
+    leak a synthesized ``|---|`` line into the output text.
+
+    Existing strict-path test (``test_single_column_table_not_extracted``)
+    covers the case WITH a separator. The relaxed path (no separator)
+    is a different branch: the parser either rejects the candidate as
+    single-column (current behaviour: PRD R1.4) or accepts it; either
+    way the synthesized ``|---|`` separator constructed inside
+    ``_extract_and_render_tables`` for ``markdown_source`` purposes
+    MUST NOT appear in the returned text body. Pre-fix this would have
+    been a presentation-into-parser leak (#142 §1 — the very thing the
+    v1.17 carry-forward refactor is meant to address).
+    """
+    text = "| Only |\n| Value |"
+    out, renders = await DiscordRenderer._extract_and_render_tables(text)
+    # Either behaviour is acceptable: no render (single-column rejected),
+    # or a render whose markdown_source separator stays out of ``out``.
+    assert renders == [], "single-column input must not extract a table (R1.4)"
+    # Both original lines must survive verbatim — they are the user's input.
+    assert "| Only |" in out
+    assert "| Value |" in out
+    # The synthesized separator must NOT have leaked into the output text.
+    assert "|---|" not in out, (
+        "synthesized relaxed-path separator must stay inside markdown_source "
+        "(architect #142 §1); leak into returned text means we bled "
+        "presentation into the parser"
+    )
+
+
+@pytest.mark.asyncio
+async def test_five_backtick_outer_fence_preserves_inner_table():
+    """v1.16 #143 — CommonMark §4.5 generalisation: a 5-backtick outer
+    fence is closed only by a ≥5-backtick run. The inner ``|---|`` table
+    must NOT be extracted and the returned text must equal the input
+    verbatim. This regression-proofs the fence helper against N>4.
+    """
+    text = (
+        "Before.\n"
+        "`````\n"
+        "| h |\n"
+        "|---|\n"
+        "| v |\n"
+        "`````\n"
+        "After."
+    )
+    out, renders = await DiscordRenderer._extract_and_render_tables(text)
+    assert renders == [], (
+        "5-backtick outer fence must preserve inner table verbatim "
+        "(no PNG extraction)"
+    )
+    assert out == text, "returned text must equal input verbatim"
+
+
+@pytest.mark.asyncio
+async def test_info_string_fence_does_not_break_subsequent_table():
+    """v1.16 #143 — a fenced code block with an info string (``` ```python
+    ``` `` `) must close on the matching ``` ``` `` `` run, leaving any
+    markdown table that follows OUTSIDE the fence available for PNG
+    extraction. Pre-fix, a sloppy fence tracker could have left fence
+    state stuck after the code block, swallowing the second table.
+    """
+    text = (
+        "First a code block:\n"
+        "```python\n"
+        "some_code = 1\n"
+        "```\n"
+        "Then a table:\n"
+        "| h | k |\n"
+        "|---|---|\n"
+        "| v | w |\n"
+        "End."
+    )
+    out, renders = await DiscordRenderer._extract_and_render_tables(text)
+    assert len(renders) == 1, (
+        "the table AFTER the info-string fence must still be extracted"
+    )
+    r = renders[0]
+    assert r.headers == ["h", "k"]
+    assert r.rows == [["v", "w"]]
+    # The code-fence content stays verbatim in the returned text.
+    assert "```python" in out
+    assert "some_code = 1" in out
+    assert "```" in out
+
+
+@pytest.mark.asyncio
+async def test_unclosed_fence_at_eof_does_not_extract_inner_table():
+    """v1.16 #143 — a fence that opens but never closes at EOF must
+    still suppress extraction of any markdown table inside it. Discord
+    will render the unclosed fence as a code block to EOF; the renderer
+    must not eagerly close it and emit a stray PNG. No crash, no
+    extraction.
+    """
+    text = "```\n| h |\n|---|\n| v |"
+    # MUST NOT raise.
+    out, renders = await DiscordRenderer._extract_and_render_tables(text)
+    assert renders == [], (
+        "unclosed fence at EOF must still suppress table extraction"
+    )
+    # All four lines survive verbatim (we don't auto-close fences).
+    assert "```" in out
+    assert "| h |" in out
+    assert "|---|" in out
+    assert "| v |" in out


### PR DESCRIPTION
Closes #142 + #143 (v1.12 R3 deferrals).

## Part A — architect cleanups (#142)
- **A1**: Drop dead `MAX_COLS/MAX_ROWS/MAX_TABLE_PIXELS` import in `discord_renderer.py`
- **A2**: Extract `_advance_fence_state(line, fence_count) -> int` module helper; rewire BOTH `_format_tables` (bool toggle → fence_count int, fixes quad-backtick handling in no-Pillow fallback) AND `_extract_and_render_tables` through it
- **A3**: Decouple ZWS from `_safe_edit` → `_clear_cursor_msg(msg)` helper. `_safe_edit` is now pure transport. Migrated `_finalize_typewriter` empty-first-segment path.
- markdown_source synthesis refactor (#142 §1) deferred to v1.17 — too risky, no real bug today

## Part B — coverage gaps (#143 top priority)
+9 tests (5 standalone + 5-case parametric):
- parametric whitespace-ZWS for `_clear_cursor_msg` ("", " ", "\t", "\n", "  \n  ")
- single-column relaxed-shape no-separator-leak
- 5-backtick fence opener
- fence with info string  
- unclosed fence at EOF

## Tests
450 pass / 2 pre-existing P1 (was 441/2). 1 existing test renamed (`test_safe_edit_skips_empty_content` → `test_clear_cursor_msg_substitutes_zws`) to follow the moved contract.

## Out of scope (v1.17)
- markdown_source synthesis move from parser to `_send_table_renders` emission layer
- 8 remaining tester R3 coverage gaps from #143 (covered: top-5; remaining: ragged-row, indented table, cursor-edit-BEFORE-PNG-send ordering, thread-race duplicate-render with active session [already shipped in #140])