### PR TITLE
v1.18: mention-required discoverability + unbind surfacing (#153 R1 product)

### DIFF
--- a/src/clauded/cogs/project.py
+++ b/src/clauded/cogs/project.py
@@ -76,7 +76,9 @@ async def project_info(interaction: discord.Interaction) -> None:
     if mode != "thread":
         lines.append(f"🔀 Channel mode: `{mode}`")
     mention_required = bot.project_manager.get_mention_required(channel_id)
-    if not mention_required:
+    if mention_required:
+        lines.append("💬 Mention: required (default — use `/project set-mention-required false` to opt out)")
+    else:
         lines.append("💬 Mention: not required (responds to all messages)")
     guild_root = bot.project_manager.get_guild_root(interaction.guild_id)
     if interaction.guild_id and str(interaction.guild_id) in bot.project_manager._guild_roots:
@@ -95,8 +97,18 @@ async def project_unbind(interaction: discord.Interaction) -> None:
         return
 
     if bot.project_manager.unbind(channel_id):
+        # v1.18 product carry: surface that mention preference survives unbind
+        # so users aren't surprised when a rebind silently restores the
+        # "responds to all messages" mode (#153 R1 product §4).
+        mention_required = bot.project_manager.get_mention_required(channel_id)
+        message_parts = ["✅ Removed this channel's project binding."]
+        if not mention_required:
+            message_parts.append(
+                "\n🔔 Note: `mention not required` preference is preserved "
+                "across rebind. Use `/project set-mention-required true` to reset."
+            )
         await interaction.response.send_message(
-            "✅ Removed this channel's project binding.", ephemeral=True
+            "".join(message_parts), ephemeral=True
         )
     else:
         await interaction.response.send_message(

--- a/tests/test_project_cog_thread_parent.py
+++ b/tests/test_project_cog_thread_parent.py
@@ -180,3 +180,142 @@ async def test_set_mention_required_unbound_channel_friendly_error(
     assert "❌" in msg
     # Channel state untouched
     assert pm.get_mention_required(60001) is True
+
+
+# ---------------------------------------------------------------------------
+# v1.18 #156 follow-up — discoverability + unbind surfacing (#153 R1 product)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_project_info_always_shows_mention_setting(
+    pm: ProjectManager, projects_root: Path
+) -> None:
+    """/project info now ALWAYS shows mention status (was: only on non-default).
+
+    Closes #153 R1 product §3 discoverability gap — new users couldn't find
+    the toggle without reading docs.
+    """
+    channel_id = 70001
+    proj = projects_root / "demo"
+    proj.mkdir()
+    pm.bind(channel_id, str(proj))
+
+    bot = MagicMock(spec=ClaudedBot)
+    bot.project_manager = pm
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = MagicMock(spec=discord.TextChannel)
+    interaction.channel.id = channel_id
+    interaction.channel_id = channel_id
+    interaction.guild_id = 9999
+    interaction.client = bot
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    from clauded.cogs.project import project_info
+    await project_info.callback(interaction)
+
+    sent = interaction.response.send_message.call_args[0][0]
+    # Default mention_required=True path
+    assert "Mention: required" in sent, f"expected 'Mention: required' in: {sent!r}"
+    assert "set-mention-required false" in sent, "expected discoverability hint"
+
+
+@pytest.mark.asyncio
+async def test_project_info_shows_not_required_when_set_false(
+    pm: ProjectManager, projects_root: Path
+) -> None:
+    """When mention_required=False is set, /project info reflects it
+    (regression pin for the non-default branch)."""
+    channel_id = 70002
+    proj = projects_root / "demo2"
+    proj.mkdir()
+    pm.bind(channel_id, str(proj))
+    pm.set_mention_required(channel_id, False)
+
+    bot = MagicMock(spec=ClaudedBot)
+    bot.project_manager = pm
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = MagicMock(spec=discord.TextChannel)
+    interaction.channel.id = channel_id
+    interaction.channel_id = channel_id
+    interaction.guild_id = 9999
+    interaction.client = bot
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    from clauded.cogs.project import project_info
+    await project_info.callback(interaction)
+
+    sent = interaction.response.send_message.call_args[0][0]
+    assert "not required" in sent
+    assert "responds to all messages" in sent
+
+
+@pytest.mark.asyncio
+async def test_project_unbind_surfaces_preserved_mention(
+    pm: ProjectManager, projects_root: Path
+) -> None:
+    """When mention_required=False is set and user unbinds, surface that
+    the setting survives so rebind isn't a surprise (#153 R1 product §4)."""
+    channel_id = 70003
+    proj = projects_root / "demo3"
+    proj.mkdir()
+    pm.bind(channel_id, str(proj))
+    pm.set_mention_required(channel_id, False)
+
+    bot = MagicMock(spec=ClaudedBot)
+    bot.project_manager = pm
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = MagicMock(spec=discord.TextChannel)
+    interaction.channel.id = channel_id
+    interaction.channel_id = channel_id
+    interaction.guild_id = 9999
+    interaction.client = bot
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    from clauded.cogs.project import project_unbind
+    await project_unbind.callback(interaction)
+
+    sent = interaction.response.send_message.call_args[0][0]
+    assert "Removed this channel" in sent
+    assert "preserved across rebind" in sent
+    assert "set-mention-required true" in sent
+    # And the setting indeed survived
+    assert pm.get_mention_required(channel_id) is False
+
+
+@pytest.mark.asyncio
+async def test_project_unbind_silent_when_mention_at_default(
+    pm: ProjectManager, projects_root: Path
+) -> None:
+    """When mention_required stays at default True, unbind doesn't add the
+    preservation footnote (avoids noise on the common case)."""
+    channel_id = 70004
+    proj = projects_root / "demo4"
+    proj.mkdir()
+    pm.bind(channel_id, str(proj))
+    # NOT setting mention_required → stays at default True
+
+    bot = MagicMock(spec=ClaudedBot)
+    bot.project_manager = pm
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = MagicMock(spec=discord.TextChannel)
+    interaction.channel.id = channel_id
+    interaction.channel_id = channel_id
+    interaction.guild_id = 9999
+    interaction.client = bot
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    from clauded.cogs.project import project_unbind
+    await project_unbind.callback(interaction)
+
+    sent = interaction.response.send_message.call_args[0][0]
+    assert "Removed this channel" in sent
+    assert "preserved across rebind" not in sent


### PR DESCRIPTION
Closes 2 deferred R1 product findings from PR #153 (v1.17 mention toggle):

## §3 Discoverability
`/project info` now ALWAYS shows mention status. Was hidden on default-True. New users discover the toggle without docs.

## §4 Unbind silent surfacing
`/project unbind` warns when `mention_required=False` is preserved across rebind. Default-True case stays silent (no noise).

## Tests
+4 in `test_project_cog_thread_parent.py` pin both branches of both fixes.

472 pass / 2 pre-existing P1.