### PR TITLE
v1.18: surface unbound-refuse hint instead of silent ignore

### DIFF
--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -30,7 +30,7 @@ from .session_config import SessionConfig
 from .session_store import SessionStore
 from .cost_tracker import CostTracker
 from .agent_manager import AgentManager
-from .cogs._unbound import UNBOUND_HINT_MESSAGE
+from .cogs._unbound import UNBOUND_HINT_MESSAGE, UNBOUND_REFUSE_MESSAGE
 from .cogs._table_view import CopyTableTextView
 from ._errors import is_transient_discord_error
 from ._http_retry import (
@@ -365,7 +365,6 @@ class ClaudedBot(commands.Bot):
             and not self.config.allow_unbound_fallback
         ):
             if self.project_manager.should_refuse_unbound(channel.id):
-                from .cogs._unbound import UNBOUND_REFUSE_MESSAGE
                 try:
                     await message.reply(UNBOUND_REFUSE_MESSAGE)
                 except discord.HTTPException:
@@ -603,7 +602,6 @@ class ClaudedBot(commands.Bot):
             and not self.config.allow_unbound_fallback
         ):
             if self.project_manager.should_refuse_unbound(parent_id):
-                from .cogs._unbound import UNBOUND_REFUSE_MESSAGE
                 try:
                     await message.reply(UNBOUND_REFUSE_MESSAGE)
                 except discord.HTTPException:

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -357,10 +357,19 @@ class ClaudedBot(commands.Bot):
         # SECURITY (sec-1): unbound fallback is off by default. v1.0 behavior
         # is to silently ignore @bot in unbound channels. Operators opt in via
         # CLAUDED_ALLOW_UNBOUND_FALLBACK=1 to enable the $HOME fallback.
+        # v1.18: first time we see an unbound channel, reply once with a hint
+        # so the user isn't left wondering why bot didn't respond. Subsequent
+        # messages in the same channel still silent-return (no spam).
         if (
             not self.project_manager.is_bound(channel.id)
             and not self.config.allow_unbound_fallback
         ):
+            if self.project_manager.should_refuse_unbound(channel.id):
+                from .cogs._unbound import UNBOUND_REFUSE_MESSAGE
+                try:
+                    await message.reply(UNBOUND_REFUSE_MESSAGE)
+                except discord.HTTPException:
+                    log.debug("Could not surface unbound-refuse hint")
             return
 
         resolved = await _resolve_path_or_friendly_error(
@@ -587,10 +596,18 @@ class ClaudedBot(commands.Bot):
         (v1.0 behavior).
         """
         # SECURITY (sec-1): mirror channel handler's gate.
+        # v1.18: also mirror the first-time-refusal hint so unbound *parent*
+        # channels of thread messages don't silent-fail either.
         if (
             not self.project_manager.is_bound(parent_id)
             and not self.config.allow_unbound_fallback
         ):
+            if self.project_manager.should_refuse_unbound(parent_id):
+                from .cogs._unbound import UNBOUND_REFUSE_MESSAGE
+                try:
+                    await message.reply(UNBOUND_REFUSE_MESSAGE)
+                except discord.HTTPException:
+                    log.debug("Could not surface unbound-refuse hint in thread")
             return
 
         resolved = await _resolve_path_or_friendly_error(

--- a/src/clauded/project_manager.py
+++ b/src/clauded/project_manager.py
@@ -41,6 +41,11 @@ class ProjectManager:
         # Channels that have already been shown the "unbound, falling back to
         # ~" hint this process. In-memory only — bot restart re-arms the hint.
         self._hinted_unbound_channels: set[int] = set()
+        # Channels where we've already replied with the unbound-refusal hint
+        # this process (v1.18: nudge user to /project bind exactly once per
+        # unbound channel so silent-ignore doesn't become invisible-failure).
+        # In-memory only — bot restart re-arms.
+        self._refused_unbound_channels: set[int] = set()
         self._load()
         self._load_guild_roots()
         self._load_channel_settings()
@@ -184,6 +189,20 @@ class ProjectManager:
         if channel_id in self._hinted_unbound_channels:
             return False
         self._hinted_unbound_channels.add(channel_id)
+        return True
+
+    def should_refuse_unbound(self, channel_id: int) -> bool:
+        """Return True only the first time we should reply with the refusal hint.
+
+        Used by ``on_message`` when ``allow_unbound_fallback`` is False so the
+        user sees one ``UNBOUND_REFUSE_MESSAGE`` reply per unbound channel
+        per process instead of getting silently ignored. Repeating it on
+        every message would be noise; once-per-process keeps the channel
+        signal-to-noise high while still surfacing the misconfiguration.
+        """
+        if channel_id in self._refused_unbound_channels:
+            return False
+        self._refused_unbound_channels.add(channel_id)
         return True
 
     # ------------------------------------------------------------------

--- a/tests/test_bot_unbound_message.py
+++ b/tests/test_bot_unbound_message.py
@@ -391,3 +391,102 @@ async def test_broken_home_dir_friendly_error(
     assert "/project bind" in reply
     # sec-2: error must NOT leak the operator's home path or any other path.
     assert str(bogus) not in reply, "broken-home reply leaked the path"
+
+
+# ---------------------------------------------------------------------------
+# v1.18 — unbound-refuse hint: when allow_unbound_fallback=False, surface
+# a one-shot reply pointing user to /project bind instead of silent ignore
+# (UX bug surfaced 2026-05-12: user sent @bot in unbound channel, no response,
+# no idea why — root cause was silent-ignore at bot.py:359-362).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cfg_strict(tmp_path: Path) -> Config:
+    """Config with allow_unbound_fallback=False (the v1.11 default + the
+    common LaunchAgent deployment shape)."""
+    return Config(
+        discord_bot_token="tok",
+        claude_model="sonnet",
+        claude_permission_mode="default",
+        projects_root=str(tmp_path),
+        allow_unbound_fallback=False,
+    )
+
+
+@pytest.fixture
+def bot_strict(
+    cfg_strict: Config, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> ClaudedBot:
+    """Bot with strict unbound policy — clone of bot fixture but flag OFF."""
+    pm = ProjectManager(data_dir=str(tmp_path / "data2"), projects_root=str(tmp_path))
+    bot = ClaudedBot.__new__(ClaudedBot)
+    bot.config = cfg_strict
+    bot.project_manager = pm
+    bot.session_manager = SessionManager()
+    bot.cost_tracker = CostTracker()
+    bot.agent_manager = MagicMock()
+    bot._start_time = 0.0
+    bot._claude_version = "test"
+    bot._debug_logging = False
+    bot._pre_tool_notifications = False
+    bot._notify_enabled = {}
+    bot._connection = MagicMock()
+    fake_user = FakeUser(id=42, name="bot")
+    monkeypatch.setattr(ClaudedBot, "user", property(lambda self: fake_user))
+    monkeypatch.setattr(discord, "TextChannel", FakeChannel)
+    class _Forum:  # noqa: D401
+        pass
+    monkeypatch.setattr(discord, "ForumChannel", _Forum)
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_unbound_strict_first_message_replies_refuse_hint(
+    bot_strict: ClaudedBot,
+) -> None:
+    """First @bot in unbound channel (flag OFF) → bot replies UNBOUND_REFUSE_MESSAGE
+    via message.reply(). Not silent — user sees the bind instruction."""
+    from clauded.cogs._unbound import UNBOUND_REFUSE_MESSAGE
+    channel = FakeChannel(channel_id=70000)
+    msg = FakeMessage(channel=channel, content="<@42> hello", bot_user_id=42)
+    await bot_strict._handle_channel_message(msg)
+    assert msg.replies == [UNBOUND_REFUSE_MESSAGE], (
+        f"Expected one reply == UNBOUND_REFUSE_MESSAGE, got: {msg.replies!r}"
+    )
+    # And no thread was created (still refused — just no longer silent)
+    assert msg._created_thread is None
+
+
+@pytest.mark.asyncio
+async def test_unbound_strict_second_message_silent(
+    bot_strict: ClaudedBot,
+) -> None:
+    """Second @bot in SAME unbound channel → silent (rate-limited to once-per-process).
+    User already saw the hint; subsequent messages don't spam."""
+    from clauded.cogs._unbound import UNBOUND_REFUSE_MESSAGE
+    channel = FakeChannel(channel_id=70001)
+    msg1 = FakeMessage(channel=channel, content="<@42> first", bot_user_id=42)
+    msg2 = FakeMessage(channel=channel, content="<@42> second", bot_user_id=42)
+    await bot_strict._handle_channel_message(msg1)
+    await bot_strict._handle_channel_message(msg2)
+    assert msg1.replies == [UNBOUND_REFUSE_MESSAGE]
+    assert msg2.replies == [], (
+        f"Expected silent on 2nd message, got: {msg2.replies!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unbound_strict_per_channel_independent(
+    bot_strict: ClaudedBot,
+) -> None:
+    """Two different unbound channels each get their own first-time hint."""
+    from clauded.cogs._unbound import UNBOUND_REFUSE_MESSAGE
+    ch_a = FakeChannel(channel_id=80001)
+    ch_b = FakeChannel(channel_id=80002)
+    msg_a = FakeMessage(channel=ch_a, content="<@42> a", bot_user_id=42)
+    msg_b = FakeMessage(channel=ch_b, content="<@42> b", bot_user_id=42)
+    await bot_strict._handle_channel_message(msg_a)
+    await bot_strict._handle_channel_message(msg_b)
+    assert msg_a.replies == [UNBOUND_REFUSE_MESSAGE]
+    assert msg_b.replies == [UNBOUND_REFUSE_MESSAGE]


### PR DESCRIPTION
Real UX bug surfaced 2026-05-12: user sent @bot in an unbound channel under v1.15 LaunchAgent (`CLAUDED_ALLOW_UNBOUND_FALLBACK` not set, so `allow_unbound_fallback=False` per v1.11 strict default). `bot.py:359 / :592` silently returned — no reply, no surfacing, no clue why bot didn't respond.

## Fix
- New `ProjectManager.should_refuse_unbound(channel_id) -> bool` mirrors existing `should_hint_unbound` once-per-process pattern.
- Both gates (`_handle_channel_message` + `_handle_thread_message`) now reply with the existing `UNBOUND_REFUSE_MESSAGE` once per channel before returning.
- **Security contract preserved**: bot STILL does not run Claude (refuse, don't fallback). Just surfaces refusal.

## Tests
+3 in `test_bot_unbound_message.py`:
- first-message replies refuse hint, no thread created
- second-message silent (rate-limited)
- per-channel independent

475 pass / 2 pre-existing P1.

## Out of scope
- Changing PRD #110 strict default (separate discussion)
- Surfacing hint as ephemeral interaction (these are plain Discord messages, not interactions)