### PR TITLE
v1.18: refuse hint also mentions CLAUDED_ALLOW_UNBOUND_FALLBACK env

### DIFF
--- a/src/clauded/cogs/_unbound.py
+++ b/src/clauded/cogs/_unbound.py
@@ -17,7 +17,10 @@ import discord
 
 UNBOUND_REFUSE_MESSAGE = (
     "❌ This channel isn't bound to a project. "
-    "Run `/project bind <path>` first, then retry."
+    "Run `/project bind <path>` first, then retry. "
+    "— Operator alternative: set `CLAUDED_ALLOW_UNBOUND_FALLBACK=1` "
+    "in the bot environment to globally allow unbound channels "
+    "(falls back to `~`)."
 )
 
 UNBOUND_HINT_MESSAGE = (

--- a/tests/test_unbound_handler.py
+++ b/tests/test_unbound_handler.py
@@ -170,3 +170,17 @@ async def test_reject_if_unbound_thread_with_no_parent_id_falls_back_to_channel_
 
     assert result is True
     bot.project_manager.is_bound.assert_called_once_with(6001)
+
+
+def test_unbound_refuse_message_is_single_line() -> None:
+    """Regression pin (#159 R1 tester nice-to-have): ``UNBOUND_REFUSE_MESSAGE``
+    must not contain ``\\n``. The existing ``test_group_a_unbound`` substring
+    matchers do ``UNBOUND_REFUSE_MESSAGE in str(call_tuple)`` where the call
+    tuple repr converts embedded newlines to ``\\\\n``, defeating the match.
+    A future contributor wanting multi-line would need to also update those
+    matchers; this guard makes the constraint loud."""
+    from clauded.cogs._unbound import UNBOUND_REFUSE_MESSAGE
+    assert "\n" not in UNBOUND_REFUSE_MESSAGE, (
+        "UNBOUND_REFUSE_MESSAGE must stay single-line — see #159 R1 tester note "
+        "for the str(tuple) repr trap that breaks 15 existing tests."
+    )


### PR DESCRIPTION
User feedback on PR #158: the one-shot unbound-refuse hint should also tell operators about the env var, not just the per-channel bind path.

## Change
`UNBOUND_REFUSE_MESSAGE` now reads:

> ❌ This channel isn't bound to a project. Run `/project bind <path>` first, then retry. — Operator alternative: set `CLAUDED_ALLOW_UNBOUND_FALLBACK=1` in the bot environment to globally allow unbound channels (falls back to `~`).

Single-line concat (no \n) keeps existing substring-match test pattern in test_group_a_unbound.py working without test-side surgery.

## Tests
475 pass / 2 pre-existing P1 unchanged.