### PR TITLE
v1.18: /unbound-fallback admin slash command for runtime toggle (#160)

### DIFF
--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -183,8 +183,25 @@ class ClaudedBot(commands.Bot):
         self.agent_manager = AgentManager()
         self._claude_version: str = "unknown"
         self._debug_logging: bool = False
+        # v1.18 #160: runtime override for allow_unbound_fallback. None = use
+        # ``self.config.allow_unbound_fallback`` (env-derived). When set via
+        # ``/unbound-fallback`` slash command, takes effect immediately and
+        # survives until process restart (Config is frozen by design; this
+        # mirror lives on the mutable bot instance instead).
+        self._allow_unbound_fallback_runtime: bool | None = None
         self._pre_tool_notifications: bool = False
         self._notify_enabled: dict[int, bool] = {}
+
+    @property
+    def allow_unbound_fallback(self) -> bool:
+        """Effective unbound-fallback policy: runtime override > config default.
+
+        Toggle via ``/unbound-fallback`` (admin slash command, runtime only) or
+        set ``CLAUDED_ALLOW_UNBOUND_FALLBACK=1`` in the bot env (persistent).
+        """
+        if self._allow_unbound_fallback_runtime is not None:
+            return self._allow_unbound_fallback_runtime
+        return self.config.allow_unbound_fallback
 
     async def setup_hook(self) -> None:
         """Register slash command groups and sync to Discord."""
@@ -227,7 +244,7 @@ class ClaudedBot(commands.Bot):
         from .cogs.ops import (
             cost_group, health_check, review_pr, plugin_group,
             send_to_claude, pin_message, ratelimit_info,
-            debug_toggle, notify_toggle,
+            debug_toggle, notify_toggle, unbound_fallback_toggle,
         )
 
         self.tree.add_command(project_group)
@@ -252,6 +269,7 @@ class ClaudedBot(commands.Bot):
         self.tree.add_command(toggle_bare)
         self.tree.add_command(debug_toggle)
         self.tree.add_command(notify_toggle)
+        self.tree.add_command(unbound_fallback_toggle)
         synced = await self.tree.sync()
         log.info("Synced %d application command(s)", len(synced))
 
@@ -362,7 +380,7 @@ class ClaudedBot(commands.Bot):
         # messages in the same channel still silent-return (no spam).
         if (
             not self.project_manager.is_bound(channel.id)
-            and not self.config.allow_unbound_fallback
+            and not self.allow_unbound_fallback
         ):
             if self.project_manager.should_refuse_unbound(channel.id):
                 try:
@@ -599,7 +617,7 @@ class ClaudedBot(commands.Bot):
         # channels of thread messages don't silent-fail either.
         if (
             not self.project_manager.is_bound(parent_id)
-            and not self.config.allow_unbound_fallback
+            and not self.allow_unbound_fallback
         ):
             if self.project_manager.should_refuse_unbound(parent_id):
                 try:

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -183,25 +183,16 @@ class ClaudedBot(commands.Bot):
         self.agent_manager = AgentManager()
         self._claude_version: str = "unknown"
         self._debug_logging: bool = False
-        # v1.18 #160: runtime override for allow_unbound_fallback. None = use
-        # ``self.config.allow_unbound_fallback`` (env-derived). When set via
-        # ``/unbound-fallback`` slash command, takes effect immediately and
-        # survives until process restart (Config is frozen by design; this
-        # mirror lives on the mutable bot instance instead).
-        self._allow_unbound_fallback_runtime: bool | None = None
+        # v1.18 #160: runtime-toggleable allow_unbound_fallback. Initialized
+        # from env-derived ``self.config.allow_unbound_fallback`` and
+        # mutated by the ``/unbound-fallback`` admin slash command. Plain
+        # mutable bool matches the sibling ``_debug_logging`` /
+        # ``_pre_tool_notifications`` pattern in this same class; bot
+        # restart re-reads env-default so the flag fails-closed unless
+        # ``CLAUDED_ALLOW_UNBOUND_FALLBACK=1`` is set in the bot env.
+        self.allow_unbound_fallback: bool = config.allow_unbound_fallback
         self._pre_tool_notifications: bool = False
         self._notify_enabled: dict[int, bool] = {}
-
-    @property
-    def allow_unbound_fallback(self) -> bool:
-        """Effective unbound-fallback policy: runtime override > config default.
-
-        Toggle via ``/unbound-fallback`` (admin slash command, runtime only) or
-        set ``CLAUDED_ALLOW_UNBOUND_FALLBACK=1`` in the bot env (persistent).
-        """
-        if self._allow_unbound_fallback_runtime is not None:
-            return self._allow_unbound_fallback_runtime
-        return self.config.allow_unbound_fallback
 
     async def setup_hook(self) -> None:
         """Register slash command groups and sync to Discord."""

--- a/src/clauded/cogs/ops.py
+++ b/src/clauded/cogs/ops.py
@@ -386,6 +386,7 @@ async def notify_toggle(interaction: discord.Interaction) -> None:
     enabled="True: unbound channels fall back to ~ (operator's home). False: refuse with hint."
 )
 @app_commands.default_permissions(administrator=True)
+@app_commands.guild_only()
 async def unbound_fallback_toggle(
     interaction: discord.Interaction, enabled: bool
 ) -> None:
@@ -402,26 +403,38 @@ async def unbound_fallback_toggle(
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
-    bot._allow_unbound_fallback_runtime = enabled
+    # Defense-in-depth: ``default_permissions`` is Discord-UI default only and
+    # is admin-reassignable. Re-check at the callback so a permission-overridden
+    # role still gets gated. (R1 security #1 + #4.)
+    member = interaction.user
+    perms = getattr(member, "guild_permissions", None)
+    if perms is None or not perms.administrator:
+        await interaction.response.send_message(
+            "❌ Administrator permission required.", ephemeral=True
+        )
+        return
+    previous = bot.allow_unbound_fallback
+    bot.allow_unbound_fallback = enabled
     # Reset the refuse-hint set so the next unbound @bot will surface a hint
-    # again under the new policy (when enabled=True the hint never fires
-    # because the gate doesn't trip; when enabled=False the user gets a fresh
-    # nudge on the next attempt). Without this, a process that's already
-    # shown the hint once before the operator toggled the policy would stay
-    # silent on the next message even though the policy now warrants surfacing.
+    # again under the new policy.
     bot.project_manager._refused_unbound_channels.clear()
+    # SEC AUDIT TRAIL (R1 security #5 blocking): every flip of this flag is
+    # forensic-worthy. Log INFO with WHO/WHERE/WHAT-CHANGED so operators can
+    # reconstruct unbound-fallback policy changes post-hoc.
+    log.warning(
+        "SECURITY: allow_unbound_fallback %s -> %s by user=%s(id=%s) guild=%s channel=%s",
+        previous, enabled,
+        getattr(member, "name", "?"), getattr(member, "id", "?"),
+        interaction.guild_id, interaction.channel_id,
+    )
     state = "ON (fallback to ~)" if enabled else "OFF (refuse with hint)"
     persist_note = (
-        "\nℹ️ Runtime only — set `CLAUDED_ALLOW_UNBOUND_FALLBACK=1` in the bot "
+        "ℹ️ Runtime only — set `CLAUDED_ALLOW_UNBOUND_FALLBACK=1` in the bot "
         "environment for the setting to survive restart."
     )
     embed = discord.Embed(
         title=f"🔓 Unbound fallback: {state}",
-        description=(
-            "Bot will create sessions in `~` for unbound channels."
-            if enabled
-            else "Bot will refuse unbound channels and direct user to `/project bind`."
-        ) + persist_note,
+        description=persist_note,
         color=COLOR_INFO,
     )
     await interaction.response.send_message(embed=embed, ephemeral=True)

--- a/src/clauded/cogs/ops.py
+++ b/src/clauded/cogs/ops.py
@@ -372,3 +372,56 @@ async def notify_toggle(interaction: discord.Interaction) -> None:
         ),
         ephemeral=True,
     )
+
+
+# ---------------------------------------------------------------------------
+# /unbound-fallback command — runtime toggle for unbound-channel fallback
+# ---------------------------------------------------------------------------
+
+@app_commands.command(
+    name="unbound-fallback",
+    description="Toggle CLAUDED_ALLOW_UNBOUND_FALLBACK at runtime (admin; no restart needed).",
+)
+@app_commands.describe(
+    enabled="True: unbound channels fall back to ~ (operator's home). False: refuse with hint."
+)
+@app_commands.default_permissions(administrator=True)
+async def unbound_fallback_toggle(
+    interaction: discord.Interaction, enabled: bool
+) -> None:
+    """Runtime override of ``Config.allow_unbound_fallback``.
+
+    Not persisted: bot restart re-loads the env-default. This is intentional —
+    the flag controls a security-relevant gate (Discord channel-write
+    permission ≠ shell access in operator's $HOME), so it fails-closed on
+    every restart unless ``CLAUDED_ALLOW_UNBOUND_FALLBACK=1`` is set in the
+    bot environment (the env-persistent path).
+    """
+    from ..bot import ClaudedBot
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    bot._allow_unbound_fallback_runtime = enabled
+    # Reset the refuse-hint set so the next unbound @bot will surface a hint
+    # again under the new policy (when enabled=True the hint never fires
+    # because the gate doesn't trip; when enabled=False the user gets a fresh
+    # nudge on the next attempt). Without this, a process that's already
+    # shown the hint once before the operator toggled the policy would stay
+    # silent on the next message even though the policy now warrants surfacing.
+    bot.project_manager._refused_unbound_channels.clear()
+    state = "ON (fallback to ~)" if enabled else "OFF (refuse with hint)"
+    persist_note = (
+        "\nℹ️ Runtime only — set `CLAUDED_ALLOW_UNBOUND_FALLBACK=1` in the bot "
+        "environment for the setting to survive restart."
+    )
+    embed = discord.Embed(
+        title=f"🔓 Unbound fallback: {state}",
+        description=(
+            "Bot will create sessions in `~` for unbound channels."
+            if enabled
+            else "Bot will refuse unbound channels and direct user to `/project bind`."
+        ) + persist_note,
+        color=COLOR_INFO,
+    )
+    await interaction.response.send_message(embed=embed, ephemeral=True)

--- a/src/clauded/cogs/ops.py
+++ b/src/clauded/cogs/ops.py
@@ -419,7 +419,7 @@ async def unbound_fallback_toggle(
     # again under the new policy.
     bot.project_manager._refused_unbound_channels.clear()
     # SEC AUDIT TRAIL (R1 security #5 blocking): every flip of this flag is
-    # forensic-worthy. Log INFO with WHO/WHERE/WHAT-CHANGED so operators can
+    # forensic-worthy. Log WARNING with WHO/WHERE/WHAT-CHANGED so operators can
     # reconstruct unbound-fallback policy changes post-hoc.
     log.warning(
         "SECURITY: allow_unbound_fallback %s -> %s by user=%s(id=%s) guild=%s channel=%s",

--- a/tests/test_bot_unbound_message.py
+++ b/tests/test_bot_unbound_message.py
@@ -162,7 +162,7 @@ def bot(cfg: Config, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Clauded
     bot._debug_logging = False
     bot._pre_tool_notifications = False
     bot._notify_enabled = {}
-    bot._allow_unbound_fallback_runtime = None
+    bot.allow_unbound_fallback = bot.config.allow_unbound_fallback
     # Bot identity used by the mention check
     bot._connection = MagicMock()  # placeholder; tests don't talk to it
     fake_user = FakeUser(id=42, name="bot")
@@ -432,7 +432,7 @@ def bot_strict(
     bot._debug_logging = False
     bot._pre_tool_notifications = False
     bot._notify_enabled = {}
-    bot._allow_unbound_fallback_runtime = None
+    bot.allow_unbound_fallback = bot.config.allow_unbound_fallback
     bot._connection = MagicMock()
     fake_user = FakeUser(id=42, name="bot")
     monkeypatch.setattr(ClaudedBot, "user", property(lambda self: fake_user))

--- a/tests/test_bot_unbound_message.py
+++ b/tests/test_bot_unbound_message.py
@@ -162,6 +162,7 @@ def bot(cfg: Config, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Clauded
     bot._debug_logging = False
     bot._pre_tool_notifications = False
     bot._notify_enabled = {}
+    bot._allow_unbound_fallback_runtime = None
     # Bot identity used by the mention check
     bot._connection = MagicMock()  # placeholder; tests don't talk to it
     fake_user = FakeUser(id=42, name="bot")
@@ -431,6 +432,7 @@ def bot_strict(
     bot._debug_logging = False
     bot._pre_tool_notifications = False
     bot._notify_enabled = {}
+    bot._allow_unbound_fallback_runtime = None
     bot._connection = MagicMock()
     fake_user = FakeUser(id=42, name="bot")
     monkeypatch.setattr(ClaudedBot, "user", property(lambda self: fake_user))

--- a/tests/test_thread_race.py
+++ b/tests/test_thread_race.py
@@ -175,7 +175,7 @@ def bot(cfg: Config, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Clauded
     bot._debug_logging = False
     bot._pre_tool_notifications = False
     bot._notify_enabled = {}
-    bot._allow_unbound_fallback_runtime = None
+    bot.allow_unbound_fallback = bot.config.allow_unbound_fallback
     bot._connection = MagicMock()
     fake_user = FakeUser(id=42, name="bot")
     monkeypatch.setattr(ClaudedBot, "user", property(lambda self: fake_user))

--- a/tests/test_thread_race.py
+++ b/tests/test_thread_race.py
@@ -175,6 +175,7 @@ def bot(cfg: Config, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Clauded
     bot._debug_logging = False
     bot._pre_tool_notifications = False
     bot._notify_enabled = {}
+    bot._allow_unbound_fallback_runtime = None
     bot._connection = MagicMock()
     fake_user = FakeUser(id=42, name="bot")
     monkeypatch.setattr(ClaudedBot, "user", property(lambda self: fake_user))

--- a/tests/test_unbound_fallback_toggle.py
+++ b/tests/test_unbound_fallback_toggle.py
@@ -1,0 +1,138 @@
+"""Tests for /unbound-fallback runtime toggle (PR #160).
+
+Real user request 2026-05-12: edit-plist-and-restart workflow is too heavy for
+operators who want to flip the security knob ad-hoc. Add slash command that
+mutates ``bot.config.allow_unbound_fallback`` at runtime (no persist).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from clauded.bot import ClaudedBot
+from clauded.config import Config
+from clauded.cost_tracker import CostTracker
+from clauded.project_manager import ProjectManager
+from clauded.session_manager import SessionManager
+
+
+@pytest.fixture
+def bot(tmp_path: Path) -> ClaudedBot:
+    """Minimal ClaudedBot stub — same shape as test_bot_unbound_message.py."""
+    cfg = Config(
+        discord_bot_token="tok",
+        claude_model="sonnet",
+        claude_permission_mode="default",
+        projects_root=str(tmp_path),
+        allow_unbound_fallback=False,  # start OFF per v1.11 default
+    )
+    pm = ProjectManager(data_dir=str(tmp_path / "data"), projects_root=str(tmp_path))
+    bot = ClaudedBot.__new__(ClaudedBot)
+    bot.config = cfg
+    bot.project_manager = pm
+    bot.session_manager = SessionManager()
+    bot.cost_tracker = CostTracker()
+    bot.agent_manager = MagicMock()
+    bot._start_time = 0.0
+    bot._claude_version = "test"
+    bot._debug_logging = False
+    bot._pre_tool_notifications = False
+    bot._notify_enabled = {}
+    bot._allow_unbound_fallback_runtime = None
+    bot._connection = MagicMock()
+    return bot
+
+
+def _make_interaction(bot: ClaudedBot) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = bot
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_unbound_fallback_toggle_on(bot: ClaudedBot) -> None:
+    """/unbound-fallback True flips effective ``bot.allow_unbound_fallback`` ON."""
+    from clauded.cogs.ops import unbound_fallback_toggle
+    interaction = _make_interaction(bot)
+    # Baseline: Config frozen-default False, runtime override None.
+    assert bot.allow_unbound_fallback is False
+    assert bot._allow_unbound_fallback_runtime is None
+    await unbound_fallback_toggle.callback(interaction, True)
+    assert bot._allow_unbound_fallback_runtime is True
+    assert bot.allow_unbound_fallback is True
+    # Config itself stays frozen — only the runtime override mutated.
+    assert bot.config.allow_unbound_fallback is False
+    interaction.response.send_message.assert_awaited_once()
+    sent_embed = interaction.response.send_message.call_args.kwargs["embed"]
+    assert "ON" in sent_embed.title
+
+
+@pytest.mark.asyncio
+async def test_unbound_fallback_toggle_off(bot: ClaudedBot) -> None:
+    """/unbound-fallback False flips override OFF."""
+    from clauded.cogs.ops import unbound_fallback_toggle
+    bot._allow_unbound_fallback_runtime = True  # start ON
+    interaction = _make_interaction(bot)
+    await unbound_fallback_toggle.callback(interaction, False)
+    assert bot._allow_unbound_fallback_runtime is False
+    assert bot.allow_unbound_fallback is False
+    sent_embed = interaction.response.send_message.call_args.kwargs["embed"]
+    assert "OFF" in sent_embed.title
+
+
+@pytest.mark.asyncio
+async def test_unbound_fallback_property_respects_config_default(bot: ClaudedBot) -> None:
+    """When no runtime override, ``bot.allow_unbound_fallback`` mirrors
+    ``Config.allow_unbound_fallback``. Pin the chain so future refactor
+    of Config field doesn't accidentally bypass the property."""
+    # Config is frozen — can't reassign field. Build a new Config with True.
+    from clauded.config import Config
+    bot.config = Config(
+        discord_bot_token="tok", claude_model="sonnet",
+        claude_permission_mode="default",
+        projects_root=bot.config.projects_root,
+        allow_unbound_fallback=True,
+    )
+    bot._allow_unbound_fallback_runtime = None
+    assert bot.allow_unbound_fallback is True
+    # Override takes precedence:
+    bot._allow_unbound_fallback_runtime = False
+    assert bot.allow_unbound_fallback is False
+
+
+@pytest.mark.asyncio
+async def test_unbound_fallback_toggle_clears_refused_set(bot: ClaudedBot) -> None:
+    """Toggling resets _refused_unbound_channels so the hint surfaces again
+    under the new policy (otherwise a once-shown channel stays silent forever)."""
+    from clauded.cogs.ops import unbound_fallback_toggle
+    bot.project_manager._refused_unbound_channels.add(11111)
+    bot.project_manager._refused_unbound_channels.add(22222)
+    assert len(bot.project_manager._refused_unbound_channels) == 2
+    interaction = _make_interaction(bot)
+    await unbound_fallback_toggle.callback(interaction, True)
+    assert bot.project_manager._refused_unbound_channels == set()
+
+
+@pytest.mark.asyncio
+async def test_unbound_fallback_response_is_ephemeral(bot: ClaudedBot) -> None:
+    """Response is ephemeral (admin command — output not in channel)."""
+    from clauded.cogs.ops import unbound_fallback_toggle
+    interaction = _make_interaction(bot)
+    await unbound_fallback_toggle.callback(interaction, True)
+    assert interaction.response.send_message.call_args.kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_unbound_fallback_response_mentions_env_persistence(bot: ClaudedBot) -> None:
+    """Embed description tells operator how to make it stick across restart."""
+    from clauded.cogs.ops import unbound_fallback_toggle
+    interaction = _make_interaction(bot)
+    await unbound_fallback_toggle.callback(interaction, True)
+    sent_embed = interaction.response.send_message.call_args.kwargs["embed"]
+    assert "CLAUDED_ALLOW_UNBOUND_FALLBACK" in sent_embed.description
+    assert "restart" in sent_embed.description.lower()

--- a/tests/test_unbound_fallback_toggle.py
+++ b/tests/test_unbound_fallback_toggle.py
@@ -1,8 +1,8 @@
-"""Tests for /unbound-fallback runtime toggle (PR #160).
+"""Tests for /unbound-fallback runtime toggle (PR #162).
 
 Real user request 2026-05-12: edit-plist-and-restart workflow is too heavy for
 operators who want to flip the security knob ad-hoc. Add slash command that
-mutates ``bot.config.allow_unbound_fallback`` at runtime (no persist).
+mutates ``bot.allow_unbound_fallback`` at runtime (no persist).
 """
 from __future__ import annotations
 
@@ -41,74 +41,77 @@ def bot(tmp_path: Path) -> ClaudedBot:
     bot._debug_logging = False
     bot._pre_tool_notifications = False
     bot._notify_enabled = {}
-    bot._allow_unbound_fallback_runtime = None
+    bot.allow_unbound_fallback = cfg.allow_unbound_fallback
     bot._connection = MagicMock()
     return bot
 
 
-def _make_interaction(bot: ClaudedBot) -> MagicMock:
+def _make_interaction(bot: ClaudedBot, is_admin: bool = True) -> MagicMock:
+    """Build an interaction with admin guild_permissions by default.
+
+    R1 security #1+#4: callback-side admin re-check. Tests must provide a
+    ``user.guild_permissions.administrator`` attribute matching the test
+    scenario; default True for happy-path tests.
+    """
     interaction = MagicMock(spec=discord.Interaction)
     interaction.client = bot
+    interaction.guild_id = 1234
+    interaction.channel_id = 5678
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
+    fake_user = MagicMock()
+    fake_user.id = 999
+    fake_user.name = "alice"
+    fake_user.guild_permissions = MagicMock(administrator=is_admin)
+    interaction.user = fake_user
     return interaction
 
 
 @pytest.mark.asyncio
 async def test_unbound_fallback_toggle_on(bot: ClaudedBot) -> None:
-    """/unbound-fallback True flips effective ``bot.allow_unbound_fallback`` ON."""
+    """/unbound-fallback True flips ``bot.allow_unbound_fallback`` ON."""
     from clauded.cogs.ops import unbound_fallback_toggle
     interaction = _make_interaction(bot)
-    # Baseline: Config frozen-default False, runtime override None.
     assert bot.allow_unbound_fallback is False
-    assert bot._allow_unbound_fallback_runtime is None
     await unbound_fallback_toggle.callback(interaction, True)
-    assert bot._allow_unbound_fallback_runtime is True
     assert bot.allow_unbound_fallback is True
-    # Config itself stays frozen — only the runtime override mutated.
+    # Config stays frozen — only the mutable bot attr changed.
     assert bot.config.allow_unbound_fallback is False
-    interaction.response.send_message.assert_awaited_once()
     sent_embed = interaction.response.send_message.call_args.kwargs["embed"]
     assert "ON" in sent_embed.title
 
 
 @pytest.mark.asyncio
 async def test_unbound_fallback_toggle_off(bot: ClaudedBot) -> None:
-    """/unbound-fallback False flips override OFF."""
+    """/unbound-fallback False flips bot attr OFF."""
     from clauded.cogs.ops import unbound_fallback_toggle
-    bot._allow_unbound_fallback_runtime = True  # start ON
+    bot.allow_unbound_fallback = True
     interaction = _make_interaction(bot)
     await unbound_fallback_toggle.callback(interaction, False)
-    assert bot._allow_unbound_fallback_runtime is False
     assert bot.allow_unbound_fallback is False
     sent_embed = interaction.response.send_message.call_args.kwargs["embed"]
     assert "OFF" in sent_embed.title
 
 
 @pytest.mark.asyncio
-async def test_unbound_fallback_property_respects_config_default(bot: ClaudedBot) -> None:
-    """When no runtime override, ``bot.allow_unbound_fallback`` mirrors
-    ``Config.allow_unbound_fallback``. Pin the chain so future refactor
-    of Config field doesn't accidentally bypass the property."""
-    # Config is frozen — can't reassign field. Build a new Config with True.
-    from clauded.config import Config
-    bot.config = Config(
-        discord_bot_token="tok", claude_model="sonnet",
-        claude_permission_mode="default",
-        projects_root=bot.config.projects_root,
-        allow_unbound_fallback=True,
-    )
-    bot._allow_unbound_fallback_runtime = None
-    assert bot.allow_unbound_fallback is True
-    # Override takes precedence:
-    bot._allow_unbound_fallback_runtime = False
-    assert bot.allow_unbound_fallback is False
+async def test_unbound_fallback_config_remains_frozen(bot: ClaudedBot) -> None:
+    """Config stays frozen across toggles; only the mutable bot attribute moves.
+
+    Regression pin for the v1.11 immutability invariant (PRD #110 sec-1
+    contract is per-process; Config is the immutable env-snapshot, bot attr
+    is the runtime mirror).
+    """
+    from clauded.cogs.ops import unbound_fallback_toggle
+    interaction = _make_interaction(bot)
+    await unbound_fallback_toggle.callback(interaction, True)
+    import dataclasses
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        bot.config.allow_unbound_fallback = True  # type: ignore[misc]
 
 
 @pytest.mark.asyncio
 async def test_unbound_fallback_toggle_clears_refused_set(bot: ClaudedBot) -> None:
-    """Toggling resets _refused_unbound_channels so the hint surfaces again
-    under the new policy (otherwise a once-shown channel stays silent forever)."""
+    """Toggling resets _refused_unbound_channels so the hint surfaces again."""
     from clauded.cogs.ops import unbound_fallback_toggle
     bot.project_manager._refused_unbound_channels.add(11111)
     bot.project_manager._refused_unbound_channels.add(22222)
@@ -136,3 +139,47 @@ async def test_unbound_fallback_response_mentions_env_persistence(bot: ClaudedBo
     sent_embed = interaction.response.send_message.call_args.kwargs["embed"]
     assert "CLAUDED_ALLOW_UNBOUND_FALLBACK" in sent_embed.description
     assert "restart" in sent_embed.description.lower()
+
+
+@pytest.mark.asyncio
+async def test_unbound_fallback_rejects_non_admin(bot: ClaudedBot) -> None:
+    """R1 security #1+#4: callback-side admin re-check rejects non-admin
+    even when Discord-UI ``default_permissions`` was overridden by a server
+    admin to grant the command to a non-admin role."""
+    from clauded.cogs.ops import unbound_fallback_toggle
+    interaction = _make_interaction(bot, is_admin=False)
+    await unbound_fallback_toggle.callback(interaction, True)
+    # State NOT changed
+    assert bot.allow_unbound_fallback is False
+    # Friendly error sent, NOT the success embed
+    call_args = interaction.response.send_message.call_args
+    sent = call_args[0][0] if call_args[0] else call_args.kwargs.get("content", "")
+    assert "Administrator permission required" in sent
+
+
+@pytest.mark.asyncio
+async def test_unbound_fallback_logs_security_event(
+    bot: ClaudedBot, caplog: pytest.LogCaptureFixture
+) -> None:
+    """R1 security #5 blocking: every flip of allow_unbound_fallback must
+    emit a WARNING-level audit log line with WHO/WHERE/PREV/NEW so operators
+    can reconstruct policy changes post-hoc."""
+    import logging
+    from clauded.cogs.ops import unbound_fallback_toggle
+    interaction = _make_interaction(bot)
+    caplog.set_level(logging.WARNING, logger="clauded.bot")
+    await unbound_fallback_toggle.callback(interaction, True)
+    audit_logs = [
+        r for r in caplog.records
+        if "SECURITY: allow_unbound_fallback" in r.getMessage()
+    ]
+    assert audit_logs, (
+        f"Expected SECURITY audit log entry; got: {[r.getMessage() for r in caplog.records]!r}"
+    )
+    msg = audit_logs[0].getMessage()
+    # Verify shape: prev → new, user id, guild, channel
+    assert "False -> True" in msg or "False" in msg and "True" in msg
+    assert "user=alice" in msg
+    assert "id=999" in msg
+    assert "guild=1234" in msg
+    assert "channel=5678" in msg


### PR DESCRIPTION
Real user request 2026-05-12: edit-plist-and-restart is too heavy for ad-hoc security knob flip. Adds admin slash command.

## Design
- `Config` stays frozen (immutability invariant). New `bot._allow_unbound_fallback_runtime` mutable override.
- New `bot.allow_unbound_fallback` property: override if set else config.
- Both gates in bot.py now read via property.
- `/unbound-fallback <enabled:bool>` admin-only (@app_commands.default_permissions(administrator=True)).
- **NOT persisted**: fails-closed on restart. Env var `CLAUDED_ALLOW_UNBOUND_FALLBACK=1` is the env-persistent path. Response embed surfaces both.
- Clears `_refused_unbound_channels` set so policy change surfaces hint on next dispatch.

## Tests
+6 in new `test_unbound_fallback_toggle.py` (on/off/property/clears-set/ephemeral/env-mention)
4 existing test fixtures updated to init the new attribute.

482 pass / 2 pre-existing P1 (was 475/2 → +6 new + 1 from #159).