### PR TITLE
v1.18: tool result short-tier inline display + WebSearch/WebFetch status bug (#161 partial)

### DIFF
--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -957,14 +957,49 @@ class DiscordRenderer:
                             if tool_log_msg is not None:
                                 # Update rolling tool log
                                 status = "✅" if not is_err else "❌"
+                                # #161 bonus bug fix: WebSearch / WebFetch emit
+                                # rolling-log lines that start with "🔄 🔍" /
+                                # "🔄 🌐" (tool-specific emoji between marker and
+                                # content). The original ``startswith("🔄 " + name)``
+                                # never matched those, so the status emoji stuck
+                                # at 🔄 forever. Use a tolerant match: any line
+                                # starting with 🔄 (any line not yet completed)
+                                # AND containing the name OR its tool-specific
+                                # emoji.
+                                tool_marker_aliases = {
+                                    "WebSearch": "🔍",
+                                    "WebFetch": "🌐",
+                                }
+                                alias = tool_marker_aliases.get(name, "")
                                 for i in range(len(tool_log_lines) - 1, -1, -1):
-                                    if tool_log_lines[i].startswith("🔄 " + name):
-                                        if is_err:
-                                            error_text = str(block.content)[:100] if block.content else "Failed"
-                                            tool_log_lines[i] = f"{status} {name}: {error_text}"
-                                        else:
-                                            tool_log_lines[i] = f"{status} {name}"
-                                        break
+                                    line = tool_log_lines[i]
+                                    if not line.startswith("🔄 "):
+                                        continue
+                                    matches_name = line.startswith("🔄 " + name)
+                                    matches_alias = alias and line.startswith("🔄 " + alias)
+                                    if not (matches_name or matches_alias):
+                                        continue
+                                    # #161 short tier: when result is short and
+                                    # single-line, surface it inline so user
+                                    # sees ``✅ Bash → 42`` instead of bare ✅ Bash.
+                                    # Per PRD: < 200 chars and no newlines.
+                                    content_str = str(block.content) if block.content else ""
+                                    is_short = (
+                                        len(content_str) < 200
+                                        and "\n" not in content_str
+                                        and content_str.strip() != ""
+                                    )
+                                    if is_err:
+                                        error_text = content_str[:100] if content_str else "Failed"
+                                        tool_log_lines[i] = f"{status} {name}: {error_text}"
+                                    elif is_short:
+                                        # Strip backticks to avoid breaking the
+                                        # rolling-log embed's markdown.
+                                        safe = content_str.strip().replace("`", "'")
+                                        tool_log_lines[i] = f"{status} {name} → {safe}"
+                                    else:
+                                        tool_log_lines[i] = f"{status} {name}"
+                                    break
                                 has_errors = any("❌" in l for l in tool_log_lines)
                                 tool_embed = discord.Embed(
                                     title="🔧 Tool Activity",

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -966,6 +966,19 @@ class DiscordRenderer:
                                 # starting with 🔄 (any line not yet completed)
                                 # AND containing the name OR its tool-specific
                                 # emoji.
+                                #
+                                # Audit of all rolling-log append sites at
+                                # _tool_log_lines.append(...) confirms the
+                                # following tools need alias entries (only those
+                                # whose append format inserts a glyph between
+                                # "🔄 " and the tool name):
+                                #   - WebSearch → "🔄 🔍 {query}"
+                                #   - WebFetch  → "🔄 🌐 {url}"
+                                # All other tools (Bash, Read, Write, Edit, Grep,
+                                # Glob, Skill, fallback) append as
+                                # "🔄 {name}: …" so direct match already works.
+                                # If a future tool adds emoji-prefix shape, add
+                                # it here and to test_tool_result_shorttier.py.
                                 tool_marker_aliases = {
                                     "WebSearch": "🔍",
                                     "WebFetch": "🌐",

--- a/tests/test_tool_result_shorttier.py
+++ b/tests/test_tool_result_shorttier.py
@@ -1,0 +1,93 @@
+"""Tests for #161 short tier inline display + bonus-bug fix in tool result rendering.
+
+Real user feedback: '我看我们 tool 什么的调用有显示的，但是没显示调用的结果.
+我觉得短的结果直接显示，长的结果折叠这样子.'
+
+This PR ships the SHORT tier only (4-tier system deferred to v1.19):
+- Short result (< 200 chars, single line, non-empty) → inline rolling log shows
+  '✅ {name} → {content}' instead of bare '✅ {name}'
+- Bonus bug: WebSearch / WebFetch rolling log lines start with '🔄 🔍' / '🔄 🌐'
+  (emoji prefix), so the old startswith('🔄 ' + name) match never fired and
+  status stuck at 🔄 forever. R2 fix: tolerant match via tool_marker_aliases.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_bonus_bug_websearch_pattern_match():
+    """Regression pin: WebSearch's rolling-log line starts with '🔄 🔍 query'.
+    Old code's ``startswith('🔄 WebSearch')`` never matched; new alias-aware
+    match should hit."""
+    name = "WebSearch"
+    line = "🔄 🔍 my query text"
+    tool_marker_aliases = {"WebSearch": "🔍", "WebFetch": "🌐"}
+    alias = tool_marker_aliases.get(name, "")
+    matches_name = line.startswith("🔄 " + name)
+    matches_alias = alias and line.startswith("🔄 " + alias)
+    assert not matches_name, "old match was supposed to fail (regression pin)"
+    assert matches_alias, "new alias-aware match must succeed"
+
+
+def test_bonus_bug_webfetch_pattern_match():
+    """Regression pin: WebFetch's rolling-log line starts with '🔄 🌐 url'."""
+    name = "WebFetch"
+    line = "🔄 🌐 https://example.com"
+    tool_marker_aliases = {"WebSearch": "🔍", "WebFetch": "🌐"}
+    alias = tool_marker_aliases.get(name, "")
+    matches_name = line.startswith("🔄 " + name)
+    matches_alias = alias and line.startswith("🔄 " + alias)
+    assert not matches_name
+    assert matches_alias
+
+
+def test_bash_grep_glob_read_still_match_directly():
+    """Tools whose rolling-log line uses '🔄 {name}: …' prefix continue to
+    match via the direct ``startswith('🔄 ' + name)`` path (no regression)."""
+    direct_match_cases = [
+        ("Bash", "🔄 Bash: `ls`"),
+        ("Read", "🔄 Read: `/tmp/foo`"),
+        ("Grep", "🔄 Grep: `TODO`"),
+        ("Glob", "🔄 Glob: `**/*.py`"),
+        ("Write", "🔄 Write: `/tmp/new.py`"),
+        ("Edit", "🔄 Edit: `/foo.py`"),
+    ]
+    for name, line in direct_match_cases:
+        assert line.startswith("🔄 " + name), (
+            f"Direct match must work for {name}: line={line!r}"
+        )
+
+
+def test_short_result_inline_arrow_display():
+    """When result content is short (<200 chars), single-line, non-empty,
+    rolling log renders ``✅ {name} → {content}`` instead of bare ``✅ {name}``.
+
+    Pure-string logic test — the production code in render_response is
+    integration-tested elsewhere; this pins the threshold semantics.
+    """
+    # Simulate the production decision logic
+    def should_inline(content):
+        return (
+            content is not None
+            and len(content) < 200
+            and "\n" not in content
+            and content.strip() != ""
+        )
+
+    assert should_inline("42")                # tiny ✅
+    assert should_inline("Found 7 matches")   # short prose ✅
+    assert should_inline("x" * 199)           # boundary
+    assert not should_inline("x" * 200)       # over threshold
+    assert not should_inline("line1\nline2")  # multiline excluded
+    assert not should_inline("")              # empty excluded
+    assert not should_inline("   \t")         # whitespace-only excluded
+    assert not should_inline(None)            # None excluded
+
+
+def test_short_result_backtick_escape():
+    """Inline display strips backticks from content to avoid breaking the
+    rolling-log embed's markdown rendering."""
+    raw = "result with `backticks` inside"
+    safe = raw.strip().replace("`", "'")
+    assert "`" not in safe
+    assert safe == "result with 'backticks' inside"

--- a/tests/test_tool_result_shorttier.py
+++ b/tests/test_tool_result_shorttier.py
@@ -91,3 +91,122 @@ def test_short_result_backtick_escape():
     safe = raw.strip().replace("`", "'")
     assert "`" not in safe
     assert safe == "result with 'backticks' inside"
+
+
+def test_skill_and_fallback_rolling_log_match():
+    """R1 engineer audit: Skill (line 821) appends as '🔄 Skill: {name}' and
+    the unnamed-tool fallback (line 841) appends as '🔄 {name}...'. Both
+    should match the direct `startswith('🔄 ' + name)` path. Pin so a future
+    rolling-log format change doesn't silently reintroduce the stuck-🔄 bug
+    for these tools."""
+    direct_cases = [
+        ("Skill", "🔄 Skill: my-skill-name"),
+        ("UnknownTool", "🔄 UnknownTool..."),
+    ]
+    for name, line in direct_cases:
+        assert line.startswith("🔄 " + name), (
+            f"{name}: direct match must succeed (line={line!r})"
+        )
+
+
+@pytest.mark.asyncio
+async def test_short_tier_integration_via_render_response():
+    """R1 tester gap closure: drive the actual `render_response` ToolResultBlock
+    path with a short Bash result and verify the rolling-log line ends with
+    `→ {content}` (not bare `✅ Bash`).
+
+    Uses the same minimal-bridge / FakeMessageable scaffolding as
+    test_subagent_threads.py so the production path is exercised end-to-end.
+    """
+    import sys
+    sys.path.insert(0, "src")
+    from unittest.mock import MagicMock, AsyncMock
+    from claude_agent_sdk.types import (
+        AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
+    )
+    from clauded.discord_renderer import DiscordRenderer
+
+    class FakeBridge:
+        def __init__(self, events):
+            self._events = events
+            self.is_active = True
+            self._client = MagicMock()
+        async def send_message(self, text):
+            for ev in self._events:
+                yield ev
+
+    class FakeMessage:
+        def __init__(self):
+            self.content = ""
+            self.embeds = []
+        async def edit(self, **kwargs):
+            if "content" in kwargs:
+                self.content = kwargs["content"]
+            if "embed" in kwargs:
+                self.embeds = [kwargs["embed"]]
+            return self
+        async def delete(self):
+            return None
+
+    class FakeTarget:
+        def __init__(self):
+            self.id = 1
+            self._sent = []
+        async def send(self, *args, **kwargs):
+            msg = FakeMessage()
+            if "content" in kwargs:
+                msg.content = kwargs["content"]
+            if "embed" in kwargs:
+                msg.embeds = [kwargs["embed"]]
+            self._sent.append(msg)
+            return msg
+
+    events = [
+        AssistantMessage(
+            content=[
+                ToolUseBlock(
+                    id="tool-1", name="Bash",
+                    input={"command": "echo 42"},
+                ),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[
+                ToolResultBlock(tool_use_id="tool-1", content="42", is_error=False),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result",
+            duration_ms=100,
+            duration_api_ms=80,
+            is_error=False,
+            num_turns=1,
+            session_id="sess-1",
+            total_cost_usd=0.001,
+        ),
+    ]
+
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+    bridge = FakeBridge(events)
+    await renderer.render_response(bridge, "run echo 42")
+
+    # Find the rolling-log embed: the message whose embed.title is
+    # "🔧 Tool Activity"; assert its description contains "✅ Bash → 42".
+    rolling_log_embeds = [
+        m for m in target._sent
+        if m.embeds and (m.embeds[0].title or "") == "🔧 Tool Activity"
+    ]
+    assert rolling_log_embeds, (
+        f"Expected a Tool Activity rolling-log embed; got: "
+        f"{[(m.embeds[0].title if m.embeds else None) for m in target._sent]}"
+    )
+    final_log = rolling_log_embeds[-1].embeds[0].description
+    assert "✅ Bash → 42" in final_log, (
+        f"Expected '✅ Bash → 42' inline-arrow display in rolling log; "
+        f"got: {final_log!r}"
+    )


### PR DESCRIPTION
Closes part of #161 (short tier + bonus bug). Medium/long/xlong tiers deferred to v1.19 follow-up.

## Bonus bug
WebSearch/WebFetch rolling-log lines start with '🔄 🔍'/'🔄 🌐' (emoji prefix). Old `startswith('🔄 ' + name)` never matched → status stuck at 🔄 forever. New alias-aware match via `tool_marker_aliases = {'WebSearch': '🔍', 'WebFetch': '🌐'}`. Bash/Grep/Glob/Read/Write/Edit unaffected (already worked).

## Short tier
Result < 200 chars + single line + non-empty → rolling log shows `✅ Bash → 42` instead of `✅ Bash`. Backticks escaped to single-quotes.

## Tests
+5 dedicated tests pinning both bug paths + threshold edge cases.

501 pass / 2 pre-existing P1.

## Out of scope (v1.19 follow-up PR for #161)
- Medium/long/xlong tiers (spoiler/button/attachment)
- Sub-agent path parity (discord_renderer.py:462)
- Per-tool threshold overrides (Read 100, WebFetch 500, etc.)