### PR TITLE
v1.18: /btw side-question slash command (#163 sub-task 1 of 4)

### DIFF
--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -235,7 +235,7 @@ class ClaudedBot(commands.Bot):
         from .cogs.ops import (
             cost_group, health_check, review_pr, plugin_group,
             send_to_claude, pin_message, ratelimit_info,
-            debug_toggle, notify_toggle, unbound_fallback_toggle,
+            debug_toggle, notify_toggle, unbound_fallback_toggle, btw_cmd,
         )
 
         self.tree.add_command(project_group)
@@ -261,6 +261,7 @@ class ClaudedBot(commands.Bot):
         self.tree.add_command(debug_toggle)
         self.tree.add_command(notify_toggle)
         self.tree.add_command(unbound_fallback_toggle)
+        self.tree.add_command(btw_cmd)
         synced = await self.tree.sync()
         log.info("Synced %d application command(s)", len(synced))
 

--- a/src/clauded/cogs/ops.py
+++ b/src/clauded/cogs/ops.py
@@ -514,20 +514,45 @@ async def btw_cmd(interaction: discord.Interaction, text: str) -> None:
 
     # Forward to the bridge with the CLI's native /btw prefix. The bundled
     # claude CLI recognizes this and opens a side-track in-session.
+    # R1 engineer + architect + tester all flagged: must hold the per-thread
+    # lock around the entire render_response cycle so a concurrent main-turn
+    # user message can't race in and double-dispatch into ``bridge.send_message``.
+    # All other ``render_response`` call sites in the project hold this lock
+    # (bot.py:_handle_thread_message, ops.py:send_to_claude, _recreate_session);
+    # /btw must follow the same discipline.
     forwarded = f"/btw {text}"
     renderer = DiscordRenderer(channel)
-    try:
-        await renderer.render_response(bridge, forwarded)
-    except Exception:
-        log.exception("/btw render failed")
-        try:
-            await channel.send(
-                embed=discord.Embed(
-                    title="❌ /btw failed",
-                    description="The side-track question couldn't complete. "
-                    "The main session is still alive.",
-                    color=COLOR_TOOL_FAILURE,
+    async with bot.session_manager.get_lock(thread_id):
+        # Re-check bridge inside the lock — a concurrent /session stop or
+        # bridge crash between the pre-lock check and the await could have
+        # cleared the session. Failing soft is better than crashing into the
+        # outer except (which would also try to send to the dead thread).
+        bridge_locked = bot.session_manager.get_session(thread_id)
+        if bridge_locked is None or not bridge_locked.is_active:
+            try:
+                await channel.send(
+                    embed=discord.Embed(
+                        title="❌ /btw raced with session shutdown",
+                        description="The active Claude session ended before "
+                        "the side-track could start. Start a new turn and retry.",
+                        color=COLOR_TOOL_FAILURE,
+                    )
                 )
-            )
+            except Exception:
+                pass
+            return
+        try:
+            await renderer.render_response(bridge_locked, forwarded)
         except Exception:
-            pass
+            log.exception("/btw render failed")
+            try:
+                await channel.send(
+                    embed=discord.Embed(
+                        title="❌ /btw failed",
+                        description="The side-track question couldn't complete. "
+                        "The main session is still alive.",
+                        color=COLOR_TOOL_FAILURE,
+                    )
+                )
+            except Exception:
+                pass

--- a/src/clauded/cogs/ops.py
+++ b/src/clauded/cogs/ops.py
@@ -438,3 +438,96 @@ async def unbound_fallback_toggle(
         color=COLOR_INFO,
     )
     await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+# ---------------------------------------------------------------------------
+# /btw — transparent forward of side-question to Claude CLI (#163 sub-task 1)
+# ---------------------------------------------------------------------------
+
+@app_commands.command(
+    name="btw",
+    description="Ask a quick side question without interrupting the main conversation.",
+)
+@app_commands.describe(text="The side question (forwarded to Claude with /btw prefix)")
+async def btw_cmd(interaction: discord.Interaction, text: str) -> None:
+    """Transparent forward of `/btw <text>` to the Claude CLI in this thread.
+
+    Mode B1 (per #163): the bundled Claude Code CLI natively recognizes the
+    `/btw` prefix and opens a side-track that answers the question without
+    interrupting the main agent's turn. claudeD just forwards `f"/btw {text}"`
+    as a user message via the existing bridge — zero semantic divergence from
+    direct CLI use.
+
+    Requires:
+      - Active session in this thread (use a thread that already had a Claude
+        @-mention or send-to-claude turn).
+      - User invoking from inside a thread (not a top-level channel; the side
+        question belongs to whatever conversation is happening in the thread).
+    """
+    from ..bot import ClaudedBot
+    from ..discord_renderer import DiscordRenderer
+
+    log.info(
+        "/btw text-len=%d channel=%s",
+        len(text), interaction.channel_id,
+    )
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("❌ Bot not ready.", ephemeral=True)
+        return
+
+    # Must be invoked from inside a thread (where there's an active session).
+    channel = interaction.channel
+    if not isinstance(channel, discord.Thread):
+        await interaction.response.send_message(
+            "❌ `/btw` must be used inside a thread. Start (or resume) a Claude "
+            "thread first, then invoke `/btw <question>` there.",
+            ephemeral=True,
+        )
+        return
+
+    # Empty / whitespace-only text → reject with usage hint.
+    if not text or not text.strip():
+        await interaction.response.send_message(
+            "❌ Side question text is empty. Usage: `/btw <your question>`",
+            ephemeral=True,
+        )
+        return
+
+    thread_id = channel.id
+    bridge = bot.session_manager.get_session(thread_id)
+    if bridge is None or not bridge.is_active:
+        await interaction.response.send_message(
+            "❌ No active Claude session in this thread. Send a regular message "
+            "to start (or `/session resume`), then try `/btw` again.",
+            ephemeral=True,
+        )
+        return
+
+    # Acknowledge synchronously — the actual side-track render runs as a
+    # background task because the slash interaction must respond within 3s but
+    # Claude's reply takes much longer.
+    await interaction.response.send_message(
+        f"💬 Forwarding side question to Claude: `{text[:200]}{'…' if len(text) > 200 else ''}`",
+        ephemeral=True,
+    )
+
+    # Forward to the bridge with the CLI's native /btw prefix. The bundled
+    # claude CLI recognizes this and opens a side-track in-session.
+    forwarded = f"/btw {text}"
+    renderer = DiscordRenderer(channel)
+    try:
+        await renderer.render_response(bridge, forwarded)
+    except Exception:
+        log.exception("/btw render failed")
+        try:
+            await channel.send(
+                embed=discord.Embed(
+                    title="❌ /btw failed",
+                    description="The side-track question couldn't complete. "
+                    "The main session is still alive.",
+                    color=COLOR_TOOL_FAILURE,
+                )
+            )
+        except Exception:
+            pass

--- a/tests/test_btw_command.py
+++ b/tests/test_btw_command.py
@@ -190,3 +190,108 @@ async def test_btw_truncates_long_text_in_ack(bot: ClaudedBot, monkeypatch: pyte
     # Verify truncation happens at 200 chars (allows ack_msg to stay short)
     assert "x" * 200 in ack_msg
     assert "x" * 250 not in ack_msg
+
+
+@pytest.mark.asyncio
+async def test_btw_acquires_per_thread_lock(bot: ClaudedBot, monkeypatch: pytest.MonkeyPatch) -> None:
+    """R1 engineer/architect/tester regression pin: /btw MUST hold
+    ``session_manager.get_lock(thread_id)`` around the render_response cycle
+    so a concurrent main-turn message can't race-call ``bridge.send_message``.
+
+    Pin via the visible side-effect: pre-acquire the lock from a separate
+    task; /btw's render_response should NOT execute until the test releases
+    it. Concretely: render_response is only awaited after we release the
+    blocking acquire — if /btw weren't using get_lock, render would run
+    immediately and the assertion order would be wrong.
+    """
+    import asyncio
+    from clauded.cogs import ops as ops_mod
+    from clauded import discord_renderer as dr_mod
+    interaction = _make_thread_interaction(bot, thread_id=99999)
+    active_bridge = MagicMock()
+    active_bridge.is_active = True
+    bot.session_manager._sessions[99999] = active_bridge
+
+    render_started = asyncio.Event()
+
+    class _SignallingRenderer:
+        def __init__(self, target):
+            pass
+        async def render_response(self, bridge, user_text):
+            render_started.set()
+    monkeypatch.setattr(dr_mod, "DiscordRenderer", _SignallingRenderer, raising=False)
+
+    # Pre-hold the per-thread lock from a separate task.
+    lock = bot.session_manager.get_lock(99999)
+    held = asyncio.Event()
+    release_pre_lock = asyncio.Event()
+
+    async def pre_hold_lock():
+        async with lock:
+            held.set()
+            await release_pre_lock.wait()
+
+    holder_task = asyncio.create_task(pre_hold_lock())
+    await held.wait()  # ensure the lock is held before /btw fires
+
+    # Now invoke /btw. If it acquires the lock, render_started must NOT be set
+    # while the pre-hold task is still holding the lock.
+    btw_task = asyncio.create_task(ops_mod.btw_cmd.callback(interaction, "test"))
+    # Give /btw a moment to reach the lock
+    await asyncio.sleep(0.05)
+    assert not render_started.is_set(), (
+        "/btw must wait on the lock; if render_started was set, /btw is "
+        "bypassing the lock (R1 engineer/architect/tester regression)"
+    )
+
+    # Release the pre-hold; now /btw should proceed and complete
+    release_pre_lock.set()
+    await holder_task
+    await btw_task
+    assert render_started.is_set(), "render must run after lock is freed"
+
+
+@pytest.mark.asyncio
+async def test_btw_handles_race_with_session_shutdown(
+    bot: ClaudedBot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """R2: if bridge is cleared between the pre-lock active-session check
+    and lock acquisition (e.g. concurrent /session stop), surface a
+    distinct error instead of crashing."""
+    from clauded.cogs import ops as ops_mod
+    from clauded import discord_renderer as dr_mod
+    interaction = _make_thread_interaction(bot, thread_id=88888)
+
+    # Pre-lock: bridge exists
+    active_bridge = MagicMock()
+    active_bridge.is_active = True
+    bot.session_manager._sessions[88888] = active_bridge
+
+    # Inside the lock, simulate the bridge being torn down (e.g. by
+    # /session stop running concurrently). The /btw handler should detect
+    # this and emit the "raced with session shutdown" message.
+    class _NoopRenderer:
+        def __init__(self, target):
+            pass
+        async def render_response(self, bridge, user_text):
+            raise AssertionError("render_response should NOT run when bridge is gone")
+    monkeypatch.setattr(dr_mod, "DiscordRenderer", _NoopRenderer, raising=False)
+
+    # Monkey-patch get_session to return None ONLY for the in-lock re-check.
+    # First call (pre-lock) returns the active bridge; second (in-lock) returns None.
+    call_count = {"n": 0}
+    original_get_session = bot.session_manager.get_session
+    def fake_get_session(tid):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return active_bridge
+        return None
+    monkeypatch.setattr(bot.session_manager, "get_session", fake_get_session)
+
+    await ops_mod.btw_cmd.callback(interaction, "test")
+    # Verify the race-message embed was sent to the channel (via thread.send mock)
+    thread_send = interaction.channel.send
+    assert thread_send.await_count == 1
+    sent_embed = thread_send.call_args.kwargs.get("embed")
+    assert sent_embed is not None
+    assert "raced with session shutdown" in sent_embed.title

--- a/tests/test_btw_command.py
+++ b/tests/test_btw_command.py
@@ -1,0 +1,192 @@
+"""Tests for /btw side-question slash command (#163 sub-task 1).
+
+The command is transparent-forward: when invoked in a thread with an active
+Claude session, sends `/btw {text}` as a user message via the bridge. The
+bundled CLI natively recognizes the prefix and opens a side-track.
+
+Tests pin the precondition checks (must be in thread, must have active
+session, text must be non-empty) and the forwarding contract.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from clauded.bot import ClaudedBot
+from clauded.config import Config
+from clauded.cost_tracker import CostTracker
+from clauded.project_manager import ProjectManager
+from clauded.session_manager import SessionManager
+
+
+@pytest.fixture
+def bot(tmp_path: Path) -> ClaudedBot:
+    cfg = Config(
+        discord_bot_token="tok", claude_model="sonnet",
+        claude_permission_mode="default", projects_root=str(tmp_path),
+        allow_unbound_fallback=False,
+    )
+    pm = ProjectManager(data_dir=str(tmp_path / "data"), projects_root=str(tmp_path))
+    bot = ClaudedBot.__new__(ClaudedBot)
+    bot.config = cfg
+    bot.project_manager = pm
+    bot.session_manager = SessionManager()
+    bot.cost_tracker = CostTracker()
+    bot.agent_manager = MagicMock()
+    bot._start_time = 0.0
+    bot._claude_version = "test"
+    bot._debug_logging = False
+    bot._pre_tool_notifications = False
+    bot._notify_enabled = {}
+    bot.allow_unbound_fallback = False
+    bot._connection = MagicMock()
+    return bot
+
+
+def _make_thread_interaction(bot: ClaudedBot, thread_id: int = 11111) -> MagicMock:
+    """Build an interaction whose .channel is a discord.Thread."""
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = thread_id
+    thread.parent_id = 22222
+    thread.send = AsyncMock()
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = bot
+    interaction.channel = thread
+    interaction.channel_id = thread_id
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+def _make_text_channel_interaction(bot: ClaudedBot) -> MagicMock:
+    """Build an interaction whose .channel is a TextChannel (not a thread)."""
+    ch = MagicMock(spec=discord.TextChannel)
+    ch.id = 33333
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = bot
+    interaction.channel = ch
+    interaction.channel_id = 33333
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_btw_rejects_when_not_in_thread(bot: ClaudedBot) -> None:
+    """/btw outside a thread → friendly error, no rendering."""
+    from clauded.cogs.ops import btw_cmd
+    interaction = _make_text_channel_interaction(bot)
+    await btw_cmd.callback(interaction, "test question")
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.call_args[0][0]
+    assert "must be used inside a thread" in msg
+    assert "❌" in msg
+
+
+@pytest.mark.asyncio
+async def test_btw_rejects_empty_text(bot: ClaudedBot) -> None:
+    """/btw with empty text → usage hint, no rendering."""
+    from clauded.cogs.ops import btw_cmd
+    interaction = _make_thread_interaction(bot)
+    await btw_cmd.callback(interaction, "   ")
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.call_args[0][0]
+    assert "empty" in msg.lower()
+    assert "Usage:" in msg
+
+
+@pytest.mark.asyncio
+async def test_btw_rejects_when_no_active_session(bot: ClaudedBot) -> None:
+    """/btw with no session in thread → friendly error guiding to /session resume."""
+    from clauded.cogs.ops import btw_cmd
+    interaction = _make_thread_interaction(bot)
+    # session_manager has no entry for this thread_id
+    await btw_cmd.callback(interaction, "test")
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.call_args[0][0]
+    assert "No active Claude session" in msg
+    assert "session resume" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_btw_rejects_when_session_inactive(bot: ClaudedBot) -> None:
+    """/btw with bridge present but not is_active → friendly error."""
+    from clauded.cogs.ops import btw_cmd
+    interaction = _make_thread_interaction(bot)
+    inactive_bridge = MagicMock()
+    inactive_bridge.is_active = False
+    bot.session_manager._sessions[interaction.channel.id] = inactive_bridge
+    await btw_cmd.callback(interaction, "test")
+    msg = interaction.response.send_message.call_args[0][0]
+    assert "No active Claude session" in msg
+
+
+@pytest.mark.asyncio
+async def test_btw_forwards_with_btw_prefix_to_active_session(
+    bot: ClaudedBot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Happy path: active session + valid text → render_response called with
+    `/btw {text}` as user_text. The CLI's bundled binary handles the prefix
+    natively (we test the forward-shape contract, not the SDK).
+    """
+    from clauded.cogs import ops as ops_mod
+    interaction = _make_thread_interaction(bot)
+    active_bridge = MagicMock()
+    active_bridge.is_active = True
+    bot.session_manager._sessions[interaction.channel.id] = active_bridge
+
+    # Monkey-patch DiscordRenderer.render_response to capture the user_text.
+    captured = {}
+    class FakeRenderer:
+        def __init__(self, target):
+            captured["target"] = target
+        async def render_response(self, bridge, user_text):
+            captured["bridge"] = bridge
+            captured["user_text"] = user_text
+    monkeypatch.setattr(ops_mod, "DiscordRenderer", FakeRenderer, raising=False)
+    # ops_mod imports DiscordRenderer inside the function — patch the source.
+    from clauded import discord_renderer as dr_mod
+    monkeypatch.setattr(dr_mod, "DiscordRenderer", FakeRenderer, raising=False)
+
+    await ops_mod.btw_cmd.callback(interaction, "what time is it")
+
+    # Acknowledged the interaction (forwarding banner)
+    interaction.response.send_message.assert_awaited_once()
+    ack_msg = interaction.response.send_message.call_args[0][0]
+    assert "Forwarding side question" in ack_msg
+
+    # Verify forward-shape: user_text starts with "/btw " and contains the query
+    assert captured.get("bridge") is active_bridge
+    assert captured.get("user_text", "").startswith("/btw "), (
+        f"expected '/btw '-prefixed forward, got: {captured.get('user_text')!r}"
+    )
+    assert "what time is it" in captured.get("user_text", "")
+
+
+@pytest.mark.asyncio
+async def test_btw_truncates_long_text_in_ack(bot: ClaudedBot, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Acknowledgement banner truncates text > 200 chars with ellipsis."""
+    from clauded.cogs import ops as ops_mod
+    from clauded import discord_renderer as dr_mod
+    interaction = _make_thread_interaction(bot)
+    active_bridge = MagicMock()
+    active_bridge.is_active = True
+    bot.session_manager._sessions[interaction.channel.id] = active_bridge
+
+    class _NoopRenderer:
+        def __init__(self, target):
+            pass
+        async def render_response(self, bridge, user_text):
+            return None
+    monkeypatch.setattr(dr_mod, "DiscordRenderer", _NoopRenderer, raising=False)
+
+    long_text = "x" * 300
+    await ops_mod.btw_cmd.callback(interaction, long_text)
+    ack_msg = interaction.response.send_message.call_args[0][0]
+    assert "…" in ack_msg, "long text should be truncated with ellipsis"
+    # Verify truncation happens at 200 chars (allows ack_msg to stay short)
+    assert "x" * 200 in ack_msg
+    assert "x" * 250 not in ack_msg


### PR DESCRIPTION
Closes 1st of #163's 4 sub-tasks (each ships own PR per epic directive).

## Design
Mode B1 transparent-forward. `/btw <text>` slash command inside a thread with active session → bridge receives `f'/btw {text}'`. Bundled Claude CLI natively recognizes prefix and opens side-track. Zero divergence from direct CLI use.

## Preconditions
- Must be inside thread, not channel
- Thread must have active bridge
- Non-empty text

Each failure: ephemeral friendly error with guidance.

## Tests
+6 in `test_btw_command.py` pinning all 4 preconditions + happy-path forward shape + ack truncation.

509 pass / 2 pre-existing P1.

## Out of scope (remaining 3 sub-tasks)
- /session clear (#163 sub-task 2)
- /context (#163 sub-task 3)
- /diff (#163 sub-task 4)
Each ships in own PR.