### PR TITLE
v1.18: /context — visualize context-window usage (#163 sub-task 3 of 4)

### DIFF
--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -232,6 +232,7 @@ class ClaudedBot(commands.Bot):
         from .cogs.agent import agent_group
         from .cogs.mcp import mcp_group
         from .cogs.skill import skill_group
+        from .cogs.context import context_cmd
         from .cogs.ops import (
             cost_group, health_check, review_pr, plugin_group,
             send_to_claude, pin_message, ratelimit_info,
@@ -262,6 +263,7 @@ class ClaudedBot(commands.Bot):
         self.tree.add_command(notify_toggle)
         self.tree.add_command(unbound_fallback_toggle)
         self.tree.add_command(btw_cmd)
+        self.tree.add_command(context_cmd)
         synced = await self.tree.sync()
         log.info("Synced %d application command(s)", len(synced))
 

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -166,6 +166,24 @@ class ClaudeBridge:
             return None
         return await client.get_server_info()
 
+    async def get_context_usage(self) -> dict | None:
+        """Return current context-window usage, or ``None`` if not connected.
+
+        Public wrapper for ``_client.get_context_usage()`` (added in v1.18
+        for ``/context`` slash command, #163 sub-task 3). Like
+        ``get_server_info``, this keeps callers out of the bridge's private
+        state.
+
+        Unlike ``get_server_info`` (which is a cached init-result read),
+        ``get_context_usage`` makes an actual SDK request to compute current
+        token counts. It's safe to invoke alongside an active ``send_message``
+        stream, but the call may be slower (~tens of ms).
+        """
+        client = self._client
+        if client is None or not self._active:
+            return None
+        return await client.get_context_usage()
+
     async def start(self) -> None:
         """Create and connect the underlying ``ClaudeSDKClient``."""
         full_system_prompt = (self.system_prompt or "") + _CHANNEL_MGMT_PROMPT

--- a/src/clauded/cogs/context.py
+++ b/src/clauded/cogs/context.py
@@ -1,0 +1,211 @@
+"""/context slash command — visualize Claude context-window usage.
+
+PRD: #163 sub-task 3. Mirrors the bundled Claude CLI's `/context` semantics:
+shows a colored grid / progress bar of current context-window usage so
+users can self-manage long sessions and know when to `/session clear` or
+`/session compact`.
+
+Implementation follows the v1.13 ``/skill list`` two-path pattern:
+
+1. **Path A** — piggyback on the channel's active bridge via
+   ``bridge.get_context_usage()``. Fast (~tens of ms), uses the
+   already-warm SDK client.
+2. **Path B** — when no active session, spin up a temporary
+   ``ClaudeSDKClient`` with ``setting_sources`` matching the channel's
+   bound state. Slower (~2-4 s cold start), but lets users check
+   baseline context budget for the model without first sending a
+   message.
+
+The CLI's ``/context`` returns a structured ``ContextUsageResponse``:
+
+    {
+      'categories': [{'name': str, 'tokens': int, 'color': str}, ...],
+      'totalTokens': int,
+      'maxTokens': int,
+      'percentage': float,
+      'model': str,
+      'mcpTools': {...}, 'memoryFiles': {...}, 'agents': {...},
+    }
+
+We render the percentage + an ASCII progress bar + top-5 categories by
+token count. Detailed breakdowns (MCP tools, memory files, per-agent)
+are out of scope for v1; they'd bloat the embed. v1.19 can add
+``/context --detail`` if useful.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord import app_commands
+
+from claude_agent_sdk import (
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    CLIConnectionError,
+    CLINotFoundError,
+)
+
+from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE
+from ._unbound import NO_CHANNEL_MESSAGE, resolve_channel_id
+
+log = logging.getLogger("clauded.bot")
+
+
+_PROGRESS_BAR_WIDTH = 20
+_TOP_N_CATEGORIES = 5
+
+
+def _format_progress_bar(percentage: float, width: int = _PROGRESS_BAR_WIDTH) -> str:
+    """Render an ASCII progress bar for a 0-100 percentage.
+
+    Uses block characters so the bar reads cleanly in Discord's monospace
+    embed field. Caps at 100% even if SDK reports overflow.
+    """
+    pct = max(0.0, min(100.0, percentage))
+    filled = int(round(pct / 100.0 * width))
+    return "█" * filled + "░" * (width - filled)
+
+
+def _format_tokens(n: int) -> str:
+    """Format token count: 92531 -> 92.5k, 523 -> 523."""
+    if n >= 1000:
+        return f"{n/1000:.1f}k"
+    return str(n)
+
+
+def _build_context_embed(usage: dict, source_label: str) -> discord.Embed:
+    """Render a ContextUsageResponse dict into a Discord embed.
+
+    ``source_label`` indicates which path generated the data ("active session"
+    vs "fresh session"). Surface this so users understand whether the
+    numbers reflect their actual conversation state or just the model's
+    baseline budget.
+    """
+    total = int(usage.get("totalTokens", 0))
+    max_tokens = int(usage.get("maxTokens", 0))
+    percentage = float(usage.get("percentage", 0))
+    model = str(usage.get("model", "unknown"))
+
+    bar = _format_progress_bar(percentage)
+    pct_color = (
+        COLOR_TOOL_FAILURE if percentage >= 90
+        else 0xF59E0B if percentage >= 75  # yellow warn
+        else COLOR_INFO
+    )
+
+    embed = discord.Embed(
+        title=f"📊 Context: {percentage:.1f}%",
+        description=(
+            f"`{bar}` {_format_tokens(total)} / {_format_tokens(max_tokens)} tokens\n"
+            f"-# Model: `{model}` · Source: {source_label}"
+        ),
+        color=pct_color,
+    )
+
+    # Top-N categories by token count (defensive on shape — empty list OK)
+    categories = usage.get("categories") or []
+    if categories:
+        sorted_cats = sorted(
+            categories,
+            key=lambda c: int(c.get("tokens", 0)),
+            reverse=True,
+        )
+        lines = []
+        for cat in sorted_cats[:_TOP_N_CATEGORIES]:
+            name = str(cat.get("name", "?"))
+            tokens = int(cat.get("tokens", 0))
+            cat_pct = (tokens / max_tokens * 100) if max_tokens else 0
+            lines.append(f"• `{name}` — {_format_tokens(tokens)} ({cat_pct:.1f}%)")
+        if len(sorted_cats) > _TOP_N_CATEGORIES:
+            lines.append(f"-# … and {len(sorted_cats) - _TOP_N_CATEGORIES} more")
+        embed.add_field(
+            name="Top categories",
+            value="\n".join(lines),
+            inline=False,
+        )
+
+    return embed
+
+
+@app_commands.command(
+    name="context",
+    description="Visualize Claude context-window usage (current session or model baseline).",
+)
+async def context_cmd(interaction: discord.Interaction) -> None:
+    """Show context-window usage as a colored progress bar + top-5 categories.
+
+    Path A (active session): uses the live bridge's `get_context_usage`.
+    Path B (no active session): spins up a temp ClaudeSDKClient to query
+    baseline budget for the bound (or fallback) cwd.
+
+    Errors (CLI not installed, connection refused, malformed response):
+    surface as a red embed instead of crashing the interaction.
+    """
+    from ..bot import ClaudedBot
+
+    log.info("/context channel=%s", interaction.channel_id)
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("❌ Bot not ready.", ephemeral=True)
+        return
+
+    channel_id = resolve_channel_id(interaction)
+    if channel_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
+        return
+
+    # Defer immediately — Path B can take 2-4 s for cold CLI startup, and
+    # Discord's 3s response deadline would otherwise time out.
+    await interaction.response.defer(ephemeral=True)
+
+    # Path A: active bridge piggyback (cheap, ~tens of ms).
+    bridge = bot.session_manager.get_session(channel_id)
+    usage = None
+    source_label = "active session"
+    if bridge is not None:
+        try:
+            usage = await bridge.get_context_usage()
+        except Exception:  # noqa: BLE001 — fail-soft to Path B
+            log.warning("/context Path A failed; falling back to temp client", exc_info=True)
+            usage = None
+
+    # Path B: temp client fallback (mirrors /skill list pattern).
+    if usage is None:
+        source_label = "fresh session (model baseline)"
+        cwd, is_bound = bot.project_manager.get_path_or_default(channel_id)
+        setting_sources = ["user", "project", "local"] if is_bound else ["user"]
+        try:
+            async with ClaudeSDKClient(
+                ClaudeAgentOptions(cwd=str(cwd), setting_sources=setting_sources)
+            ) as tmp:
+                usage = await tmp.get_context_usage()
+        except (CLINotFoundError, CLIConnectionError, Exception) as exc:  # noqa: BLE001
+            log.warning("/context Path B failed", exc_info=True)
+            await interaction.followup.send(
+                embed=discord.Embed(
+                    title="❌ Context unavailable",
+                    description=f"`{type(exc).__name__}`",
+                    color=COLOR_TOOL_FAILURE,
+                ),
+                ephemeral=True,
+            )
+            return
+
+    if usage is None:
+        await interaction.followup.send(
+            embed=discord.Embed(
+                title="❌ Context unavailable",
+                description="`NoUsage`: get_context_usage() returned None",
+                color=COLOR_TOOL_FAILURE,
+            ),
+            ephemeral=True,
+        )
+        return
+
+    embed = _build_context_embed(usage, source_label=source_label)
+    await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+__all__ = ["context_cmd"]

--- a/tests/test_context_cmd.py
+++ b/tests/test_context_cmd.py
@@ -1,0 +1,287 @@
+"""Tests for /context (#163 sub-task 3).
+
+Visualizes Claude context-window usage. Two paths:
+- Path A: active bridge piggyback (fast, current session state)
+- Path B: temp ClaudeSDKClient (slow, model baseline)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from clauded.bot import ClaudedBot
+from clauded.config import Config
+from clauded.cost_tracker import CostTracker
+from clauded.project_manager import ProjectManager
+from clauded.session_manager import SessionManager
+from clauded.session_store import SessionStore
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — no SDK interaction
+# ---------------------------------------------------------------------------
+
+
+def test_format_progress_bar_zero_and_full():
+    from clauded.cogs.context import _format_progress_bar
+    assert _format_progress_bar(0) == "░" * 20
+    assert _format_progress_bar(100) == "█" * 20
+    assert _format_progress_bar(50) == "█" * 10 + "░" * 10
+
+
+def test_format_progress_bar_caps_at_100():
+    from clauded.cogs.context import _format_progress_bar
+    # SDK could report >100 if context overflows; bar should cap.
+    assert _format_progress_bar(150) == "█" * 20
+    assert _format_progress_bar(-5) == "░" * 20
+
+
+def test_format_tokens_humanizes_thousands():
+    from clauded.cogs.context import _format_tokens
+    assert _format_tokens(523) == "523"
+    assert _format_tokens(2235) == "2.2k"
+    assert _format_tokens(92531) == "92.5k"
+
+
+def test_build_embed_uses_red_at_90_pct():
+    """High context usage → red color to signal urgency."""
+    from clauded.cogs.context import _build_context_embed
+    from clauded.discord_renderer import COLOR_TOOL_FAILURE
+    usage = {
+        "totalTokens": 180000, "maxTokens": 200000,
+        "percentage": 90.0, "model": "claude-sonnet",
+        "categories": [],
+    }
+    embed = _build_context_embed(usage, "active session")
+    assert embed.color.value == COLOR_TOOL_FAILURE
+    assert "90.0%" in embed.title
+
+
+def test_build_embed_uses_yellow_at_75_pct():
+    """Medium usage → yellow warn."""
+    from clauded.cogs.context import _build_context_embed
+    usage = {
+        "totalTokens": 150000, "maxTokens": 200000,
+        "percentage": 75.0, "model": "claude-sonnet",
+        "categories": [],
+    }
+    embed = _build_context_embed(usage, "active session")
+    assert embed.color.value == 0xF59E0B  # yellow
+
+
+def test_build_embed_includes_top_categories():
+    """Categories shown in description, sorted by tokens desc, top-5."""
+    from clauded.cogs.context import _build_context_embed
+    usage = {
+        "totalTokens": 50000, "maxTokens": 200000, "percentage": 25.0,
+        "model": "claude-sonnet",
+        "categories": [
+            {"name": "messages", "tokens": 30000},
+            {"name": "system", "tokens": 12000},
+            {"name": "tools", "tokens": 5000},
+            {"name": "memory", "tokens": 2000},
+            {"name": "agents", "tokens": 1000},
+        ],
+    }
+    embed = _build_context_embed(usage, "active session")
+    cat_field = next((f for f in embed.fields if f.name == "Top categories"), None)
+    assert cat_field is not None
+    assert "messages" in cat_field.value
+    # Sorted by tokens — messages (30k) appears before system (12k)
+    assert cat_field.value.find("messages") < cat_field.value.find("system")
+
+
+def test_build_embed_truncates_to_top_5_categories():
+    """7 categories → only top-5 + 'and N more' line."""
+    from clauded.cogs.context import _build_context_embed
+    usage = {
+        "totalTokens": 100, "maxTokens": 1000, "percentage": 10.0,
+        "model": "claude-sonnet",
+        "categories": [{"name": f"cat{i}", "tokens": 100 - i} for i in range(7)],
+    }
+    embed = _build_context_embed(usage, "active session")
+    cat_field = next((f for f in embed.fields if f.name == "Top categories"), None)
+    assert cat_field is not None
+    assert "and 2 more" in cat_field.value
+    # cat0 has highest tokens, should appear
+    assert "cat0" in cat_field.value
+    # cat5 should NOT appear (truncated)
+    assert "cat5" not in cat_field.value
+
+
+def test_build_embed_handles_empty_categories():
+    """No categories from SDK → embed still renders progress bar."""
+    from clauded.cogs.context import _build_context_embed
+    usage = {
+        "totalTokens": 0, "maxTokens": 200000, "percentage": 0.0,
+        "model": "claude-sonnet", "categories": [],
+    }
+    embed = _build_context_embed(usage, "fresh session")
+    assert embed.title == "📊 Context: 0.0%"
+    assert "200.0k" in embed.description
+    assert len(embed.fields) == 0
+
+
+# ---------------------------------------------------------------------------
+# Cog callback — Path A / Path B / error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bot(tmp_path: Path) -> ClaudedBot:
+    cfg = Config(
+        discord_bot_token="tok", claude_model="sonnet",
+        claude_permission_mode="default", projects_root=str(tmp_path),
+        allow_unbound_fallback=False,
+    )
+    pm = ProjectManager(data_dir=str(tmp_path / "data"), projects_root=str(tmp_path))
+    sm = SessionManager(session_store=SessionStore(data_dir=str(tmp_path / "data")))
+    bot = ClaudedBot.__new__(ClaudedBot)
+    bot.config = cfg
+    bot.project_manager = pm
+    bot.session_manager = sm
+    bot.cost_tracker = CostTracker()
+    bot.agent_manager = MagicMock()
+    bot._start_time = 0.0
+    bot._claude_version = "test"
+    bot._debug_logging = False
+    bot._pre_tool_notifications = False
+    bot._notify_enabled = {}
+    bot.allow_unbound_fallback = False
+    bot._connection = MagicMock()
+    return bot
+
+
+def _make_interaction(bot: ClaudedBot, channel_id: int) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = bot
+    interaction.channel_id = channel_id
+    # interaction.channel must satisfy resolve_channel_id (TextChannel-like)
+    ch = MagicMock(spec=discord.TextChannel)
+    ch.id = channel_id
+    interaction.channel = ch
+    interaction.guild_id = 4242
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_context_path_a_active_bridge(bot: ClaudedBot) -> None:
+    """Active bridge present → uses bridge.get_context_usage (no temp client)."""
+    from clauded.cogs.context import context_cmd
+    thread_id = 12345
+    fake_usage = {
+        "totalTokens": 45000, "maxTokens": 200000,
+        "percentage": 22.5, "model": "claude-sonnet",
+        "categories": [{"name": "messages", "tokens": 45000}],
+    }
+    mock_bridge = MagicMock()
+    mock_bridge.is_active = True
+    mock_bridge.get_context_usage = AsyncMock(return_value=fake_usage)
+    bot.session_manager._sessions[thread_id] = mock_bridge
+
+    interaction = _make_interaction(bot, thread_id)
+    await context_cmd.callback(interaction)
+
+    mock_bridge.get_context_usage.assert_awaited_once()
+    interaction.response.defer.assert_awaited_once()
+    interaction.followup.send.assert_awaited_once()
+    embed = interaction.followup.send.call_args.kwargs["embed"]
+    assert "22.5%" in embed.title
+    assert "active session" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_context_path_b_falls_back_when_no_bridge(
+    bot: ClaudedBot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No active bridge → spin up temp ClaudeSDKClient."""
+    from clauded.cogs import context as ctx_mod
+    fake_usage = {
+        "totalTokens": 1000, "maxTokens": 200000,
+        "percentage": 0.5, "model": "claude-sonnet", "categories": [],
+    }
+
+    class FakeTempClient:
+        def __init__(self, opts):
+            self.opts = opts
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return None
+        async def get_context_usage(self):
+            return fake_usage
+    monkeypatch.setattr(ctx_mod, "ClaudeSDKClient", FakeTempClient)
+
+    interaction = _make_interaction(bot, channel_id=99999)
+    await ctx_mod.context_cmd.callback(interaction)
+
+    interaction.followup.send.assert_awaited_once()
+    embed = interaction.followup.send.call_args.kwargs["embed"]
+    assert "0.5%" in embed.title
+    assert "fresh session" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_context_path_a_failure_falls_to_b(
+    bot: ClaudedBot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bridge present but get_context_usage raises → fall through to Path B."""
+    from clauded.cogs import context as ctx_mod
+    thread_id = 33333
+    mock_bridge = MagicMock()
+    mock_bridge.is_active = True
+    mock_bridge.get_context_usage = AsyncMock(side_effect=RuntimeError("oops"))
+    bot.session_manager._sessions[thread_id] = mock_bridge
+
+    fake_usage = {
+        "totalTokens": 500, "maxTokens": 100000,
+        "percentage": 0.5, "model": "claude-sonnet", "categories": [],
+    }
+
+    class FakeTempClient:
+        def __init__(self, opts): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return None
+        async def get_context_usage(self): return fake_usage
+    monkeypatch.setattr(ctx_mod, "ClaudeSDKClient", FakeTempClient)
+
+    interaction = _make_interaction(bot, thread_id)
+    await ctx_mod.context_cmd.callback(interaction)
+
+    mock_bridge.get_context_usage.assert_awaited_once()
+    embed = interaction.followup.send.call_args.kwargs["embed"]
+    assert "fresh session" in embed.description, (
+        "fallback to Path B must label source as 'fresh session'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_context_path_b_error_returns_red_embed(
+    bot: ClaudedBot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Temp client construction/query fails → red error embed (not crash)."""
+    from clauded.cogs import context as ctx_mod
+    from clauded.discord_renderer import COLOR_TOOL_FAILURE
+    from claude_agent_sdk import CLIConnectionError
+
+    class FakeTempClient:
+        def __init__(self, opts): pass
+        async def __aenter__(self):
+            raise CLIConnectionError("not running")
+        async def __aexit__(self, *a): return None
+    monkeypatch.setattr(ctx_mod, "ClaudeSDKClient", FakeTempClient)
+
+    interaction = _make_interaction(bot, channel_id=88888)
+    await ctx_mod.context_cmd.callback(interaction)
+    embed = interaction.followup.send.call_args.kwargs["embed"]
+    assert embed.color.value == COLOR_TOOL_FAILURE
+    assert "Context unavailable" in embed.title
+    assert "CLIConnectionError" in embed.description


### PR DESCRIPTION
Closes 3rd of #163's 4 sub-tasks. CLI-native /context semantics.

## Design
Two-path mirror of /skill list:
- **Path A**: bridge.get_context_usage() piggyback on active session (~tens of ms)
- **Path B**: temp ClaudeSDKClient (~2-4s cold start, model baseline only)

## UI
- Progress bar + percentage in title
- Color: red ≥90%, yellow ≥75%, blue <75%
- Top-5 categories by token count
- ephemeral=True
- defer() handles Discord 3s timeout for Path B cold start

## Tests
+12: pure helpers (progress bar, token format, embed colors, category sort/truncate) + cog paths (A success, B fallback, A→B failover, B error red embed).

531 pass / 2 pre-existing P1.

## Remaining #163
- sub-task 4: /diff