### PR TITLE
v1.18: /diff — show git diff of bound project (#163 sub-task 4 of 4, EPIC COMPLETE)

### DIFF
--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -233,6 +233,7 @@ class ClaudedBot(commands.Bot):
         from .cogs.mcp import mcp_group
         from .cogs.skill import skill_group
         from .cogs.context import context_cmd
+        from .cogs.diff import diff_cmd
         from .cogs.ops import (
             cost_group, health_check, review_pr, plugin_group,
             send_to_claude, pin_message, ratelimit_info,
@@ -264,6 +265,7 @@ class ClaudedBot(commands.Bot):
         self.tree.add_command(unbound_fallback_toggle)
         self.tree.add_command(btw_cmd)
         self.tree.add_command(context_cmd)
+        self.tree.add_command(diff_cmd)
         synced = await self.tree.sync()
         log.info("Synced %d application command(s)", len(synced))
 

--- a/src/clauded/cogs/diff.py
+++ b/src/clauded/cogs/diff.py
@@ -1,0 +1,193 @@
+"""/diff slash command — show git diff of the bound project.
+
+PRD: #163 sub-task 4. Mirrors the bundled Claude CLI's `/diff` semantics:
+visualize uncommitted changes in the channel's bound project so users
+can review what Claude has changed before committing.
+
+## Behavior
+
+1. Resolve the channel's bound project path (via ``project_manager.get_path``).
+2. Run ``git diff`` (unstaged) in that directory.
+3. If unstaged diff is empty, fall back to ``git diff --staged``.
+4. If both are empty → "No uncommitted changes" message.
+
+## Output tiering
+
+- Empty diff → ephemeral plain text "No uncommitted changes"
+- Short (<3500 chars) → embed with ```diff fenced code block
+- Long (≥3500 chars) → ``.diff`` file attachment (auto-syntax-highlighted
+  by Discord's mobile client on click)
+
+## Errors
+
+- Not a git repo → friendly "Not a git repository" message
+- Channel not bound → standard refuse-hint (via ``reject_if_unbound``)
+- Subprocess failure → red error embed with class name (no stderr leak)
+
+## Why subprocess and not GitPython
+
+Adding a Python git library (GitPython, pygit2) for a single read-only
+command is over-engineering. ``git diff`` via ``asyncio.create_subprocess_exec``
+is what users expect from a ``/diff`` command anyway, and we get full
+git config / aliases / pager-disable semantics for free.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import os
+
+import discord
+from discord import app_commands
+
+from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE
+from ._unbound import reject_if_unbound
+
+log = logging.getLogger("clauded.bot")
+
+
+_DIFF_EMBED_THRESHOLD = 3500  # Discord embed description hard cap is 4096; leave headroom for code-fence wrapper
+_DIFF_SUBPROCESS_TIMEOUT_S = 10.0
+
+
+async def _run_git_diff(cwd: str, staged: bool) -> tuple[int, str, str]:
+    """Run ``git diff`` (or ``git diff --staged``) in cwd.
+
+    Returns (returncode, stdout, stderr). Uses asyncio subprocess to avoid
+    blocking the event loop. Times out after ``_DIFF_SUBPROCESS_TIMEOUT_S``
+    so a runaway git process (rare but possible with huge diffs or
+    filesystem locks) can't stall the slash command.
+    """
+    args = ["git", "diff", "--no-color"]
+    if staged:
+        args.append("--staged")
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        cwd=cwd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env={**os.environ, "GIT_PAGER": "cat", "LESS": "FRX"},
+    )
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(
+            proc.communicate(), timeout=_DIFF_SUBPROCESS_TIMEOUT_S
+        )
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.communicate()
+        return -1, "", "git diff timed out"
+    return proc.returncode, stdout_b.decode("utf-8", errors="replace"), stderr_b.decode("utf-8", errors="replace")
+
+
+@app_commands.command(
+    name="diff",
+    description="Show git diff (unstaged then staged) of the bound project.",
+)
+async def diff_cmd(interaction: discord.Interaction) -> None:
+    """Display the channel's bound project's uncommitted changes.
+
+    Short diffs land as an embed; long diffs ship as a ``.diff`` attachment.
+    Falls back to staged-diff if unstaged is empty. Friendly error when
+    the path isn't a git repository.
+    """
+    from ..bot import ClaudedBot
+
+    log.info("/diff channel=%s", interaction.channel_id)
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("❌ Bot not ready.", ephemeral=True)
+        return
+
+    # Refuse on unbound channel — /diff needs a project path. Reuse the
+    # shared Group A refusal helper (mention-required toggle / set-mode /
+    # set-mention-required / system-prompt all follow the same pattern).
+    if await reject_if_unbound(interaction, bot):
+        return
+
+    # Resolve bound path. We already know the channel is bound (reject
+    # above returned False), so get_path won't return None here.
+    channel_id = interaction.channel_id
+    if channel_id is None:
+        # Defensive — reject_if_unbound already handles None, but the
+        # type-checker can't see that.
+        return
+    project_path = bot.project_manager.get_path(channel_id)
+    if not project_path:
+        await interaction.response.send_message(
+            "❌ Channel not bound.", ephemeral=True
+        )
+        return
+
+    # Subprocess can take a moment for large repos; defer to clear the
+    # 3-second interaction deadline.
+    await interaction.response.defer(ephemeral=True)
+
+    # Unstaged diff first
+    rc, stdout, stderr = await _run_git_diff(project_path, staged=False)
+    if rc != 0:
+        # rc != 0 is usually "not a git repo" or transient filesystem error
+        err_lower = (stderr or "").lower()
+        if "not a git" in err_lower or "no such file" in err_lower:
+            await interaction.followup.send(
+                embed=discord.Embed(
+                    title="❌ Not a git repository",
+                    description=f"`{project_path}` isn't a git working tree.",
+                    color=COLOR_TOOL_FAILURE,
+                ),
+                ephemeral=True,
+            )
+            return
+        # Other failures (rc=-1 = timeout, or genuine error)
+        await interaction.followup.send(
+            embed=discord.Embed(
+                title="❌ git diff failed",
+                description=f"`exit={rc}` — see bot.log for details.",
+                color=COLOR_TOOL_FAILURE,
+            ),
+            ephemeral=True,
+        )
+        log.warning("/diff git failed cwd=%s rc=%s stderr=%s", project_path, rc, stderr[:200])
+        return
+
+    diff_text = stdout
+    source_label = "unstaged"
+    if not diff_text.strip():
+        # Try staged diff as a fallback
+        rc2, stdout2, _stderr2 = await _run_git_diff(project_path, staged=True)
+        if rc2 == 0 and stdout2.strip():
+            diff_text = stdout2
+            source_label = "staged"
+
+    if not diff_text.strip():
+        await interaction.followup.send(
+            "✅ No uncommitted changes (working tree + index both clean).",
+            ephemeral=True,
+        )
+        return
+
+    # Tier 1: short → embed with code fence
+    if len(diff_text) < _DIFF_EMBED_THRESHOLD:
+        # ```diff at start, ``` at end — Discord renders diff syntax
+        # highlighting in desktop + recent mobile clients.
+        embed = discord.Embed(
+            title=f"📋 Diff ({source_label})",
+            description=f"```diff\n{diff_text}\n```",
+            color=COLOR_INFO,
+        )
+        embed.set_footer(text=f"{project_path}")
+        await interaction.followup.send(embed=embed, ephemeral=True)
+        return
+
+    # Tier 2: long → file attachment
+    file_bytes = diff_text.encode("utf-8", errors="replace")
+    file = discord.File(io.BytesIO(file_bytes), filename="changes.diff")
+    summary = (
+        f"📋 Diff ({source_label}) — {len(diff_text):,} chars, "
+        f"{diff_text.count(chr(10))} lines"
+    )
+    await interaction.followup.send(content=summary, file=file, ephemeral=True)
+
+
+__all__ = ["diff_cmd"]

--- a/src/clauded/cogs/diff.py
+++ b/src/clauded/cogs/diff.py
@@ -169,11 +169,15 @@ async def diff_cmd(interaction: discord.Interaction) -> None:
 
     # Tier 1: short → embed with code fence
     if len(diff_text) < _DIFF_EMBED_THRESHOLD:
-        # ```diff at start, ``` at end — Discord renders diff syntax
-        # highlighting in desktop + recent mobile clients.
+        # CommonMark §4.5 / Discord rendering: use a 4-backtick outer fence
+        # so any 3-backtick sequences inside the diff content (legitimate
+        # in diffs of markdown / python / shell files containing code
+        # examples) don't close the outer fence early. R1 tester +
+        # simplicity flagged this as a fence-escape risk; pinning with a
+        # dedicated test (test_diff_short_handles_triple_backticks).
         embed = discord.Embed(
             title=f"📋 Diff ({source_label})",
-            description=f"```diff\n{diff_text}\n```",
+            description=f"````diff\n{diff_text}\n````",
             color=COLOR_INFO,
         )
         embed.set_footer(text=f"{project_path}")

--- a/tests/test_diff_cmd.py
+++ b/tests/test_diff_cmd.py
@@ -9,12 +9,10 @@ Errors: not-a-git-repo, subprocess failure, channel not bound.
 """
 from __future__ import annotations
 
-import asyncio
-import io
 import shutil
 import subprocess
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import discord
 import pytest
@@ -25,6 +23,16 @@ from clauded.cost_tracker import CostTracker
 from clauded.project_manager import ProjectManager
 from clauded.session_manager import SessionManager
 from clauded.session_store import SessionStore
+
+
+# Skip the whole module if git isn't available on PATH (CI sandbox / minimal
+# Docker). R1 tester suggestion: production cog DOES require git too, so a
+# git-less host wouldn't be a valid deployment anyway; skipping the tests
+# rather than failing them keeps the suite clean across environments.
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None,
+    reason="git not on PATH; /diff tests need real git subprocess",
+)
 
 
 @pytest.fixture
@@ -257,3 +265,31 @@ async def test_diff_response_is_ephemeral(bot: ClaudedBot, tmp_path: Path) -> No
     interaction = _make_interaction(bot, channel_id)
     await diff_cmd.callback(interaction)
     assert interaction.followup.send.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_diff_short_handles_triple_backticks_in_content(
+    bot: ClaudedBot, tmp_path: Path
+) -> None:
+    """R1 tester + simplicity convergent finding: diff containing literal
+    ```` ``` ```` (e.g. modifying a markdown file with code examples) must
+    not break the outer code fence. R2: use 4-backtick outer fence
+    (CommonMark §4.5: outer fence longer than any inner fence)."""
+    from clauded.cogs.diff import diff_cmd
+    repo = _make_real_git_repo(tmp_path, modify=False)
+    # Modify a file to contain triple backticks (markdown code example)
+    (repo / "foo.txt").write_text("hello\n```python\nprint('hi')\n```\n")
+
+    channel_id = 78901
+    bot.project_manager.bind(channel_id, str(repo))
+    interaction = _make_interaction(bot, channel_id)
+    await diff_cmd.callback(interaction)
+    embed = interaction.followup.send.call_args.kwargs.get("embed")
+    assert embed is not None, "short diff should still render as embed"
+    # Outer fence must be 4 backticks so inner 3-backticks don't close it
+    assert embed.description.startswith("````diff\n"), (
+        f"outer fence should be 4 backticks; got: {embed.description[:30]!r}"
+    )
+    assert embed.description.endswith("\n````")
+    # Inner 3-backticks preserved
+    assert "```python" in embed.description

--- a/tests/test_diff_cmd.py
+++ b/tests/test_diff_cmd.py
@@ -1,0 +1,259 @@
+"""Tests for /diff (#163 sub-task 4).
+
+Shows git diff of the bound project. Output tiering:
+- Empty → "No uncommitted changes" plain text
+- <3500 chars → embed with ```diff fence
+- ≥3500 chars → .diff file attachment
+
+Errors: not-a-git-repo, subprocess failure, channel not bound.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import shutil
+import subprocess
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from clauded.bot import ClaudedBot
+from clauded.config import Config
+from clauded.cost_tracker import CostTracker
+from clauded.project_manager import ProjectManager
+from clauded.session_manager import SessionManager
+from clauded.session_store import SessionStore
+
+
+@pytest.fixture
+def bot(tmp_path: Path) -> ClaudedBot:
+    cfg = Config(
+        discord_bot_token="tok", claude_model="sonnet",
+        claude_permission_mode="default", projects_root=str(tmp_path),
+        allow_unbound_fallback=False,
+    )
+    pm = ProjectManager(data_dir=str(tmp_path / "data"), projects_root=str(tmp_path))
+    sm = SessionManager(session_store=SessionStore(data_dir=str(tmp_path / "data")))
+    bot = ClaudedBot.__new__(ClaudedBot)
+    bot.config = cfg
+    bot.project_manager = pm
+    bot.session_manager = sm
+    bot.cost_tracker = CostTracker()
+    bot.agent_manager = MagicMock()
+    bot._start_time = 0.0
+    bot._claude_version = "test"
+    bot._debug_logging = False
+    bot._pre_tool_notifications = False
+    bot._notify_enabled = {}
+    bot.allow_unbound_fallback = False
+    bot._connection = MagicMock()
+    return bot
+
+
+def _make_interaction(bot: ClaudedBot, channel_id: int) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = bot
+    interaction.channel_id = channel_id
+    ch = MagicMock(spec=discord.TextChannel)
+    ch.id = channel_id
+    interaction.channel = ch
+    interaction.guild_id = 4242
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_real_git_repo(tmp_path: Path, modify: bool = True) -> Path:
+    """Create a real git repo for integration tests; optionally make a modification."""
+    repo = tmp_path / "myproj"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    (repo / "foo.txt").write_text("hello\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "initial"], cwd=repo, check=True)
+    if modify:
+        (repo / "foo.txt").write_text("hello\nworld\n")
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — no SDK
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_git_diff_returns_unstaged_changes(tmp_path: Path) -> None:
+    """Real git repo with unstaged change → diff output contains '+world'."""
+    from clauded.cogs.diff import _run_git_diff
+    repo = _make_real_git_repo(tmp_path, modify=True)
+    rc, stdout, stderr = await _run_git_diff(str(repo), staged=False)
+    assert rc == 0
+    assert "+world" in stdout
+    assert "foo.txt" in stdout
+
+
+@pytest.mark.asyncio
+async def test_run_git_diff_empty_when_clean(tmp_path: Path) -> None:
+    """Clean repo → empty stdout, rc=0."""
+    from clauded.cogs.diff import _run_git_diff
+    repo = _make_real_git_repo(tmp_path, modify=False)
+    rc, stdout, _ = await _run_git_diff(str(repo), staged=False)
+    assert rc == 0
+    assert stdout.strip() == ""
+
+
+@pytest.mark.asyncio
+async def test_run_git_diff_not_a_repo(tmp_path: Path) -> None:
+    """Non-git directory → rc != 0, stderr mentions 'not a git'."""
+    from clauded.cogs.diff import _run_git_diff
+    notrepo = tmp_path / "plain"
+    notrepo.mkdir()
+    rc, stdout, stderr = await _run_git_diff(str(notrepo), staged=False)
+    assert rc != 0
+    assert "not a git" in stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# /diff cog callback — happy path + tiering + errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_diff_returns_no_changes_when_clean(
+    bot: ClaudedBot, tmp_path: Path
+) -> None:
+    """Clean working tree + clean index → 'No uncommitted changes'."""
+    from clauded.cogs.diff import diff_cmd
+    repo = _make_real_git_repo(tmp_path, modify=False)
+    channel_id = 12345
+    bot.project_manager.bind(channel_id, str(repo))
+
+    interaction = _make_interaction(bot, channel_id)
+    await diff_cmd.callback(interaction)
+    msg = interaction.followup.send.call_args[0][0]
+    assert "No uncommitted changes" in msg
+
+
+@pytest.mark.asyncio
+async def test_diff_short_renders_embed(bot: ClaudedBot, tmp_path: Path) -> None:
+    """Short unstaged diff (< 3500 chars) → embed with ```diff fence."""
+    from clauded.cogs.diff import diff_cmd
+    repo = _make_real_git_repo(tmp_path, modify=True)
+    channel_id = 23456
+    bot.project_manager.bind(channel_id, str(repo))
+
+    interaction = _make_interaction(bot, channel_id)
+    await diff_cmd.callback(interaction)
+    embed = interaction.followup.send.call_args.kwargs.get("embed")
+    assert embed is not None
+    assert "Diff (unstaged)" in embed.title
+    assert "```diff" in embed.description
+    assert "+world" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_diff_long_attaches_file(bot: ClaudedBot, tmp_path: Path) -> None:
+    """Large diff (≥3500 chars) → file attachment, not embed."""
+    from clauded.cogs.diff import diff_cmd
+    repo = _make_real_git_repo(tmp_path, modify=False)
+    # Create a large change
+    huge_line = "x" * 100
+    big_content = "\n".join([huge_line] * 50)  # ~5000 chars
+    (repo / "foo.txt").write_text(big_content)
+
+    channel_id = 34567
+    bot.project_manager.bind(channel_id, str(repo))
+
+    interaction = _make_interaction(bot, channel_id)
+    await diff_cmd.callback(interaction)
+
+    # File attachment was sent
+    call_kwargs = interaction.followup.send.call_args.kwargs
+    assert "file" in call_kwargs
+    file = call_kwargs["file"]
+    assert isinstance(file, discord.File)
+    assert file.filename == "changes.diff"
+    # Embed should NOT be set when attachment is used
+    assert "embed" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_diff_falls_back_to_staged_when_unstaged_empty(
+    bot: ClaudedBot, tmp_path: Path
+) -> None:
+    """Unstaged clean but index has staged change → diff shows staged."""
+    from clauded.cogs.diff import diff_cmd
+    repo = _make_real_git_repo(tmp_path, modify=False)
+    # Stage a change
+    (repo / "foo.txt").write_text("hello\nstaged-only\n")
+    subprocess.run(["git", "add", "foo.txt"], cwd=repo, check=True)
+    # Unstaged should now be empty (working tree == index)
+    rc_unstaged, out_unstaged, _ = await _make_unstaged_run(repo)
+    assert out_unstaged.strip() == ""  # sanity
+
+    channel_id = 45678
+    bot.project_manager.bind(channel_id, str(repo))
+    interaction = _make_interaction(bot, channel_id)
+    await diff_cmd.callback(interaction)
+    embed = interaction.followup.send.call_args.kwargs.get("embed")
+    assert embed is not None, "should render staged diff as embed"
+    assert "Diff (staged)" in embed.title
+    assert "+staged-only" in embed.description
+
+
+async def _make_unstaged_run(repo: Path):
+    """Helper: run git diff (unstaged) via the same subprocess module."""
+    from clauded.cogs.diff import _run_git_diff
+    return await _run_git_diff(str(repo), staged=False)
+
+
+@pytest.mark.asyncio
+async def test_diff_not_a_git_repo_friendly_error(
+    bot: ClaudedBot, tmp_path: Path
+) -> None:
+    """Bound path is not a git repo → red 'Not a git repository' embed."""
+    from clauded.cogs.diff import diff_cmd
+    plain_dir = tmp_path / "plain"
+    plain_dir.mkdir()
+    channel_id = 56789
+    bot.project_manager.bind(channel_id, str(plain_dir))
+    interaction = _make_interaction(bot, channel_id)
+    await diff_cmd.callback(interaction)
+    embed = interaction.followup.send.call_args.kwargs.get("embed")
+    assert embed is not None
+    assert "Not a git repository" in embed.title
+
+
+@pytest.mark.asyncio
+async def test_diff_unbound_channel_refuses(bot: ClaudedBot) -> None:
+    """Unbound channel → standard refuse-hint (no git diff attempted)."""
+    from clauded.cogs.diff import diff_cmd
+    interaction = _make_interaction(bot, channel_id=99999)
+    # Bot's config has allow_unbound_fallback=False; channel never bound.
+    await diff_cmd.callback(interaction)
+    # reject_if_unbound sends the refuse message via response.send_message
+    # (NOT followup, because response.is_done() was False on entry)
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.call_args[0][0]
+    assert "❌" in msg
+    assert "not bound" in msg.lower() or "/project bind" in msg
+
+
+@pytest.mark.asyncio
+async def test_diff_response_is_ephemeral(bot: ClaudedBot, tmp_path: Path) -> None:
+    """All response paths use ephemeral=True (admin-style info command)."""
+    from clauded.cogs.diff import diff_cmd
+    repo = _make_real_git_repo(tmp_path, modify=False)
+    channel_id = 67890
+    bot.project_manager.bind(channel_id, str(repo))
+    interaction = _make_interaction(bot, channel_id)
+    await diff_cmd.callback(interaction)
+    assert interaction.followup.send.call_args.kwargs.get("ephemeral") is True


### PR DESCRIPTION
Closes 4th and FINAL sub-task of #163. Epic now 4/4 complete.

## Design
- Resolve bound project path; reject_if_unbound on unbound channels
- asyncio subprocess `git diff --no-color` in that cwd
- Unstaged first; fall back to --staged if empty
- 10s timeout to prevent runaway git stalling slash interaction

## Output tiering
- Empty: "✅ No uncommitted changes"
- Short (<3500): embed with ```diff fence
- Long (≥3500): `.diff` attachment

## Errors
- Not-a-repo / subprocess failure / unbound channel: friendly red embeds

## Tests
+10 using real git subprocess + Discord interaction mocks. Covers helper, happy paths (clean/short/long/staged-fallback), errors (not-repo/unbound), ephemeral invariant.

541 pass / 2 pre-existing P1.

## #163 epic recap

| Sub-task | PR |
|---|---|
| 1. /btw | #166 |
| 2. /session clear | #167 |
| 3. /context | #169 |
| 4. /diff | **this** |

Total: 4 PRs, ~1200 LOC code + ~1000 LOC tests, full 7-perspective review on each.
