### PR TITLE
v1.18: send_message exception-path disconnect() timeout protection (#173)

### DIFF
--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -403,12 +403,27 @@ class ClaudeBridge:
         except BaseException:
             self._active = False
             # Best-effort disconnect; if it fails, we still re-raise the
-            # original exception is what callers care about.
+            # original exception which is what callers care about.
+            #
+            # #173 fix: wrap ``disconnect()`` in ``asyncio.wait_for(timeout)``
+            # matching the ``stop()`` path's protection (#146). The SDK's
+            # ``disconnect()`` can deadlock on anyio cross-task cancel scope
+            # (verified upstream). Without the timeout, this exception path
+            # would hang the current user's Discord turn forever — the same
+            # frozen-UI symptom that #145 documented. We reuse the same env
+            # var so operators only tune one knob.
             client = self._client
             self._client = None
             if client is not None:
+                timeout = float(os.environ.get("CLAUDED_BRIDGE_STOP_TIMEOUT", "30"))
                 try:
-                    await client.disconnect()
+                    await asyncio.wait_for(client.disconnect(), timeout=timeout)
+                except asyncio.TimeoutError:
+                    log.warning(
+                        "send_message error-path disconnect timed out after %ss; "
+                        "force-dropping (subprocess may leak)",
+                        timeout,
+                    )
                 except Exception:  # pragma: no cover - defensive
                     log.exception(
                         "Error disconnecting ClaudeSDKClient after stream failure"

--- a/tests/test_cleanup_deadlock.py
+++ b/tests/test_cleanup_deadlock.py
@@ -149,3 +149,57 @@ async def test_cleanup_concurrent_one_stuck_two_healthy(
         f"{CONCURRENCY_BOUND:.3f}s (serial would be "
         f"~{STUCK_TIMEOUT + 2 * HEALTHY_DELAY:.3f}s)"
     )
+
+
+@pytest.mark.asyncio
+async def test_send_message_exception_path_disconnect_force_drops_after_timeout(
+    cfg: "Config", monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#173 regression pin: when send_message hits an exception and the
+    cleanup `disconnect()` call hangs (anyio cross-task cancel scope dead-
+    lock — same root cause as #146), the call MUST time out per the env
+    var and force-drop the client. Without this fix, the current user's
+    Discord turn would hang forever (the #145 frozen-UI symptom).
+
+    Construct a bridge where:
+      - send_message's inner SDK call raises (synthetic ValueError to
+        force the BaseException branch at claude_bridge.py:411)
+      - The same client's disconnect() never returns (mirrors the #146
+        anyio deadlock)
+
+    Assert: send_message returns within (timeout + small margin), and
+    the bridge has been force-dropped (client=None, active=False).
+    """
+    from clauded.claude_bridge import ClaudeBridge
+
+    bridge = ClaudeBridge(project_path="/tmp/p", config=cfg)
+
+    class FakeStuckClient:
+        async def query(self, *args, **kwargs):
+            raise ValueError("synthetic SDK failure")
+        async def receive_response(self):
+            # If query raised before stream starts, this won't be called;
+            # included for completeness.
+            raise ValueError("synthetic SDK failure")
+            yield  # pragma: no cover
+        async def disconnect(self):
+            await asyncio.sleep(999)  # mirrors the anyio deadlock
+
+    bridge._client = FakeStuckClient()
+    bridge._active = True
+
+    monkeypatch.setenv("CLAUDED_BRIDGE_STOP_TIMEOUT", "0.5")
+
+    # send_message must raise (re-raises the original ValueError after
+    # attempting cleanup) AND must NOT hang forever on the stuck disconnect.
+    with pytest.raises(ValueError, match="synthetic SDK failure"):
+        # Use wait_for as a safety net so a regression doesn't hang the
+        # test suite. Cap at 3s — generous vs the 0.5s timeout.
+        async def _drive():
+            async for _ in bridge.send_message("test prompt"):
+                pass
+        await asyncio.wait_for(_drive(), timeout=3.0)
+
+    # After the timeout fired, bridge must be force-dropped
+    assert bridge._client is None
+    assert bridge._active is False


### PR DESCRIPTION
Closes #173 — #146 follow-up: send_message exception-path disconnect() was unguarded.

## Bug
#146 protected `bridge.stop()` against anyio cross-task cancel scope deadlock via `asyncio.wait_for(timeout=30)`. Same risk on the second `disconnect()` call site in `send_message` exception path (`claude_bridge.py:411`). If that hangs, the user's current Discord turn hangs forever (the #145 frozen-UI symptom).

## Fix
Wrap the call in `asyncio.wait_for(timeout=CLAUDED_BRIDGE_STOP_TIMEOUT)` matching #146. Reuses the same env var so operators tune one knob.

## Test
+1 regression pin: synthesizes SDK ValueError + stuck disconnect; asserts force-drop + bridge re-raises within timeout.

548 pass / 2 pre-existing P1.
