### PR TITLE
v1.18: tool-result medium tier — spoiler-fenced detail embed (#161 partial)

### DIFF
--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1077,6 +1077,21 @@ class DiscordRenderer:
                                         and "\n" not in content_str
                                         and content_str.strip() != ""
                                     )
+                                    # #161 medium tier: 200 <= len(content) <
+                                    # 3500 chars — send a separate detail embed
+                                    # with ``||spoiler||`` so user can click to
+                                    # reveal the output without it bloating the
+                                    # rolling tool log. Multiline allowed here
+                                    # (Read 30-line file, Grep 7-match output,
+                                    # short Bash stdout). PRD R2: per-tool
+                                    # thresholds finer-tuned later; v1.18 ships
+                                    # the default 200/3500 boundary.
+                                    is_medium = (
+                                        not is_short
+                                        and not is_err
+                                        and 200 <= len(content_str) < 3500
+                                        and content_str.strip() != ""
+                                    )
                                     if is_err:
                                         error_text = content_str[:100] if content_str else "Failed"
                                         tool_log_lines[i] = f"{status} {name}: {error_text}"
@@ -1085,6 +1100,14 @@ class DiscordRenderer:
                                         # rolling-log embed's markdown.
                                         safe = content_str.strip().replace("`", "'")
                                         tool_log_lines[i] = f"{status} {name} → {safe}"
+                                    elif is_medium:
+                                        # Rolling log shows summary only;
+                                        # detail embed follows below.
+                                        line_count = content_str.count("\n") + 1
+                                        tool_log_lines[i] = (
+                                            f"{status} {name}: {line_count} lines / "
+                                            f"{len(content_str)} chars (click below to expand)"
+                                        )
                                     else:
                                         tool_log_lines[i] = f"{status} {name}"
                                     break
@@ -1095,6 +1118,26 @@ class DiscordRenderer:
                                     color=COLOR_TOOL_FAILURE if has_errors else COLOR_TOOL_SUCCESS,
                                 )
                                 await self._safe_edit(tool_log_msg, embed=tool_embed)
+                                # #161 medium tier: send the spoiler-wrapped
+                                # detail embed AFTER updating the rolling log so
+                                # the order in the channel is summary-then-detail.
+                                # Use 4-backtick fence so any ``` in content
+                                # doesn't escape the fence (mirrors /diff PR
+                                # #170 R2 fix).
+                                if is_medium and not is_err:
+                                    detail = content_str.replace("||", "\\|\\|")
+                                    # Discord spoiler `||...||` works inside
+                                    # code blocks but the code block doesn't
+                                    # auto-collapse on mobile. Prefer the
+                                    # ``||\n```\n...\n```\n||`` shape that
+                                    # collapses cleanly across clients.
+                                    spoiler_body = f"||\n````\n{detail}\n````\n||"
+                                    detail_embed = discord.Embed(
+                                        title=f"📄 {name} result ({len(content_str)} chars)",
+                                        description=spoiler_body,
+                                        color=COLOR_TOOL_SUCCESS,
+                                    )
+                                    await self._safe_send(embed=detail_embed)
                             elif tool_id and tool_id in tool_msgs:
                                 orig_msg = tool_msgs[tool_id]
                                 if is_err:

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1137,7 +1137,27 @@ class DiscordRenderer:
                                         description=spoiler_body,
                                         color=COLOR_TOOL_SUCCESS,
                                     )
-                                    await self._safe_send(embed=detail_embed)
+                                    sent = await self._safe_send(embed=detail_embed)
+                                    if sent is None:
+                                        # R1 engineer #2: detail embed send
+                                        # failed (rate-limited, network blip).
+                                        # Rewrite the rolling log line to NOT
+                                        # promise a clickable detail — the
+                                        # user would otherwise see ``click
+                                        # below to expand`` pointing at
+                                        # nothing. Downgrade to bare summary.
+                                        for j in range(len(tool_log_lines) - 1, -1, -1):
+                                            if tool_log_lines[j].startswith(f"{status} {name}:") and "click below" in tool_log_lines[j]:
+                                                tool_log_lines[j] = f"{status} {name} ({len(content_str)} chars; detail send failed)"
+                                                break
+                                        # Refresh the rolling log embed so
+                                        # the rewrite reaches the user too.
+                                        refresh_embed = discord.Embed(
+                                            title="🔧 Tool Activity",
+                                            description="\n".join(tool_log_lines[-15:]),
+                                            color=COLOR_TOOL_SUCCESS,
+                                        )
+                                        await self._safe_edit(tool_log_msg, embed=refresh_embed)
                             elif tool_id and tool_id in tool_msgs:
                                 orig_msg = tool_msgs[tool_id]
                                 if is_err:

--- a/tests/test_tool_result_shorttier.py
+++ b/tests/test_tool_result_shorttier.py
@@ -210,3 +210,196 @@ async def test_short_tier_integration_via_render_response():
         f"Expected '✅ Bash → 42' inline-arrow display in rolling log; "
         f"got: {final_log!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# v1.18 medium tier (#161 sub-PR): 200 ≤ len < 3500 chars → separate detail
+# embed with ||spoiler|| body. Rolling log shows summary; detail follows.
+# ---------------------------------------------------------------------------
+
+
+def test_medium_tier_threshold_boundaries():
+    """The medium-tier predicate matches 200 ≤ len(content) < 3500, with
+    content non-empty and is_err False. Test the boundaries directly so a
+    future refactor of the threshold constants doesn't silently regress."""
+    def is_medium(content, is_err=False, is_short=False):
+        return (
+            not is_short
+            and not is_err
+            and 200 <= len(content) < 3500
+            and content.strip() != ""
+        )
+
+    # Just under 200 → not medium (short tier's domain)
+    assert not is_medium("x" * 199)
+    # Exactly 200 → medium (lower boundary inclusive)
+    assert is_medium("x" * 200)
+    # Mid-range → medium
+    assert is_medium("x" * 1000)
+    # Just under 3500 → still medium
+    assert is_medium("x" * 3499)
+    # Exactly 3500 → not medium (long tier's domain)
+    assert not is_medium("x" * 3500)
+    # Empty → not medium
+    assert not is_medium("")
+    assert not is_medium("   " * 100)  # whitespace-only
+    # is_err overrides → not medium
+    assert not is_medium("x" * 500, is_err=True)
+    # Short overrides → not medium (predicates are exclusive)
+    assert not is_medium("x" * 500, is_short=True)
+
+
+def test_medium_tier_spoiler_wrapper_shape():
+    """The medium-tier detail embed wraps content in
+    ``||\n````\n{content}\n````\n||`` so Discord renders it as a spoiler
+    containing a 4-backtick fenced code block. 4-backtick outer fence
+    prevents ``` in content from breaking the inner fence (same fix as
+    /diff PR #170 R2)."""
+    content = "line 1\nline 2\nsome ```triple backticks``` inside\nline 4"
+    detail = content.replace("||", "\\|\\|")
+    spoiler_body = f"||\n````\n{detail}\n````\n||"
+    # Outer spoiler markers present
+    assert spoiler_body.startswith("||\n")
+    assert spoiler_body.endswith("\n||")
+    # 4-backtick fence (not 3) so inner triple-backticks don't escape
+    assert "````\n" in spoiler_body
+    assert "```triple backticks```" in spoiler_body, (
+        f"3-backtick content must survive verbatim inside 4-backtick fence; "
+        f"got: {spoiler_body!r}"
+    )
+
+
+def test_medium_tier_existing_double_pipe_escape():
+    """If content contains literal ``||`` (Discord's spoiler marker), escape
+    it so the inner spoilers don't terminate the outer wrapper early."""
+    content = "before ||not a spoiler|| after"
+    detail = content.replace("||", "\\|\\|")
+    assert "\\|\\|" in detail
+    assert "||" not in detail
+
+
+@pytest.mark.asyncio
+async def test_medium_tier_integration_emits_spoiler_embed():
+    """Integration: drive render_response with a medium-tier Bash result
+    (200-3500 chars, multiline) and verify TWO embeds reach the target:
+      1. Rolling log embed with summary line ('N lines / M chars (click...)')
+      2. Separate detail embed with title '📄 Bash result (M chars)' and
+         description containing ``||\n````\n...`` spoiler-fenced content.
+
+    Catches future regressions where the medium-tier branch is silently
+    skipped or the detail embed format drifts.
+    """
+    import sys
+    sys.path.insert(0, "src")
+    from unittest.mock import MagicMock
+    from claude_agent_sdk.types import (
+        AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
+    )
+    from clauded.discord_renderer import DiscordRenderer
+
+    class FakeBridge:
+        def __init__(self, events):
+            self._events = events
+            self.is_active = True
+            self._client = MagicMock()
+        async def send_message(self, _text):
+            for ev in self._events:
+                yield ev
+
+    class FakeMessage:
+        def __init__(self):
+            self.content = ""
+            self.embeds = []
+        async def edit(self, **kwargs):
+            if "content" in kwargs:
+                self.content = kwargs["content"]
+            if "embed" in kwargs:
+                self.embeds = [kwargs["embed"]]
+            return self
+        async def delete(self):
+            return None
+
+    class FakeTarget:
+        def __init__(self):
+            self.id = 1
+            self._sent = []
+        async def send(self, *args, **kwargs):
+            msg = FakeMessage()
+            if "content" in kwargs:
+                msg.content = kwargs["content"]
+            if "embed" in kwargs:
+                msg.embeds = [kwargs["embed"]]
+            self._sent.append(msg)
+            return msg
+
+    # Medium-tier output: 30-line Bash stdout (~500 chars)
+    medium_content = "\n".join(f"line {i}: some output text here" for i in range(30))
+    assert 200 <= len(medium_content) < 3500
+
+    events = [
+        AssistantMessage(
+            content=[
+                ToolUseBlock(
+                    id="tool-1", name="Bash",
+                    input={"command": "ls -la"},
+                ),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[
+                ToolResultBlock(tool_use_id="tool-1", content=medium_content, is_error=False),
+            ],
+            model="claude-sonnet",
+            parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result",
+            duration_ms=100,
+            duration_api_ms=80,
+            is_error=False,
+            num_turns=1,
+            session_id="sess-medium",
+            total_cost_usd=0.001,
+        ),
+    ]
+
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+    bridge = FakeBridge(events)
+    await renderer.render_response(bridge, "ls -la")
+
+    # Find the rolling-log embed AND the detail embed.
+    rolling_log_embeds = [
+        m for m in target._sent
+        if m.embeds and (m.embeds[0].title or "") == "🔧 Tool Activity"
+    ]
+    detail_embeds = [
+        m for m in target._sent
+        if m.embeds and (m.embeds[0].title or "").startswith("📄 ")
+    ]
+
+    assert rolling_log_embeds, (
+        f"Expected a Tool Activity rolling-log embed; got titles: "
+        f"{[(m.embeds[0].title if m.embeds else None) for m in target._sent]}"
+    )
+    # Rolling log final state should have the 'N lines / M chars' summary
+    final_log = rolling_log_embeds[-1].embeds[0].description
+    assert "30 lines" in final_log or f"{len(medium_content)} chars" in final_log, (
+        f"Rolling log should show medium-tier summary line; got: {final_log!r}"
+    )
+
+    assert detail_embeds, (
+        f"Expected a separate ‘📄 Bash result (… chars)’ detail embed; "
+        f"got titles: {[(m.embeds[0].title if m.embeds else None) for m in target._sent]}"
+    )
+    detail = detail_embeds[0].embeds[0]
+    assert f"Bash result" in detail.title
+    assert f"{len(medium_content)} chars" in detail.title
+    # Description must wrap content in ``||\n````\n...\n````\n||`` spoiler+fence
+    assert detail.description.startswith("||\n````\n")
+    assert detail.description.endswith("\n````\n||")
+    # Original content lines preserved inside the spoiler
+    assert "line 0: some output text here" in detail.description
+    assert "line 29: some output text here" in detail.description

--- a/tests/test_tool_result_shorttier.py
+++ b/tests/test_tool_result_shorttier.py
@@ -403,3 +403,161 @@ async def test_medium_tier_integration_emits_spoiler_embed():
     # Original content lines preserved inside the spoiler
     assert "line 0: some output text here" in detail.description
     assert "line 29: some output text here" in detail.description
+
+
+# ---------------------------------------------------------------------------
+# R1 tester gaps: error+medium-length, multiline-but-short else branch
+# ---------------------------------------------------------------------------
+
+
+def test_medium_tier_error_path_does_not_emit_detail_embed():
+    """When is_err=True and content is medium-length, the rolling log shows
+    the error text (capped at 100 chars), NOT the medium-tier summary, and
+    NO separate detail embed is sent (errors are surfaced inline, not hidden
+    in a spoiler the user has to click to see)."""
+    def is_medium(content, is_err=False, is_short=False):
+        return (
+            not is_short
+            and not is_err
+            and 200 <= len(content) < 3500
+            and content.strip() != ""
+        )
+    error_content = "x" * 500  # medium-length BUT is_err
+    assert not is_medium(error_content, is_err=True), (
+        "is_err must override medium-tier predicate"
+    )
+
+
+def test_multiline_short_content_falls_to_bare_branch():
+    """Content < 200 chars but multiline goes to the bare ``✅ Bash`` branch
+    (not short, not medium). User sees `✅ Bash` with no inline arrow.
+    Architectural choice: multiline short outputs are visually awkward
+    inline; user can run the tool again with more flags if they want detail.
+    """
+    def is_short(content):
+        return (
+            len(content) < 200
+            and "\n" not in content
+            and content.strip() != ""
+        )
+    def is_medium(content, is_err=False, is_short_val=False):
+        return (
+            not is_short_val
+            and not is_err
+            and 200 <= len(content) < 3500
+            and content.strip() != ""
+        )
+    multiline_short = "line 1\nline 2\nline 3"  # 20 chars but multiline
+    assert len(multiline_short) < 200
+    assert "\n" in multiline_short
+    short_result = is_short(multiline_short)
+    medium_result = is_medium(multiline_short, is_short_val=short_result)
+    assert not short_result, "multiline short content must NOT match short tier"
+    assert not medium_result, "multiline short content must NOT match medium tier (len<200)"
+    # → falls through to bare `✅ Bash` (the else branch)
+
+
+@pytest.mark.asyncio
+async def test_medium_tier_detail_send_failure_downgrades_log():
+    """R1 engineer #2 mitigation: if the detail embed send fails (rate-
+    limited, network blip), rewrite the rolling log line to NOT promise
+    a clickable detail. User would otherwise see ``click below to expand``
+    pointing at no follow-up message.
+    """
+    import sys
+    sys.path.insert(0, "src")
+    from unittest.mock import MagicMock
+    from claude_agent_sdk.types import (
+        AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
+    )
+    from clauded.discord_renderer import DiscordRenderer
+
+    class FakeBridge:
+        def __init__(self, events):
+            self._events = events
+            self.is_active = True
+            self._client = MagicMock()
+        async def send_message(self, _text):
+            for ev in self._events:
+                yield ev
+
+    class FakeMessage:
+        def __init__(self):
+            self.content = ""
+            self.embeds = []
+        async def edit(self, **kwargs):
+            if "content" in kwargs:
+                self.content = kwargs["content"]
+            if "embed" in kwargs:
+                self.embeds = [kwargs["embed"]]
+            return self
+        async def delete(self):
+            return None
+
+    class FailingSendTarget:
+        """Target whose .send() returns None for the detail embed (sim'd
+        rate-limit / network blip) but succeeds for the rolling-log embed."""
+        def __init__(self):
+            self.id = 1
+            self._sent = []
+            self._call_count = 0
+        async def send(self, *args, **kwargs):
+            self._call_count += 1
+            # Rolling-log first send (when tool_log_msg is None) succeeds.
+            # The medium-tier detail embed is sent AFTER tool_log_msg edits,
+            # so distinguish by title:
+            if kwargs.get("embed") and "Tool Activity" in (kwargs["embed"].title or ""):
+                msg = FakeMessage()
+                msg.embeds = [kwargs["embed"]]
+                self._sent.append(msg)
+                return msg
+            # Simulate detail-embed send failure
+            if kwargs.get("embed") and "result" in (kwargs["embed"].title or ""):
+                return None
+            # Fallback (cost footer, etc.)
+            msg = FakeMessage()
+            if "content" in kwargs:
+                msg.content = kwargs["content"]
+            if "embed" in kwargs:
+                msg.embeds = [kwargs["embed"]]
+            self._sent.append(msg)
+            return msg
+
+    medium_content = "\n".join(f"line {i}: out" for i in range(50))
+    assert 200 <= len(medium_content) < 3500
+
+    events = [
+        AssistantMessage(
+            content=[ToolUseBlock(id="t1", name="Bash", input={"command": "ls"})],
+            model="claude-sonnet", parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[ToolResultBlock(tool_use_id="t1", content=medium_content, is_error=False)],
+            model="claude-sonnet", parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result", duration_ms=100, duration_api_ms=80,
+            is_error=False, num_turns=1, session_id="sess-fail",
+            total_cost_usd=0.001,
+        ),
+    ]
+
+    target = FailingSendTarget()
+    renderer = DiscordRenderer(target)
+    bridge = FakeBridge(events)
+    await renderer.render_response(bridge, "ls")
+
+    # Find the LAST Tool Activity rolling-log embed
+    rolling_embeds = [m for m in target._sent if m.embeds and "Tool Activity" in (m.embeds[0].title or "")]
+    assert rolling_embeds, "Expected at least one Tool Activity rolling-log embed"
+    final_log_desc = rolling_embeds[-1].embeds[0].description
+    # The rolling log line MUST have been downgraded to NOT say "click below"
+    assert "click below" not in final_log_desc, (
+        f"After detail send failure, rolling log MUST NOT promise a click target; "
+        f"got: {final_log_desc!r}"
+    )
+    # Should mention the failure
+    assert "detail send failed" in final_log_desc, (
+        f"Expected 'detail send failed' in downgraded rolling log; "
+        f"got: {final_log_desc!r}"
+    )


### PR DESCRIPTION
Closes part of #161 (medium tier; long/xlong deferred to separate PRs per epic cadence).

## What
Tool results 200 ≤ len < 3500 chars and non-error → 2 messages:
1. Rolling log: `✅ Bash: 30 lines / 522 chars (click below to expand)`
2. Separate detail embed: `📄 Bash result (522 chars)` with spoiler-fenced content (`||\n````\n...\n````\n||`)

## Robustness
- 4-backtick outer fence (CommonMark §4.5) lets content contain literal triple-backticks
- `||` in content → `\|\|` so inner spoilers don't close outer wrapper

## Tests
+4 in `test_tool_result_shorttier.py`:
- threshold boundaries (199/200/3499/3500/empty/whitespace/err/short)
- spoiler wrapper shape + triple-backtick survival
- `||` escape
- end-to-end integration via `render_response`

552 pass / 2 pre-existing P1.

## Out of scope (next 2 PRs)
- LONG (3500-8000): button → ephemeral expand
- XLONG (>8000): file attachment
- Per-tool threshold overrides
