### PR TITLE
chore: env-gated testbot allowlist for end-to-end smoke testing

### DIFF
--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -322,8 +322,12 @@ class ClaudedBot(commands.Bot):
         if message.author.id == getattr(self.user, "id", None):
             return
         # Ignore other bots, except an opt-in testbot allowlist for smoke
-        # testing (set CLAUDED_TESTBOT_ID to the bot account's user id;
-        # leave unset in production).
+        # testing. Set CLAUDED_TESTBOT_ID to the bot account's user id to
+        # let it drive on_message (e.g. for end-to-end smoke runs).
+        # **MUST be unset in production** — if the env value leaks to a
+        # hostile bot account in the same guild, that bot could drive
+        # arbitrary user-facing turns. Self-skip above prevents the obvious
+        # misconfig where env=bot's own id (would loop infinitely).
         if message.author.bot:
             testbot_id = os.environ.get("CLAUDED_TESTBOT_ID")
             if not (testbot_id and str(message.author.id) == testbot_id):

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -318,9 +318,16 @@ class ClaudedBot(commands.Bot):
         log.info("Bot online as %s (id=%s)", user, getattr(user, "id", "?"))
 
     async def on_message(self, message: discord.Message) -> None:  # type: ignore[override]
-        # Ignore self / other bots.
-        if message.author.bot:
+        # Always ignore self.
+        if message.author.id == getattr(self.user, "id", None):
             return
+        # Ignore other bots, except an opt-in testbot allowlist for smoke
+        # testing (set CLAUDED_TESTBOT_ID to the bot account's user id;
+        # leave unset in production).
+        if message.author.bot:
+            testbot_id = os.environ.get("CLAUDED_TESTBOT_ID")
+            if not (testbot_id and str(message.author.id) == testbot_id):
+                return
 
         channel = message.channel
         parent_id = getattr(channel, "parent_id", None)

--- a/tests/test_testbot_allowlist.py
+++ b/tests/test_testbot_allowlist.py
@@ -77,3 +77,16 @@ async def test_on_message_allowlisted_bot_passes_early_filter(monkeypatch, caplo
         pass
     info_records = [r for r in caplog.records if r.name == "clauded.bot" and "on_message" in r.message]
     assert info_records, "Allowlisted testbot was wrongly short-circuited before the on_message log"
+
+
+@pytest.mark.asyncio
+async def test_on_message_empty_env_treated_as_unset(monkeypatch):
+    """R1 tester gap: CLAUDED_TESTBOT_ID="" must behave like unset (truthy
+    check on the env value handles this — pin so a refactor doesn't break
+    it by using `os.environ.get(...) is not None`).
+    """
+    from clauded.bot import ClaudedBot
+    monkeypatch.setenv("CLAUDED_TESTBOT_ID", "")
+    msg = _make_msg(author_id=12345, author_is_bot=True)
+    result = await ClaudedBot.on_message(_Stub(), msg)
+    assert result is None  # empty env → no allowlist → other bots skipped

--- a/tests/test_testbot_allowlist.py
+++ b/tests/test_testbot_allowlist.py
@@ -1,0 +1,79 @@
+"""Tests for CLAUDED_TESTBOT_ID env-gated bot-author allowlist (v1.18 smoke utility)."""
+from unittest.mock import MagicMock
+import pytest
+
+
+class _Stub:
+    """Bare minimal stand-in that ClaudedBot.on_message can dispatch on.
+    We bypass ClaudedBot's full __init__ (needs discord client, intents,
+    etc.) and only assert on the early-return short-circuits."""
+    user_id = 99
+    def __init__(self):
+        self._user_obj = MagicMock(id=self.user_id)
+    @property
+    def user(self):
+        return self._user_obj
+
+
+def _make_msg(author_id: int, author_is_bot: bool, content: str = "x"):
+    msg = MagicMock()
+    msg.author.id = author_id
+    msg.author.bot = author_is_bot
+    msg.content = content
+    msg.channel.id = 1
+    return msg
+
+
+@pytest.mark.asyncio
+async def test_on_message_self_always_skipped(monkeypatch):
+    """Self-bot messages MUST always be skipped even if testbot allowlist
+    is set to bot's own id (misconfig guard against infinite loop)."""
+    from clauded.bot import ClaudedBot
+    monkeypatch.setenv("CLAUDED_TESTBOT_ID", "99")  # misconfig
+    msg = _make_msg(author_id=99, author_is_bot=True)
+    # If self-skip doesn't fire, the channel lookup will run and break on
+    # the bare MagicMock. We want early-return BEFORE that.
+    result = await ClaudedBot.on_message(_Stub(), msg)
+    assert result is None  # early return
+
+
+@pytest.mark.asyncio
+async def test_on_message_other_bot_skipped_when_env_unset(monkeypatch):
+    """Production: env unset → all other bots skipped."""
+    from clauded.bot import ClaudedBot
+    monkeypatch.delenv("CLAUDED_TESTBOT_ID", raising=False)
+    msg = _make_msg(author_id=12345, author_is_bot=True)
+    result = await ClaudedBot.on_message(_Stub(), msg)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_on_message_other_bot_still_skipped_with_different_allowlist(monkeypatch):
+    """Smoke mode set to bot A, message from bot B → still skipped."""
+    from clauded.bot import ClaudedBot
+    monkeypatch.setenv("CLAUDED_TESTBOT_ID", "555")
+    msg = _make_msg(author_id=12345, author_is_bot=True)
+    result = await ClaudedBot.on_message(_Stub(), msg)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_on_message_allowlisted_bot_passes_early_filter(monkeypatch, caplog):
+    """Smoke mode: env=555, message from bot 555 → passes the early bot
+    filter and reaches the log.info call before downstream parts fail on
+    the bare MagicMock. Use caplog to detect the on_message INFO log
+    that runs RIGHT AFTER the early-return block."""
+    import logging
+    from clauded.bot import ClaudedBot
+    monkeypatch.setenv("CLAUDED_TESTBOT_ID", "555")
+    msg = _make_msg(author_id=555, author_is_bot=True)
+    caplog.set_level(logging.INFO, logger="clauded.bot")
+    # Will likely raise downstream when project_manager / bot.session_manager
+    # are touched. We only care that the on_message INFO log fires (proving
+    # we passed the early return).
+    try:
+        await ClaudedBot.on_message(_Stub(), msg)
+    except Exception:
+        pass
+    info_records = [r for r in caplog.records if r.name == "clauded.bot" and "on_message" in r.message]
+    assert info_records, "Allowlisted testbot was wrongly short-circuited before the on_message log"


### PR DESCRIPTION
Env-gated testbot allowlist. Enables driving on_message from a second bot account for smoke tests; production behavior unchanged when env unset.

## Why
End-to-end verification of #176 medium-tier needed a way to drive ClaudeBot from TesterBot. `message.author.bot` short-circuit blocked it.

## What
- `CLAUDED_TESTBOT_ID` unset → all other bots skipped (no change)
- `CLAUDED_TESTBOT_ID=<id>` → that single bot account allowed
- Self-bot guard prepended (fires first; misconfig cannot infinite-loop)

## Smoke result (verified live)
Driving ClaudeBot from TesterBot in test guild:
- rolling log: `✅ Bash: 80 lines / 230 chars (click below to expand)`
- detail embed: `📄 Bash result (230 chars)` desc starts `||\n\`\`\`\`\n` ends `\n\`\`\`\`\n||`
- 80 lines preserved verbatim inside the spoiler-fence
- cost footer rendered normally

## Tests
+4 in `test_testbot_allowlist.py`. 559 pass / 2 pre-existing P1.
