### PR TITLE
fix(renderer): medium-tier detail must be a button on the rolling log, not a separate message

### DIFF
--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -589,6 +589,7 @@ class ClaudedBot(commands.Bot):
                     thread=thread,
                     project_path=project_path,
                     session_config=sc,
+                    author_id=message.author.id,
                 )
                 _render_ok = True
             except Exception:
@@ -724,6 +725,7 @@ class ClaudedBot(commands.Bot):
                     thread=message.channel,
                     project_path=project_path,
                     session_config=sc,
+                    author_id=message.author.id,
                 )
                 _render_ok = True
             except Exception:
@@ -880,15 +882,20 @@ class ClaudedBot(commands.Bot):
         thread: discord.abc.Messageable,
         project_path: str,
         session_config: SessionConfig | None = None,
+        author_id: int | None = None,
     ) -> None:
         """Run ``renderer.render_response`` and surface a retry button on crash.
 
         On exception we drop the (now-dead) bridge so the next message —
         either via the retry button or a fresh user message — recreates a
         clean session.
+
+        ``author_id`` (optional) is threaded into ``render_response`` so the
+        :class:`ToolResultsView` can restrict per-button ephemeral followups
+        to the original requester (#179 R1 security).
         """
         try:
-            await renderer.render_response(bridge, user_text)
+            await renderer.render_response(bridge, user_text, author_id=author_id)
         except Exception as exc:
             if is_transient_discord_error(exc):
                 # Render gave up (rare — _retry_http exhausted), but bridge is
@@ -907,8 +914,9 @@ class ClaudedBot(commands.Bot):
             if thread_id is not None:
                 await self.session_manager.stop_session(thread_id)
 
-            # Capture session_config for retry (#80)
+            # Capture session_config + author_id for retry (#80, #161 sec)
             _retry_sc = session_config
+            _retry_author_id = author_id
 
             async def _on_retry() -> None:
                 # Re-acquire the lock so a manual click can't race with a
@@ -976,6 +984,7 @@ class ClaudedBot(commands.Bot):
                         thread=thread,
                         project_path=project_path,
                         session_config=retry_sc,
+                        author_id=_retry_author_id,
                     )
 
             await renderer.send_error_with_retry(exc, _on_retry)

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -382,8 +382,21 @@ class DiscordRenderer:
     # Public entry point
     # ------------------------------------------------------------------
 
-    async def render_response(self, bridge: "ClaudeBridge", user_text: str) -> None:
-        """Stream Claude's response for ``user_text`` to :attr:`target`."""
+    async def render_response(
+        self,
+        bridge: "ClaudeBridge",
+        user_text: str,
+        *,
+        author_id: int | None = None,
+    ) -> None:
+        """Stream Claude's response for ``user_text`` to :attr:`target`.
+
+        ``author_id`` (optional) is the Discord user id that triggered the
+        turn — used by :class:`ToolResultsView` to restrict ephemeral
+        followups (clicking a tool-result button) to the original author,
+        so other channel members can't read another user's tool output.
+        When omitted, the View accepts clicks from anyone (legacy /
+        single-user channel behavior)."""
         buffer = ""                               # text not yet finalized into a sent msg
         live_msg: discord.Message | None = None   # the in-flight typewriter message
         start_time: float | None = None
@@ -1141,7 +1154,21 @@ class DiscordRenderer:
                                 if is_medium and not is_err and tool_id:
                                     medium_results[tool_id] = (name, content_str)
                                     if tool_results_view is None:
-                                        tool_results_view = ToolResultsView()
+                                        # R1 architect: finite timeout so
+                                        # orphan views (rolling-log msg from
+                                        # a past turn nobody clicked) are
+                                        # garbage-collected by discord.py
+                                        # after 24h instead of accumulating
+                                        # forever in long-running bots.
+                                        # R1 security: author_id restricts
+                                        # ephemeral followups to the turn's
+                                        # original requester; same-channel
+                                        # third parties cannot read another
+                                        # user's tool output via the button.
+                                        tool_results_view = ToolResultsView(
+                                            author_id=author_id,
+                                            timeout=86400.0,
+                                        )
                                     # Idempotent: add_result skips if id
                                     # already present (defends against
                                     # duplicate ToolResultBlock events).
@@ -2504,8 +2531,9 @@ class ToolResultsView(discord.ui.View):
     # cap; we never hit content-length issues because the body lives in
     # the attachment.
 
-    def __init__(self) -> None:
-        super().__init__(timeout=None)  # persistent through session
+    def __init__(self, *, author_id: int | None = None, timeout: float | None = 86400.0) -> None:
+        super().__init__(timeout=timeout)
+        self._author_id = author_id
         self._results: dict[str, tuple[str, str]] = {}  # id -> (name, content)
         self._buttons: dict[str, discord.ui.Button] = {}  # id -> Button
 
@@ -2539,7 +2567,19 @@ class ToolResultsView(discord.ui.View):
 
     async def _dispatch(self, interaction: discord.Interaction, tool_use_id: str) -> None:
         """Send the .txt file as an ephemeral followup visible only to
-        the user who clicked."""
+        the user who clicked. If ``author_id`` was set at construction,
+        non-author clicks get a polite refusal (so other channel members
+        can't read another user's tool output)."""
+        if self._author_id is not None and interaction.user.id != self._author_id:
+            try:
+                await interaction.response.send_message(
+                    "🔒 This tool result is only viewable by the user who "
+                    "started this turn.",
+                    ephemeral=True,
+                )
+            except discord.HTTPException:
+                pass
+            return
         entry = self._results.get(tool_use_id)
         if entry is None:
             try:

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -411,6 +411,15 @@ class DiscordRenderer:
         # right stats. Populated in the UserMessage branch below; consumed
         # at line ~915 / ~944.
         tool_use_results: dict[str, dict[str, Any]] = {}
+        # #161 medium tier (v1.18 R3): collected tool results that need a
+        # "view" button on the rolling-log embed itself. Each entry:
+        #   {tool_use_id: (tool_name, content_str)}
+        # The accompanying ToolResultsView attaches one button per entry
+        # (up to 25, Discord's per-view limit) to the rolling-log message.
+        # Clicking sends an ephemeral message containing the .txt file
+        # attachment — only the clicker sees it, zero channel real-estate.
+        medium_results: dict[str, tuple[str, str]] = {}
+        tool_results_view: ToolResultsView | None = None
 
         try:
             async for event in bridge.send_message(user_text):
@@ -1077,22 +1086,20 @@ class DiscordRenderer:
                                         and "\n" not in content_str
                                         and content_str.strip() != ""
                                     )
-                                    # #161 medium tier: 200 <= len(content)
-                                    # — send as a .txt FILE ATTACHMENT below
-                                    # the rolling log. Discord renders file
-                                    # attachments as a single-line link/icon
-                                    # that the user can click to view in a
-                                    # side-pane, which is the actual collapse
-                                    # UX (verified post-R1: both embed-desc
-                                    # spoilers AND message-content spoilers
-                                    # only BLUR text — they don't reduce
-                                    # vertical height, so an 80-line output
-                                    # remained an 80-line gray block).
-                                    # Upper bound 8000 chars: covers nearly
-                                    # all real Bash/Read outputs; xlong tier
-                                    # (>8000) can compress or paginate in
-                                    # a follow-up. No 2000-char content cap
-                                    # because file payload is separate.
+                                    # #161 medium tier (v1.18 R3): 200 <=
+                                    # len(content) < 8000. Instead of
+                                    # sending a separate file message (R2)
+                                    # or trying spoiler hacks (R1), attach
+                                    # a *button* directly to the rolling-
+                                    # log embed. Clicking the button sends
+                                    # an ephemeral message with the .txt
+                                    # file attachment — only the clicker
+                                    # sees it, zero channel real-estate
+                                    # when nobody clicks. Discord per-view
+                                    # cap is 25 buttons / 5 rows; that
+                                    # bounds tool calls per turn but is
+                                    # rarely hit (typical turn < 10 tool
+                                    # calls).
                                     is_medium = (
                                         not is_short
                                         and not is_err
@@ -1108,12 +1115,14 @@ class DiscordRenderer:
                                         safe = content_str.strip().replace("`", "'")
                                         tool_log_lines[i] = f"{status} {name} → {safe}"
                                     elif is_medium:
-                                        # Rolling log shows summary only;
-                                        # file attachment follows below.
+                                        # Rolling log shows summary;
+                                        # button on this same message lets
+                                        # the user open the full content
+                                        # ephemerally. No separate message.
                                         line_count = content_str.count("\n") + 1
                                         tool_log_lines[i] = (
                                             f"{status} {name}: {line_count} lines / "
-                                            f"{len(content_str)} chars (see attached file)"
+                                            f"{len(content_str)} chars (⬇ click to view)"
                                         )
                                     else:
                                         tool_log_lines[i] = f"{status} {name}"
@@ -1124,50 +1133,41 @@ class DiscordRenderer:
                                     description="\n".join(tool_log_lines[-15:]),
                                     color=COLOR_TOOL_FAILURE if has_errors else COLOR_TOOL_SUCCESS,
                                 )
-                                await self._safe_edit(tool_log_msg, embed=tool_embed)
-                                # #161 medium tier: send the detail file
-                                # attachment AFTER updating the rolling log
-                                # so the order in the channel is summary-
-                                # then-detail.
-                                if is_medium and not is_err:
-                                    # #161 medium tier: send as .txt file
-                                    # attachment below the rolling log.
-                                    # Discord file attachments render as a
-                                    # single-line preview card that the user
-                                    # clicks to expand — the actual collapse
-                                    # UX. Spoiler-text hacks (`||...||`)
-                                    # only blur text, they don't reduce
-                                    # vertical height.
-                                    label = f"📄 **{name} result** \u2014 {len(content_str)} chars / {content_str.count(chr(10)) + 1} lines"
-                                    file_bytes = content_str.encode("utf-8", errors="replace")
-                                    file_name = f"{name.lower()}_result.txt"
-                                    detail_file = discord.File(
-                                        fp=io.BytesIO(file_bytes),
-                                        filename=file_name,
+                                # #161 medium tier (v1.18 R3): if this tool
+                                # call hit medium tier, add it to the view
+                                # before editing the rolling-log message,
+                                # so the new button is part of the same
+                                # edit (atomic).
+                                if is_medium and not is_err and tool_id:
+                                    medium_results[tool_id] = (name, content_str)
+                                    if tool_results_view is None:
+                                        tool_results_view = ToolResultsView()
+                                    # Idempotent: add_result skips if id
+                                    # already present (defends against
+                                    # duplicate ToolResultBlock events).
+                                    tool_results_view.add_result(
+                                        tool_use_id=tool_id,
+                                        tool_name=name,
+                                        content=content_str,
                                     )
-                                    sent = await self._safe_send(
-                                        content=label, file=detail_file
-                                    )
-                                    if sent is None:
-                                        # R1 engineer #2: detail send failed
-                                        # (rate-limited, network blip).
-                                        # Rewrite the rolling log line to NOT
-                                        # promise an attached file — the
-                                        # user would otherwise see ``see
-                                        # attached file`` pointing at
-                                        # nothing. Downgrade to bare summary.
-                                        for j in range(len(tool_log_lines) - 1, -1, -1):
-                                            if tool_log_lines[j].startswith(f"{status} {name}:") and "see attached file" in tool_log_lines[j]:
-                                                tool_log_lines[j] = f"{status} {name} ({len(content_str)} chars; detail send failed)"
-                                                break
-                                        # Refresh the rolling log embed so
-                                        # the rewrite reaches the user too.
-                                        refresh_embed = discord.Embed(
-                                            title="🔧 Tool Activity",
-                                            description="\n".join(tool_log_lines[-15:]),
-                                            color=COLOR_TOOL_SUCCESS,
-                                        )
-                                        await self._safe_edit(tool_log_msg, embed=refresh_embed)
+                                # Edit the rolling-log message with the new
+                                # embed AND attach (or refresh) the view.
+                                edit_view_kwarg = tool_results_view if tool_results_view is not None else None
+                                edit_ok = await self._safe_edit(
+                                    tool_log_msg,
+                                    embed=tool_embed,
+                                    view=edit_view_kwarg,
+                                )
+                                if not edit_ok and is_medium and not is_err and tool_id:
+                                    # Edit failed permanently (rate-limit /
+                                    # message deleted). Downgrade the
+                                    # rolling log line so the user doesn't
+                                    # see a click-to-view promise that
+                                    # can't be honored.
+                                    for j in range(len(tool_log_lines) - 1, -1, -1):
+                                        if tool_log_lines[j].startswith(f"{status} {name}:") and "click to view" in tool_log_lines[j]:
+                                            tool_log_lines[j] = f"{status} {name} ({len(content_str)} chars; view button unavailable)"
+                                            break
                             elif tool_id and tool_id in tool_msgs:
                                 orig_msg = tool_msgs[tool_id]
                                 if is_err:
@@ -2481,6 +2481,97 @@ _RETRY_EMBED_DESC_MAX = 4000
 _RETRY_TIMEOUT_SECONDS = 600.0
 
 
+class ToolResultsView(discord.ui.View):
+    """Per-rolling-log persistent view holding one button per medium-tier
+    tool result. Click → ephemeral followup with the result as a .txt
+    file attachment, visible only to the clicker.
+
+    Lifecycle: attached to the ``🔧 Tool Activity`` message via _safe_edit.
+    Each ToolResultBlock that hits medium tier calls :meth:`add_result`
+    which appends a new ``📄 #N {name}`` button. View edits are idempo-
+    tent on (tool_use_id, ...) so duplicate events don't add dup buttons.
+
+    Discord limits: max 25 components per view, 5 components per row.
+    Each button uses 1 component slot → max 25 medium-tier results per
+    turn before we stop accepting new ones (rare in practice).
+    """
+
+    # Cap so we don't try to over-pack the view
+    _MAX_BUTTONS = 25
+    # Discord ephemeral followup hard cap is 2000 chars (content); file
+    # attachments are independent and capped at the bot's upload limit.
+    # For medium tier (< 8000 chars) the file is always well under any
+    # cap; we never hit content-length issues because the body lives in
+    # the attachment.
+
+    def __init__(self) -> None:
+        super().__init__(timeout=None)  # persistent through session
+        self._results: dict[str, tuple[str, str]] = {}  # id -> (name, content)
+        self._buttons: dict[str, discord.ui.Button] = {}  # id -> Button
+
+    def add_result(self, *, tool_use_id: str, tool_name: str, content: str) -> bool:
+        """Add a new result; return True iff a button was actually appen-
+        ded. Idempotent on tool_use_id. Returns False once the 25-button
+        cap is hit — caller should fall back to a different surface
+        (e.g., the per-message file attachment path) for the overflow.
+        """
+        if tool_use_id in self._results:
+            return False  # already added
+        if len(self._results) >= self._MAX_BUTTONS:
+            return False  # at cap
+        self._results[tool_use_id] = (tool_name, content)
+        index = len(self._results)
+        # Custom_id must be unique per button across the bot's active
+        # views; embed the tool_use_id so callbacks can dispatch.
+        button = discord.ui.Button(  # type: ignore[var-annotated]
+            label=f"📄 #{index} {tool_name[:18]}",
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"clauded_toolresult_{tool_use_id[:64]}",
+        )
+
+        async def _callback(interaction: discord.Interaction) -> None:
+            await self._dispatch(interaction, tool_use_id)
+
+        button.callback = _callback  # type: ignore[assignment]
+        self._buttons[tool_use_id] = button
+        self.add_item(button)
+        return True
+
+    async def _dispatch(self, interaction: discord.Interaction, tool_use_id: str) -> None:
+        """Send the .txt file as an ephemeral followup visible only to
+        the user who clicked."""
+        entry = self._results.get(tool_use_id)
+        if entry is None:
+            try:
+                await interaction.response.send_message(
+                    "⚠️ Result no longer available.", ephemeral=True
+                )
+            except discord.HTTPException:
+                pass
+            return
+        tool_name, content = entry
+        file_bytes = content.encode("utf-8", errors="replace")
+        file_name = f"{tool_name.lower()}_result.txt"
+        try:
+            await interaction.response.send_message(
+                content=(
+                    f"📄 **{tool_name} result** \u2014 "
+                    f"{len(content)} chars / {content.count(chr(10)) + 1} lines"
+                ),
+                file=discord.File(fp=io.BytesIO(file_bytes), filename=file_name),
+                ephemeral=True,
+            )
+        except discord.HTTPException as exc:
+            log.warning("ToolResultsView dispatch failed: %s", exc)
+            try:
+                await interaction.response.send_message(
+                    f"⚠️ Could not send result: {exc.text[:200] if hasattr(exc, 'text') else 'unknown'}",
+                    ephemeral=True,
+                )
+            except discord.HTTPException:
+                pass
+
+
 class RetryView(discord.ui.View):
     """View attached to a crash embed that re-runs the last user message."""
 
@@ -2537,6 +2628,7 @@ class RetryView(discord.ui.View):
 __all__ = [
     "DiscordRenderer",
     "RetryView",
+    "ToolResultsView",
     "COLOR_CLAUDE",
     "COLOR_TOOL_RUNNING",
     "COLOR_TOOL_SUCCESS",

--- a/tests/test_tool_result_shorttier.py
+++ b/tests/test_tool_result_shorttier.py
@@ -518,3 +518,48 @@ async def test_toolresults_view_button_label_truncates_long_tool_name():
     assert len(label) <= 80, f"Discord button label cap exceeded: {len(label)}"
     # First 18 chars of name preserved
     assert long_name[:18] in label
+
+
+@pytest.mark.asyncio
+async def test_toolresults_view_rejects_non_author_click():
+    """R1 security: when author_id is set at View construction, clicks
+    from a different user must NOT receive the .txt — they get a polite
+    refusal message ephemerally. Defends against same-channel third
+    parties reading another user's tool output."""
+    from clauded.discord_renderer import ToolResultsView
+    from unittest.mock import AsyncMock, MagicMock
+
+    view = ToolResultsView(author_id=12345)
+    view.add_result(tool_use_id="tool-x", tool_name="Bash", content="x" * 500)
+
+    # Author click — should send the file
+    author_interaction = MagicMock()
+    author_interaction.user.id = 12345
+    author_interaction.response.send_message = AsyncMock()
+    await view._dispatch(author_interaction, "tool-x")
+    args, kwargs = author_interaction.response.send_message.call_args
+    assert kwargs.get("file") is not None
+    assert "Bash result" in kwargs.get("content", "")
+    assert kwargs.get("ephemeral") is True
+
+    # Non-author click — should get a refusal, no file
+    intruder_interaction = MagicMock()
+    intruder_interaction.user.id = 99999
+    intruder_interaction.response.send_message = AsyncMock()
+    await view._dispatch(intruder_interaction, "tool-x")
+    args, kwargs = intruder_interaction.response.send_message.call_args
+    # Refusal sent as positional content arg (no file kwarg)
+    assert kwargs.get("file") is None
+    refusal_text = args[0] if args else kwargs.get("content", "")
+    assert "only viewable" in refusal_text
+    assert kwargs.get("ephemeral") is True
+
+
+def test_toolresults_view_has_finite_default_timeout():
+    """R1 architect: persistent views (timeout=None) accumulate over
+    long bot uptimes since discord.py never garbage-collects them.
+    Default timeout is now 24h (86400s) so abandoned views from past
+    turns get released."""
+    from clauded.discord_renderer import ToolResultsView
+    v = ToolResultsView()
+    assert v.timeout == 86400.0

--- a/tests/test_tool_result_shorttier.py
+++ b/tests/test_tool_result_shorttier.py
@@ -282,22 +282,23 @@ def test_medium_tier_content_preserves_raw_bytes():
 
 
 @pytest.mark.asyncio
-async def test_medium_tier_integration_emits_file_attachment():
+async def test_medium_tier_integration_attaches_view_button():
     """Integration: drive render_response with a medium-tier Bash result
     (multiline) and verify:
-      1. Rolling log embed updated with summary line ('N lines / M chars
-         (see attached file)')
-      2. Separate message sent with a discord.File attachment whose body
-         contains the raw tool output verbatim (no spoiler escape).
+      1. Rolling log embed updated with summary line ending '(⬇ click
+         to view)' — no separate detail message
+      2. The same rolling-log message edit attaches a ToolResultsView
+         containing 1 button labeled with the tool name and ordinal
+      3. The view holds the raw content; clicking would dispatch an
+         ephemeral with the .txt file attachment
     """
-    import sys, io
+    import sys
     sys.path.insert(0, "src")
     from unittest.mock import MagicMock
-    import discord
     from claude_agent_sdk.types import (
         AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
     )
-    from clauded.discord_renderer import DiscordRenderer
+    from clauded.discord_renderer import DiscordRenderer, ToolResultsView
 
     class FakeBridge:
         def __init__(self, events):
@@ -312,13 +313,14 @@ async def test_medium_tier_integration_emits_file_attachment():
         def __init__(self):
             self.content = ""
             self.embeds = []
-            self.attachments = []
-            self.sent_kwargs = None
+            self.attached_view = None
         async def edit(self, **kwargs):
             if "content" in kwargs:
                 self.content = kwargs["content"]
             if "embed" in kwargs:
                 self.embeds = [kwargs["embed"]]
+            if "view" in kwargs:
+                self.attached_view = kwargs["view"]
             return self
         async def delete(self):
             return None
@@ -329,45 +331,34 @@ async def test_medium_tier_integration_emits_file_attachment():
             self._sent = []
         async def send(self, *args, **kwargs):
             msg = FakeMessage()
-            msg.sent_kwargs = kwargs
             if "content" in kwargs:
                 msg.content = kwargs["content"]
             if "embed" in kwargs:
                 msg.embeds = [kwargs["embed"]]
-            if "file" in kwargs:
-                msg.attachments = [kwargs["file"]]
+            if "view" in kwargs:
+                msg.attached_view = kwargs["view"]
             self._sent.append(msg)
             return msg
 
-    # Medium-tier output: 30-line Bash stdout (~500 chars)
     medium_content = "\n".join(f"line {i}: some output text here" for i in range(30))
     assert 200 <= len(medium_content) < 8000
 
     events = [
         AssistantMessage(
             content=[
-                ToolUseBlock(
-                    id="tool-1", name="Bash",
-                    input={"command": "ls -la"},
-                ),
+                ToolUseBlock(id="tool-1", name="Bash", input={"command": "ls -la"}),
             ],
-            model="claude-sonnet",
-            parent_tool_use_id=None,
+            model="claude-sonnet", parent_tool_use_id=None,
         ),
         AssistantMessage(
             content=[
                 ToolResultBlock(tool_use_id="tool-1", content=medium_content, is_error=False),
             ],
-            model="claude-sonnet",
-            parent_tool_use_id=None,
+            model="claude-sonnet", parent_tool_use_id=None,
         ),
         ResultMessage(
-            subtype="result",
-            duration_ms=100,
-            duration_api_ms=80,
-            is_error=False,
-            num_turns=1,
-            session_id="sess-medium",
+            subtype="result", duration_ms=100, duration_api_ms=80,
+            is_error=False, num_turns=1, session_id="sess-medium",
             total_cost_usd=0.001,
         ),
     ]
@@ -377,34 +368,47 @@ async def test_medium_tier_integration_emits_file_attachment():
     bridge = FakeBridge(events)
     await renderer.render_response(bridge, "ls -la")
 
-    # 1) rolling log embed
-    rolling_log_embeds = [
+    # Find the rolling-log message (it's the one with the Tool Activity
+    # embed and a ToolResultsView attached).
+    rolling_log_msgs = [
         m for m in target._sent
         if m.embeds and (m.embeds[0].title or "") == "🔧 Tool Activity"
     ]
-    assert rolling_log_embeds, (
-        f"Expected Tool Activity rolling-log embed; got: "
-        f"{[(m.embeds[0].title if m.embeds else None) for m in target._sent]}"
+    assert rolling_log_msgs, (
+        f"Expected Tool Activity rolling-log msg; got: "
+        f"{[(m.embeds[0].title if m.embeds else None, type(m.attached_view).__name__) for m in target._sent]}"
     )
-    final_log = rolling_log_embeds[-1].embeds[0].description
-    assert "30 lines" in final_log
-    assert "see attached file" in final_log
-
-    # 2) file attachment message
-    file_msgs = [
+    rolling = rolling_log_msgs[-1]
+    # Summary line on the embed
+    desc = rolling.embeds[0].description
+    assert "30 lines" in desc
+    assert "click to view" in desc
+    # View attached with the button
+    assert isinstance(rolling.attached_view, ToolResultsView), (
+        f"Expected ToolResultsView attached to rolling log; got: "
+        f"{type(rolling.attached_view).__name__}"
+    )
+    view: ToolResultsView = rolling.attached_view
+    assert len(view._results) == 1
+    name, content = view._results["tool-1"]
+    assert name == "Bash"
+    assert content == medium_content
+    # Button label includes ordinal + tool name
+    button = view._buttons["tool-1"]
+    assert "#1" in button.label
+    assert "Bash" in button.label
+    # NO separate detail message was sent
+    other_msgs = [
         m for m in target._sent
-        if m.attachments and isinstance(m.attachments[0], discord.File)
+        if not (m.embeds and (m.embeds[0].title or "") == "🔧 Tool Activity")
     ]
-    assert file_msgs, f"Expected a discord.File attachment for medium tier; got: {target._sent}"
-    file_msg = file_msgs[0]
-    # Label content present
-    assert "Bash result" in file_msg.content
-    assert f"{len(medium_content)} chars" in file_msg.content
-    # File payload preserves content verbatim
-    detail_file = file_msg.attachments[0]
-    assert detail_file.filename == "bash_result.txt"
-    detail_file.fp.seek(0)
-    assert detail_file.fp.read().decode("utf-8") == medium_content
+    # `other_msgs` may contain cost-footer-style messages; assert none has
+    # the old separate-file-attachment shape.
+    for m in other_msgs:
+        assert not (m.content and m.content.startswith("📄 ")), (
+            f"Medium-tier should NOT send a separate 📄 message anymore; got: "
+            f"{m.content[:120]!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -460,99 +464,57 @@ def test_multiline_short_content_falls_to_bare_branch():
 
 
 @pytest.mark.asyncio
-async def test_medium_tier_detail_send_failure_downgrades_log():
-    """R1 engineer #2 mitigation: if the detail embed send fails (rate-
-    limited, network blip), rewrite the rolling log line to NOT promise
-    a clickable detail. User would otherwise see ``click below to expand``
-    pointing at no follow-up message.
+async def test_toolresults_view_add_result_idempotent_and_capped():
+    """v1.18 R3: replace the old send-failure test (file-attachment
+    fallback is gone). Pin the ToolResultsView contract directly:
+
+    - add_result is idempotent on tool_use_id (same id twice → single
+      button, second call returns False)
+    - 25-button cap honored (Discord per-view limit). Once full,
+      add_result returns False and the view stops accepting new ones.
+    - Button label includes ordinal (#N) and tool name (truncated to
+      18 chars to fit Discord's 80-char label cap with the prefix).
     """
-    import sys
-    sys.path.insert(0, "src")
-    from unittest.mock import MagicMock
-    from claude_agent_sdk.types import (
-        AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
-    )
-    from clauded.discord_renderer import DiscordRenderer
+    from clauded.discord_renderer import ToolResultsView
 
-    class FakeBridge:
-        def __init__(self, events):
-            self._events = events
-            self.is_active = True
-            self._client = MagicMock()
-        async def send_message(self, _text):
-            for ev in self._events:
-                yield ev
+    view = ToolResultsView()
 
-    class FakeMessage:
-        def __init__(self):
-            self.content = ""
-            self.embeds = []
-        async def edit(self, **kwargs):
-            if "content" in kwargs:
-                self.content = kwargs["content"]
-            if "embed" in kwargs:
-                self.embeds = [kwargs["embed"]]
-            return self
-        async def delete(self):
-            return None
+    # First add succeeds, second add (same id) is no-op
+    assert view.add_result(tool_use_id="id-1", tool_name="Bash", content="x" * 500) is True
+    assert view.add_result(tool_use_id="id-1", tool_name="Bash", content="x" * 500) is False
+    assert len(view._results) == 1
+    assert len(view._buttons) == 1
+    btn = view._buttons["id-1"]
+    assert "#1" in btn.label
+    assert "Bash" in btn.label
 
-    class FailingSendTarget:
-        """Target whose .send() returns None for the file-attachment msg
-        (sim'd rate-limit / network blip) but succeeds for embed-only
-        sends (rolling log)."""
-        def __init__(self):
-            self.id = 1
-            self._sent = []
-            self._call_count = 0
-        async def send(self, *args, **kwargs):
-            self._call_count += 1
-            # File-attachment sends fail (medium-tier detail)
-            if kwargs.get("file") is not None:
-                return None
-            # Embed-only sends succeed (rolling log creation)
-            msg = FakeMessage()
-            if "content" in kwargs:
-                msg.content = kwargs["content"]
-            if "embed" in kwargs:
-                msg.embeds = [kwargs["embed"]]
-            self._sent.append(msg)
-            return msg
+    # Different id → new button at ordinal #2
+    assert view.add_result(tool_use_id="id-2", tool_name="Read", content="x" * 500) is True
+    assert "#2" in view._buttons["id-2"].label
 
-    medium_content = "\n".join(f"line {i}: out" for i in range(50))
-    assert 200 <= len(medium_content) < 8000
+    # Fill to cap (25)
+    for i in range(3, 26):
+        ok = view.add_result(tool_use_id=f"id-{i}", tool_name="Tool", content="x" * 500)
+        assert ok is True
+    assert len(view._results) == 25
 
-    events = [
-        AssistantMessage(
-            content=[ToolUseBlock(id="t1", name="Bash", input={"command": "ls"})],
-            model="claude-sonnet", parent_tool_use_id=None,
-        ),
-        AssistantMessage(
-            content=[ToolResultBlock(tool_use_id="t1", content=medium_content, is_error=False)],
-            model="claude-sonnet", parent_tool_use_id=None,
-        ),
-        ResultMessage(
-            subtype="result", duration_ms=100, duration_api_ms=80,
-            is_error=False, num_turns=1, session_id="sess-fail",
-            total_cost_usd=0.001,
-        ),
-    ]
+    # 26th add: refused
+    assert view.add_result(tool_use_id="id-overflow", tool_name="Tool", content="x" * 500) is False
+    assert len(view._results) == 25
 
-    target = FailingSendTarget()
-    renderer = DiscordRenderer(target)
-    bridge = FakeBridge(events)
-    await renderer.render_response(bridge, "ls")
 
-    # Find the LAST Tool Activity rolling-log embed
-    rolling_embeds = [m for m in target._sent if m.embeds and "Tool Activity" in (m.embeds[0].title or "")]
-    assert rolling_embeds, "Expected at least one Tool Activity rolling-log embed"
-    final_log_desc = rolling_embeds[-1].embeds[0].description
-    # The rolling log line MUST have been downgraded to NOT say "click below"
-    assert "click below" not in final_log_desc, (
-        f"After detail send failure, rolling log MUST NOT promise a click target; "
-        f"got: {final_log_desc!r}"
-    )
-    # Should mention the failure
-    assert "detail send failed" in final_log_desc, (
-        f"Expected 'detail send failed' in downgraded rolling log; "
-        f"got: {final_log_desc!r}"
-    )
+@pytest.mark.asyncio
+async def test_toolresults_view_button_label_truncates_long_tool_name():
+    """Discord button labels max 80 chars. Tool names can be arbitrary
+    SDK strings (Task, ExitPlanMode, plus future MCP tools). The view
+    truncates the name segment to 18 chars so the full label fits as
+    ``📄 #N <name[:18]>`` (≄30 chars total)."""
+    from clauded.discord_renderer import ToolResultsView
+
+    view = ToolResultsView()
+    long_name = "VeryLongHypotheticalToolName_That_Will_Get_Truncated"
+    view.add_result(tool_use_id="id-x", tool_name=long_name, content="x" * 500)
+    label = view._buttons["id-x"].label
+    assert len(label) <= 80, f"Discord button label cap exceeded: {len(label)}"
+    # First 18 chars of name preserved
+    assert long_name[:18] in label


### PR DESCRIPTION
P0 UX fix — separate file-attachment message (PR #178) still occupied a full message card slot in the channel. Real zero-space UX = button attached to the rolling-log message itself; click → ephemeral file (only the clicker sees it).

## What
- New `ToolResultsView` (`discord.ui.View`, persistent timeout=None)
- Each medium-tier (200 ≤ len < 8000) ToolResultBlock adds a `📄 #N {name}` button to the existing rolling-log Tool Activity message (same _safe_edit call, no new message)
- Button click → ephemeral followup with `.txt` attachment

## Live smoke
```
🔧 Tool Activity
✅ Bash: 80 lines / 230 chars (⬇ click to view)
[📄 #1 Bash]   ← single button on the same message
```
No separate detail message — zero extra channel space until clicked.

## Discord limits respected
- 25 buttons / view (per-turn cap; add_result returns False at 26)
- 80-char button label (tool name truncated to 18 chars)
- Buttons each have stable custom_id derived from tool_use_id

## Tests
15/15 pass. Renamed integration test; added 2 new unit tests for the View contract (idempotency, cap, label truncation).

pytest 561 / 2 pre-existing P1.
