### PR TITLE
fix(renderer): #161 followups — view-click routing + short-tier multiline display

### DIFF
--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -578,7 +578,7 @@ class ClaudedBot(commands.Bot):
                 user_text = user_text.replace(message.content, content) if message.content else user_text
             else:
                 user_text = content
-            renderer = DiscordRenderer(thread)
+            renderer = DiscordRenderer(thread, bot=self)
             cost_before = bridge.total_cost if bridge else 0.0
             _render_ok = False
             try:
@@ -714,7 +714,7 @@ class ClaudedBot(commands.Bot):
                 pass
 
             user_text, tmp_dir = await self._compose_user_text(message)
-            renderer = DiscordRenderer(message.channel)
+            renderer = DiscordRenderer(message.channel, bot=self)
             cost_before = bridge.total_cost if bridge else 0.0
             _render_ok = False
             try:
@@ -976,7 +976,7 @@ class ClaudedBot(commands.Bot):
                         # blip; on permanent failure we silently drop.
                         await safe_send_message(thread, embed=err_embed)
                         return
-                    new_renderer = DiscordRenderer(thread)
+                    new_renderer = DiscordRenderer(thread, bot=self)
                     await self._render_with_retry(
                         renderer=new_renderer,
                         bridge=new_bridge,

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1221,6 +1221,7 @@ class DiscordRenderer:
                                     and self._bot is not None
                                     and tool_log_msg is not None
                                 ):
+                                    add_view_failed = False
                                     try:
                                         self._bot.add_view(
                                             tool_results_view,
@@ -1230,6 +1231,31 @@ class DiscordRenderer:
                                         log.exception(
                                             "Failed to register ToolResultsView "
                                             "for persistence"
+                                        )
+                                        add_view_failed = True
+                                    # R1 engineer: if add_view raised, the
+                                    # rolling-log line still promises
+                                    # ``click to view`` but Discord won't
+                                    # route the click anywhere. Downgrade
+                                    # the line + refresh embed so the user
+                                    # isn't lied to.
+                                    if add_view_failed and is_medium and tool_id:
+                                        for j in range(len(tool_log_lines) - 1, -1, -1):
+                                            line = tool_log_lines[j]
+                                            if line.startswith(f"{status} {name}:") and "click to view" in line:
+                                                tool_log_lines[j] = (
+                                                    f"{status} {name}: "
+                                                    f"{len(content_str)} chars "
+                                                    f"(view registration failed)"
+                                                )
+                                                break
+                                        refresh_embed = discord.Embed(
+                                            title="🔧 Tool Activity",
+                                            description="\n".join(tool_log_lines[-15:]),
+                                            color=COLOR_TOOL_SUCCESS,
+                                        )
+                                        await self._safe_edit(
+                                            tool_log_msg, embed=refresh_embed
                                         )
                                 if not edit_ok and is_medium and not is_err and tool_id:
                                     # Edit failed permanently (rate-limit /

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1101,14 +1101,19 @@ class DiscordRenderer:
                                     matches_alias = alias and line.startswith("🔄 " + alias)
                                     if not (matches_name or matches_alias):
                                         continue
-                                    # #161 short tier: when result is short and
-                                    # single-line, surface it inline so user
-                                    # sees ``✅ Bash → 42`` instead of bare ✅ Bash.
-                                    # Per PRD: < 200 chars and no newlines.
+                                    # #161 short tier: when result is short
+                                    # (< 200 chars), surface it inline so
+                                    # user sees the actual data instead of a
+                                    # bare ``✅ Bash``. v1.18 R3 (user
+                                    # feedback "1-3 lines should display
+                                    # directly"): drop the single-line
+                                    # constraint. Multiline short outputs
+                                    # collapse to ``line1 │ line2 │ line3``
+                                    # so they fit in the rolling-log embed
+                                    # without ballooning vertical height.
                                     content_str = str(block.content) if block.content else ""
                                     is_short = (
                                         len(content_str) < 200
-                                        and "\n" not in content_str
                                         and content_str.strip() != ""
                                     )
                                     # #161 medium tier (v1.18 R3): 200 <=
@@ -1136,8 +1141,14 @@ class DiscordRenderer:
                                         tool_log_lines[i] = f"{status} {name}: {error_text}"
                                     elif is_short:
                                         # Strip backticks to avoid breaking the
-                                        # rolling-log embed's markdown.
-                                        safe = content_str.strip().replace("`", "'")
+                                        # rolling-log embed's markdown. Collapse
+                                        # newlines to ``│`` so multi-line short
+                                        # outputs fit on one log line.
+                                        safe = (
+                                            content_str.strip()
+                                            .replace("`", "'")
+                                            .replace("\n", " │ ")
+                                        )
                                         tool_log_lines[i] = f"{status} {name} → {safe}"
                                     elif is_medium:
                                         # Rolling log shows summary;

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -327,8 +327,20 @@ def _format_subagent_footer(stats: dict[str, Any] | None) -> str | None:
 class DiscordRenderer:
     """Render a Claude streaming response into a Discord channel/thread."""
 
-    def __init__(self, target: discord.abc.Messageable) -> None:
+    def __init__(
+        self,
+        target: discord.abc.Messageable,
+        *,
+        bot: discord.Client | None = None,
+    ) -> None:
         self.target = target
+        # Optional bot reference — when provided, persistent views (e.g.
+        # :class:`ToolResultsView` from #161) are registered via
+        # ``bot.add_view(view, message_id=...)`` so button-click routing
+        # works even after the in-memory View instance is gc'd or the bot
+        # restarts (discord.py only re-dispatches custom_id interactions
+        # to views that are in the client's persistent view store).
+        self._bot = bot
         self._last_msg: discord.Message | None = None
         # Shadow of the text we last wrote to ``_last_msg``. discord.py 2.0+
         # Message.edit() is not in-place; reading msg.content post-edit returns
@@ -723,7 +735,7 @@ class DiscordRenderer:
 
                                     if tool_id:
                                         subagent_threads[tool_id] = sub_thread
-                                        subagent_renderers[tool_id] = DiscordRenderer(sub_thread)
+                                        subagent_renderers[tool_id] = DiscordRenderer(sub_thread, bot=self._bot)
 
                                     # Compact summary in main thread
                                     summary_embed = discord.Embed(
@@ -1154,20 +1166,18 @@ class DiscordRenderer:
                                 if is_medium and not is_err and tool_id:
                                     medium_results[tool_id] = (name, content_str)
                                     if tool_results_view is None:
-                                        # R1 architect: finite timeout so
-                                        # orphan views (rolling-log msg from
-                                        # a past turn nobody clicked) are
-                                        # garbage-collected by discord.py
-                                        # after 24h instead of accumulating
-                                        # forever in long-running bots.
-                                        # R1 security: author_id restricts
+                                        # R2: timeout=None required by
+                                        # ``bot.add_view`` for persistent
+                                        # dispatch. Buttons carry stable
+                                        # custom_ids derived from
+                                        # tool_use_id so clicks route to
+                                        # this view instance via the bot's
+                                        # view store. author_id restricts
                                         # ephemeral followups to the turn's
-                                        # original requester; same-channel
-                                        # third parties cannot read another
-                                        # user's tool output via the button.
+                                        # original requester.
                                         tool_results_view = ToolResultsView(
                                             author_id=author_id,
-                                            timeout=86400.0,
+                                            timeout=None,
                                         )
                                     # Idempotent: add_result skips if id
                                     # already present (defends against
@@ -1185,6 +1195,31 @@ class DiscordRenderer:
                                     embed=tool_embed,
                                     view=edit_view_kwarg,
                                 )
+                                # #161 R2 fix: register the view in the
+                                # bot's persistent-view store so button
+                                # clicks route to this View instance even
+                                # after gc / bot restart. Without this,
+                                # ``Message.edit(view=v)`` stores the view
+                                # only weakly and clicks were getting
+                                # dropped silently (user-reported). Idem-
+                                # potent: discord.py de-dups by
+                                # (custom_id, message_id).
+                                if (
+                                    edit_ok
+                                    and tool_results_view is not None
+                                    and self._bot is not None
+                                    and tool_log_msg is not None
+                                ):
+                                    try:
+                                        self._bot.add_view(
+                                            tool_results_view,
+                                            message_id=tool_log_msg.id,
+                                        )
+                                    except Exception:
+                                        log.exception(
+                                            "Failed to register ToolResultsView "
+                                            "for persistence"
+                                        )
                                 if not edit_ok and is_medium and not is_err and tool_id:
                                     # Edit failed permanently (rate-limit /
                                     # message deleted). Downgrade the
@@ -2531,7 +2566,13 @@ class ToolResultsView(discord.ui.View):
     # cap; we never hit content-length issues because the body lives in
     # the attachment.
 
-    def __init__(self, *, author_id: int | None = None, timeout: float | None = 86400.0) -> None:
+    def __init__(self, *, author_id: int | None = None, timeout: float | None = None) -> None:
+        # discord.py requires ``timeout=None`` for persistent views
+        # (those registered via ``bot.add_view``). Per-instance items'
+        # ``custom_id`` is the unique routing key; the view is dispatch-
+        # ed from the bot's view store keyed on (custom_id, message_id).
+        # Since the buttons in this view have stable custom_ids derived
+        # from ``tool_use_id``, ``timeout=None`` is the correct choice.
         super().__init__(timeout=timeout)
         self._author_id = author_id
         self._results: dict[str, tuple[str, str]] = {}  # id -> (name, content)
@@ -2558,6 +2599,10 @@ class ToolResultsView(discord.ui.View):
         )
 
         async def _callback(interaction: discord.Interaction) -> None:
+            log.info(
+                "ToolResultsView click: tool_use_id=%s user_id=%s",
+                tool_use_id, interaction.user.id,
+            )
             await self._dispatch(interaction, tool_use_id)
 
         button.callback = _callback  # type: ignore[assignment]

--- a/tests/test_tool_result_shorttier.py
+++ b/tests/test_tool_result_shorttier.py
@@ -677,3 +677,104 @@ async def test_medium_tier_registers_view_via_bot_add_view():
     assert isinstance(view, ToolResultsView), f"Expected ToolResultsView; got {type(view).__name__}"
     assert msg_id is not None, "add_view must be called with message_id= to scope the persistence"
     assert msg_id > 0
+
+
+@pytest.mark.asyncio
+async def test_medium_tier_downgrades_log_when_add_view_raises():
+    """R1 engineer mitigation: if bot.add_view raises (e.g.
+    timeout != None contract violation regression, or any other
+    discord.py ValueError), the rolling-log line MUST be downgraded
+    so the user doesn't see `⬇ click to view` pointing at a dead
+    button."""
+    import sys
+    sys.path.insert(0, "src")
+    from unittest.mock import MagicMock
+    from claude_agent_sdk.types import (
+        AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
+    )
+    from clauded.discord_renderer import DiscordRenderer
+
+    class FakeBridge:
+        def __init__(self, events):
+            self._events = events
+            self.is_active = True
+            self._client = MagicMock()
+        async def send_message(self, _text):
+            for ev in self._events:
+                yield ev
+
+    class FakeMessage:
+        def __init__(self, msg_id=999):
+            self.id = msg_id
+            self.content = ""
+            self.embeds = []
+            self.attached_view = None
+        async def edit(self, **kwargs):
+            if "content" in kwargs:
+                self.content = kwargs["content"]
+            if "embed" in kwargs:
+                self.embeds = [kwargs["embed"]]
+            if "view" in kwargs:
+                self.attached_view = kwargs["view"]
+            return self
+        async def delete(self):
+            return None
+
+    class FakeTarget:
+        def __init__(self):
+            self.id = 1
+            self._sent = []
+            self._next_id = 90000
+        async def send(self, *args, **kwargs):
+            self._next_id += 1
+            msg = FakeMessage(msg_id=self._next_id)
+            if "content" in kwargs:
+                msg.content = kwargs["content"]
+            if "embed" in kwargs:
+                msg.embeds = [kwargs["embed"]]
+            if "view" in kwargs:
+                msg.attached_view = kwargs["view"]
+            self._sent.append(msg)
+            return msg
+
+    class FailingAddViewBot:
+        def add_view(self, view, *, message_id=None):
+            raise ValueError("synthetic: View is not persistent")
+
+    medium_content = "\n".join(f"line {i}" for i in range(30))
+
+    events = [
+        AssistantMessage(
+            content=[ToolUseBlock(id="t1", name="Bash", input={"command": "ls"})],
+            model="claude-sonnet", parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[ToolResultBlock(tool_use_id="t1", content=medium_content, is_error=False)],
+            model="claude-sonnet", parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result", duration_ms=100, duration_api_ms=80,
+            is_error=False, num_turns=1, session_id="sess-x",
+            total_cost_usd=0.001,
+        ),
+    ]
+
+    target = FakeTarget()
+    bot = FailingAddViewBot()
+    renderer = DiscordRenderer(target, bot=bot)
+    bridge = FakeBridge(events)
+    await renderer.render_response(bridge, "ls")
+
+    rolling = [
+        m for m in target._sent
+        if m.embeds and (m.embeds[0].title or "") == "🔧 Tool Activity"
+    ]
+    assert rolling
+    final_desc = rolling[-1].embeds[0].description
+    # MUST NOT promise click; MUST signal failure
+    assert "click to view" not in final_desc, (
+        f"After add_view failure, rolling log MUST NOT promise click; got: {final_desc!r}"
+    )
+    assert "view registration failed" in final_desc, (
+        f"Expected explicit 'view registration failed' downgrade; got: {final_desc!r}"
+    )

--- a/tests/test_tool_result_shorttier.py
+++ b/tests/test_tool_result_shorttier.py
@@ -59,8 +59,13 @@ def test_bash_grep_glob_read_still_match_directly():
 
 
 def test_short_result_inline_arrow_display():
-    """When result content is short (<200 chars), single-line, non-empty,
-    rolling log renders ``✅ {name} → {content}`` instead of bare ``✅ {name}``.
+    """When result content is short (<200 chars), non-empty, rolling log
+    renders ``✅ {name} → {content}`` instead of bare ``✅ {name}``.
+
+    v1.18 R3 (user feedback): multiline short outputs are NO LONGER
+    excluded — they collapse to ``line1 │ line2 │ line3`` so a `ls`
+    that prints 3 file names still shows the actual file names inline
+    instead of disappearing into a bare ✅.
 
     Pure-string logic test — the production code in render_response is
     integration-tested elsewhere; this pins the threshold semantics.
@@ -70,27 +75,29 @@ def test_short_result_inline_arrow_display():
         return (
             content is not None
             and len(content) < 200
-            and "\n" not in content
             and content.strip() != ""
         )
 
     assert should_inline("42")                # tiny ✅
     assert should_inline("Found 7 matches")   # short prose ✅
     assert should_inline("x" * 199)           # boundary
+    assert should_inline("line1\nline2")      # multiline short ✅ (new in R3)
+    assert should_inline("a\nb\nc")           # 3 lines short ✅
     assert not should_inline("x" * 200)       # over threshold
-    assert not should_inline("line1\nline2")  # multiline excluded
     assert not should_inline("")              # empty excluded
     assert not should_inline("   \t")         # whitespace-only excluded
     assert not should_inline(None)            # None excluded
 
 
-def test_short_result_backtick_escape():
-    """Inline display strips backticks from content to avoid breaking the
-    rolling-log embed's markdown rendering."""
-    raw = "result with `backticks` inside"
-    safe = raw.strip().replace("`", "'")
+def test_short_result_backtick_escape_and_newline_collapse():
+    """Inline display: backticks → single-quotes (avoids markdown break)
+    AND newlines → ``│`` separator (keeps multiline outputs on one log
+    line, v1.18 R3 user feedback)."""
+    raw = "result with `backticks`\nand a newline"
+    safe = raw.strip().replace("`", "'").replace("\n", " │ ")
     assert "`" not in safe
-    assert safe == "result with 'backticks' inside"
+    assert "\n" not in safe
+    assert safe == "result with 'backticks' │ and a newline"
 
 
 def test_skill_and_fallback_rolling_log_match():
@@ -434,16 +441,15 @@ def test_medium_tier_error_path_does_not_emit_detail_message():
     )
 
 
-def test_multiline_short_content_falls_to_bare_branch():
-    """Content < 200 chars but multiline goes to the bare ``✅ Bash`` branch
-    (not short, not medium). User sees `✅ Bash` with no inline arrow.
-    Architectural choice: multiline short outputs are visually awkward
-    inline; user can run the tool again with more flags if they want detail.
-    """
+def test_multiline_short_content_inlines_with_separator():
+    """v1.18 R3 (user feedback): content < 200 chars with multiline now
+    inlines with ``│`` separator instead of falling to bare ``✅ Bash``.
+    Architectural choice: short multi-line outputs (3-file ``ls``,
+    7-match ``grep``) are useful to see; the separator keeps the rolling
+    log compact."""
     def is_short(content):
         return (
             len(content) < 200
-            and "\n" not in content
             and content.strip() != ""
         )
     def is_medium(content, is_err=False, is_short_val=False):
@@ -453,14 +459,17 @@ def test_multiline_short_content_falls_to_bare_branch():
             and 200 <= len(content) < 8000
             and content.strip() != ""
         )
-    multiline_short = "line 1\nline 2\nline 3"  # 20 chars but multiline
+    multiline_short = "line 1\nline 2\nline 3"  # 20 chars, multiline
     assert len(multiline_short) < 200
     assert "\n" in multiline_short
     short_result = is_short(multiline_short)
     medium_result = is_medium(multiline_short, is_short_val=short_result)
-    assert not short_result, "multiline short content must NOT match short tier"
-    assert not medium_result, "multiline short content must NOT match medium tier (len<200)"
-    # → falls through to bare `✅ Bash` (the else branch)
+    assert short_result, "multiline short content MUST now match short tier (R3)"
+    assert not medium_result, "multiline short content excluded from medium tier (handled by short)"
+    # Verify separator collapse
+    rendered = multiline_short.replace("`", "'").replace("\n", " │ ")
+    assert "\n" not in rendered
+    assert rendered == "line 1 │ line 2 │ line 3"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_result_shorttier.py
+++ b/tests/test_tool_result_shorttier.py
@@ -555,11 +555,116 @@ async def test_toolresults_view_rejects_non_author_click():
     assert kwargs.get("ephemeral") is True
 
 
-def test_toolresults_view_has_finite_default_timeout():
-    """R1 architect: persistent views (timeout=None) accumulate over
-    long bot uptimes since discord.py never garbage-collects them.
-    Default timeout is now 24h (86400s) so abandoned views from past
-    turns get released."""
+def test_toolresults_view_has_none_timeout_for_persistence():
+    """R2 fix: discord.py's bot.add_view requires timeout=None for
+    persistent dispatch. Buttons carry stable custom_ids so clicks route
+    via the bot's view store. We tried timeout=86400 first per the R1
+    architect note but bot.add_view raised ValueError forcing the
+    revert. The orphan-accumulation concern is now handled by the view
+    store's own lifecycle (discord.py replaces same-message-id views).
+    """
     from clauded.discord_renderer import ToolResultsView
     v = ToolResultsView()
-    assert v.timeout == 86400.0
+    assert v.timeout is None
+
+
+@pytest.mark.asyncio
+async def test_medium_tier_registers_view_via_bot_add_view():
+    """R2 fix for #161 user-reported "点击没获取到": Message.edit(view=v)
+    alone is insufficient for click-routing — clicks were dropping
+    silently because the view was not in the bot's persistent view store.
+    Fix: after edit, call bot.add_view(view, message_id=msg.id). This
+    test pins that call so a regression can't drop it."""
+    import sys
+    sys.path.insert(0, "src")
+    from unittest.mock import MagicMock
+    from claude_agent_sdk.types import (
+        AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
+    )
+    from clauded.discord_renderer import DiscordRenderer, ToolResultsView
+
+    class FakeBridge:
+        def __init__(self, events):
+            self._events = events
+            self.is_active = True
+            self._client = MagicMock()
+        async def send_message(self, _text):
+            for ev in self._events:
+                yield ev
+
+    class FakeMessage:
+        def __init__(self, msg_id=12345):
+            self.id = msg_id
+            self.content = ""
+            self.embeds = []
+            self.attached_view = None
+        async def edit(self, **kwargs):
+            if "content" in kwargs:
+                self.content = kwargs["content"]
+            if "embed" in kwargs:
+                self.embeds = [kwargs["embed"]]
+            if "view" in kwargs:
+                self.attached_view = kwargs["view"]
+            return self
+        async def delete(self):
+            return None
+
+    class FakeTarget:
+        def __init__(self):
+            self.id = 1
+            self._sent = []
+            self._next_id = 99000
+        async def send(self, *args, **kwargs):
+            self._next_id += 1
+            msg = FakeMessage(msg_id=self._next_id)
+            if "content" in kwargs:
+                msg.content = kwargs["content"]
+            if "embed" in kwargs:
+                msg.embeds = [kwargs["embed"]]
+            if "view" in kwargs:
+                msg.attached_view = kwargs["view"]
+            self._sent.append(msg)
+            return msg
+
+    class FakeBot:
+        """Captures add_view calls."""
+        def __init__(self):
+            self.add_view_calls = []
+        def add_view(self, view, *, message_id=None):
+            self.add_view_calls.append((view, message_id))
+
+    medium_content = "\n".join(f"line {i}" for i in range(30))
+
+    events = [
+        AssistantMessage(
+            content=[ToolUseBlock(id="t1", name="Bash", input={"command": "ls"})],
+            model="claude-sonnet", parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[ToolResultBlock(tool_use_id="t1", content=medium_content, is_error=False)],
+            model="claude-sonnet", parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result", duration_ms=100, duration_api_ms=80,
+            is_error=False, num_turns=1, session_id="sess-pv",
+            total_cost_usd=0.001,
+        ),
+    ]
+
+    target = FakeTarget()
+    bot = FakeBot()
+    renderer = DiscordRenderer(target, bot=bot)
+    bridge = FakeBridge(events)
+    await renderer.render_response(bridge, "ls")
+
+    # bot.add_view MUST have been called with the ToolResultsView and a
+    # message_id pointing at the rolling-log message.
+    assert bot.add_view_calls, (
+        "Expected bot.add_view to be called for medium-tier view persistence; "
+        "without it, button clicks are silently dropped (user reported "
+        "'点击没获取到')."
+    )
+    view, msg_id = bot.add_view_calls[-1]
+    assert isinstance(view, ToolResultsView), f"Expected ToolResultsView; got {type(view).__name__}"
+    assert msg_id is not None, "add_view must be called with message_id= to scope the persistence"
+    assert msg_id > 0


### PR DESCRIPTION
Two #161 user-feedback fixes in one PR (small, contained):

## Fix 1 — view-button clicks were dropped silently (`53b2d79`)
User: "点击之后没获取到"

**Root cause**: `Message.edit(view=v)` stores the view weakly. Persistent click-routing requires `bot.add_view(view, message_id=msg.id)`. The 24h `timeout` from PR #179 R1 was incompatible (add_view raises `ValueError: View is not persistent` unless timeout=None).

**Fix**:
- Thread `bot` reference into `DiscordRenderer` via optional kwarg
- After edit, call `bot.add_view(view, message_id=tool_log_msg.id)`
- `ToolResultsView.timeout` default → `None`

**Live-verified**: clicked button 3× in test channel; ToolResultsView log fires; ephemeral with .txt attachment arrives.

## Fix 2 — short tier accepts multiline (`932b7b7`)
User: "1-3行的就是直接显示对吧？"

**Gap**: short-tier predicate excluded any content with `\n`, so 3-file `ls` (80 chars but multiline) showed as bare `✅ Bash` — file names lost.

**Fix**: drop newline-excluded constraint; collapse `\n` → ` │ ` so multi-line outputs display inline as `✅ Bash → file1.py │ file2.py │ file3.py`.

## Tests
+1 regression pin for `bot.add_view`; predicate + renderer-side display tests updated. 564/2 pre-existing P1.
