### PR TITLE
fix(bot): sync slash commands per-guild only — no global sync, no duplicates (#185)

### DIFF
--- a/scripts/clear-global-slash-commands.py
+++ b/scripts/clear-global-slash-commands.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""One-shot: clear all GLOBAL slash commands for the bot.
+
+#185 cleanup: claudeD historically registered commands in BOTH global
+and per-guild scopes, so each command appeared twice in Discord
+autocomplete. Per-guild is the new canonical scope (instant sync vs
+~1h global propagation). Run this script ONCE to clear the leftover
+global commands, then the in-tree fix prevents re-registration.
+
+This script is destructive. It is gated on ``CONFIRM=1`` so a
+copy-paste-and-run accident can't silently nuke production commands.
+
+## Usage
+    cd /path/to/claudeD
+    CONFIRM=1 .venv/bin/python scripts/clear-global-slash-commands.py
+
+Reads ``DISCORD_BOT_TOKEN`` from ``.env`` in the repo root.
+"""
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+try:
+    from dotenv import dotenv_values
+except ImportError:
+    print("dotenv not installed. Run `pip install python-dotenv`.")
+    sys.exit(1)
+
+
+APP_ID = "1499415416701980704"
+
+
+def main() -> int:
+    if os.environ.get("CONFIRM") != "1":
+        print(
+            "REFUSED: this clears GLOBAL slash commands.\n"
+            "If you really mean to do that, re-run with CONFIRM=1:\n\n"
+            "    CONFIRM=1 .venv/bin/python scripts/clear-global-slash-commands.py\n"
+        )
+        return 1
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    if not env_path.exists():
+        print(f"ERROR: .env not found at {env_path}")
+        return 2
+    env = dotenv_values(env_path)
+    token = env.get("DISCORD_BOT_TOKEN")
+    if not token:
+        print("ERROR: DISCORD_BOT_TOKEN missing from .env")
+        return 3
+
+    url = f"https://discord.com/api/v10/applications/{APP_ID}/commands"
+    print(f"Bulk-overwriting GLOBAL commands at {url} to []...")
+    req = urllib.request.Request(
+        url,
+        data=b"[]",
+        headers={
+            "Authorization": f"Bot {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "DiscordBot (claudeD-cleanup, 1.0)",
+        },
+        method="PUT",
+    )
+    try:
+        resp = urllib.request.urlopen(req, timeout=15)
+        body = json.loads(resp.read())
+        if isinstance(body, list) and len(body) == 0:
+            print("OK: GLOBAL commands cleared (now 0).")
+            return 0
+        print(f"UNEXPECTED response shape: {body!r}")
+        return 4
+    except urllib.error.HTTPError as e:
+        print(f"HTTP {e.code}: {e.read().decode()[:300]}")
+        return 5
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -193,6 +193,9 @@ class ClaudedBot(commands.Bot):
         self.allow_unbound_fallback: bool = config.allow_unbound_fallback
         self._pre_tool_notifications: bool = False
         self._notify_enabled: dict[int, bool] = {}
+        # #185: per-guild slash-sync idempotency guard. on_ready can fire
+        # multiple times per process (reconnects); we sync each guild once.
+        self._slash_synced: set[int] = set()
 
     async def setup_hook(self) -> None:
         """Register slash command groups and sync to Discord."""
@@ -266,8 +269,16 @@ class ClaudedBot(commands.Bot):
         self.tree.add_command(btw_cmd)
         self.tree.add_command(context_cmd)
         self.tree.add_command(diff_cmd)
-        synced = await self.tree.sync()
-        log.info("Synced %d application command(s)", len(synced))
+        # #185: do NOT sync globally here — historically claudeD synced
+        # via both ``tree.sync()`` (global) AND PR-specific per-guild
+        # PUT calls, so commands ended up registered in BOTH scopes and
+        # showed twice in Discord's autocomplete. Per-guild sync is
+        # instant (vs. global's ~1h propagation) which is what a self-
+        # hosted bot wants. We sync per-guild from ``on_ready`` instead,
+        # where ``self.guilds`` is populated. Use guarded idempotency
+        # (``self._slash_synced`` initialized in __init__) so reconnect-
+        # driven re-fires don't repeatedly re-sync.
+        log.info("Slash commands registered in tree; per-guild sync deferred to on_ready")
 
     @tasks.loop(minutes=5)
     async def _cleanup_task(self) -> None:
@@ -316,6 +327,27 @@ class ClaudedBot(commands.Bot):
     async def on_ready(self) -> None:  # type: ignore[override]
         user = self.user
         log.info("Bot online as %s (id=%s)", user, getattr(user, "id", "?"))
+        # #185: sync slash commands per-guild on first on_ready. Guarded
+        # idempotency (``self._slash_synced``) so reconnect-driven
+        # re-fires don't waste Discord rate-limit budget. Global sync
+        # is intentionally NOT performed — see setup_hook for the
+        # historical duplicate-registration root cause.
+        guilds_synced: list[str] = []
+        for guild in self.guilds:
+            if guild.id in self._slash_synced:
+                continue
+            try:
+                # Copy globally-defined tree commands into the guild's
+                # scope so the existing ``self.tree.add_command(...)``
+                # API in setup_hook continues to work unchanged.
+                self.tree.copy_global_to(guild=guild)
+                synced = await self.tree.sync(guild=guild)
+                self._slash_synced.add(guild.id)
+                guilds_synced.append(f"{guild.name}({guild.id}):{len(synced)}")
+            except Exception:
+                log.exception("Per-guild slash sync failed for %s", guild.id)
+        if guilds_synced:
+            log.info("Per-guild slash sync done: %s", ", ".join(guilds_synced))
 
     async def on_message(self, message: discord.Message) -> None:  # type: ignore[override]
         # Always ignore self.

--- a/tests/test_slash_command_sync.py
+++ b/tests/test_slash_command_sync.py
@@ -86,3 +86,31 @@ async def test_on_ready_with_no_guilds_does_nothing():
     await ClaudedBot.on_ready(stub)
     assert stub._tree.sync.await_count == 0
     assert stub._slash_synced == set()
+
+
+def test_setup_hook_source_has_no_global_tree_sync():
+    """R1 tester regression pin: source-level assertion that setup_hook
+    never calls ``tree.sync()`` (i.e., without a guild kwarg). This was
+    THE bug — global sync registered all 26 commands in both scopes,
+    causing the autocomplete to show each twice.
+
+    Source-level test instead of behavioral mock because:
+    1. ``self.tree`` is a property with no setter on commands.Bot,
+       making a behavioral mock awkward (we'd have to patch the
+       property descriptor)
+    2. The bug class is "someone re-adds tree.sync() somewhere in
+       setup_hook" — a textual guard catches that even if the call
+       site moves
+    """
+    import inspect
+    from clauded.bot import ClaudedBot
+    src = inspect.getsource(ClaudedBot.setup_hook)
+    # Allow tree.sync(guild=...) but forbid bare tree.sync() / tree.sync(
+    # without a guild= keyword. Approximate via substring match (this is
+    # a regression test, not a parser):
+    for forbidden in ("await self.tree.sync()", "self.tree.sync()"):
+        assert forbidden not in src, (
+            f"setup_hook MUST NOT call {forbidden} — it registers commands "
+            f"GLOBALLY, which is what caused #185 (every command appeared "
+            f"twice in autocomplete). Per-guild sync from on_ready instead."
+        )

--- a/tests/test_slash_command_sync.py
+++ b/tests/test_slash_command_sync.py
@@ -1,0 +1,88 @@
+"""#185 — slash commands were registered to BOTH global and per-guild
+scopes, causing every command to appear twice in Discord autocomplete.
+
+Fix: only sync per-guild from on_ready (with idempotency guard).
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+
+class _BotStub:
+    """Bare stand-in: bypass ClaudedBot's full __init__ (needs discord
+    Client wiring, intents, etc.) and only assert on the sync surface."""
+    def __init__(self, guilds=()):
+        self._tree = MagicMock()
+        self._tree.sync = AsyncMock()
+        self._tree.copy_global_to = MagicMock()
+        self.guilds = list(guilds)
+        self._slash_synced: set[int] = set()
+        self.user = MagicMock(id=999, __str__=lambda self: "ClaudeBot#1130")
+
+    @property
+    def tree(self):
+        return self._tree
+
+
+@pytest.mark.asyncio
+async def test_on_ready_per_guild_sync_with_idempotency():
+    """on_ready syncs per-guild, marking each guild in ``_slash_synced``
+    so a reconnect re-fire doesn't re-sync."""
+    from clauded.bot import ClaudedBot
+    g1 = MagicMock(id=111, name="Guild1")
+    g2 = MagicMock(id=222, name="Guild2")
+    stub = _BotStub(guilds=[g1, g2])
+    stub._tree.sync.return_value = [MagicMock(), MagicMock()]
+
+    # First on_ready
+    await ClaudedBot.on_ready(stub)
+    assert stub._slash_synced == {111, 222}
+    assert stub._tree.sync.await_count == 2
+    assert stub._tree.copy_global_to.call_count == 2
+
+    # Second on_ready (reconnect simulation): no new syncs
+    stub._tree.sync.reset_mock()
+    stub._tree.copy_global_to.reset_mock()
+    await ClaudedBot.on_ready(stub)
+    assert stub._tree.sync.await_count == 0
+    assert stub._tree.copy_global_to.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_on_ready_new_guild_after_reconnect_gets_synced():
+    """If a guild was added between on_readys, only the new one syncs."""
+    from clauded.bot import ClaudedBot
+    g1 = MagicMock(id=111, name="Old")
+    g2 = MagicMock(id=222, name="New")
+    stub = _BotStub(guilds=[g1, g2])
+    stub._slash_synced = {111}
+    stub._tree.sync.return_value = [MagicMock()]
+
+    await ClaudedBot.on_ready(stub)
+    assert stub._tree.sync.await_count == 1
+    sync_call = stub._tree.sync.await_args_list[0]
+    assert sync_call.kwargs.get("guild") is g2
+    assert stub._slash_synced == {111, 222}
+
+
+@pytest.mark.asyncio
+async def test_on_ready_sync_failure_logged_but_does_not_block_others():
+    """One guild fails → others still sync."""
+    from clauded.bot import ClaudedBot
+    g1 = MagicMock(id=111, name="Fail")
+    g2 = MagicMock(id=222, name="OK")
+    stub = _BotStub(guilds=[g1, g2])
+    stub._tree.sync = AsyncMock(side_effect=[Exception("synthetic"), [MagicMock()]])
+
+    await ClaudedBot.on_ready(stub)
+    assert 222 in stub._slash_synced
+    assert 111 not in stub._slash_synced
+
+
+@pytest.mark.asyncio
+async def test_on_ready_with_no_guilds_does_nothing():
+    """No guilds (rare boot state): no syncs, no crash."""
+    from clauded.bot import ClaudedBot
+    stub = _BotStub(guilds=[])
+    await ClaudedBot.on_ready(stub)
+    assert stub._tree.sync.await_count == 0
+    assert stub._slash_synced == set()


### PR DESCRIPTION
Closes #185.

## Bug
All 26 slash commands appeared twice in Discord autocomplete (user screenshot showed `/model`, `/fallback-model`, `/context` duplicates).

## Root cause (verified by Discord REST audit)
Every command was registered in BOTH global AND test-guild scopes:
- GLOBAL: 26 (from `setup_hook`'s `tree.sync()`)
- GUILD: 26 (from the per-PR manual PUT force-sync we used to skip 1h global propagation)

Discord UI shows union → duplicates.

## Fix
- **Code**: drop global sync from `setup_hook`; add per-guild sync from `on_ready` with idempotency guard (handles reconnect re-fires, new-guild joins, partial failures)
- **One-shot data cleanup**: PUT empty array to global scope → cleared 26 global commands (verified live, applied before pushing)

## Live verification (Discord API)
- GLOBAL: 0 commands
- GUILD: 26 commands
- Discord autocomplete now shows 1 entry per command

## Tests
+4 in `test_slash_command_sync.py`. 581 / 2 pre-existing P1.
