### PR TITLE
feat(model): /model becomes a group with list/current/switch (#186)

### DIFF
--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -230,7 +230,7 @@ class ClaudedBot(commands.Bot):
         # ----- Import command objects from cog modules -----
         from .cogs.project import project_group, env_group
         from .cogs.session import session_group
-        from .cogs.model import switch_model, set_effort, max_turns_cmd, fallback_model_cmd, toggle_bare
+        from .cogs.model import model_group, set_effort, max_turns_cmd, fallback_model_cmd, toggle_bare
         from .cogs.tools import tools_group, budget_group
         from .cogs.agent import agent_group
         from .cogs.mcp import mcp_group
@@ -246,7 +246,7 @@ class ClaudedBot(commands.Bot):
         self.tree.add_command(project_group)
         self.tree.add_command(session_group)
         self.tree.add_command(cost_group)
-        self.tree.add_command(switch_model)
+        self.tree.add_command(model_group)
         self.tree.add_command(set_effort)
         self.tree.add_command(tools_group)
         self.tree.add_command(budget_group)

--- a/src/clauded/cogs/model.py
+++ b/src/clauded/cogs/model.py
@@ -165,15 +165,6 @@ async def model_switch_autocomplete(interaction: discord.Interaction, current: s
 model_switch.autocomplete("name")(model_switch_autocomplete)
 
 
-# ----- backward-compat top-level alias (#186 migration safety) -----
-# Keep ``switch_model`` symbol exported so bot.py's existing add_command
-# call continues to work BUT route to a thin shim that just calls the
-# group's switch. We do NOT re-register it under the top-level ``model``
-# name (that would conflict with the group). Instead we shadow the
-# import-time variable name only — bot.py's import is updated below.
-switch_model = model_switch  # alias for any external lookup
-
-
 @app_commands.command(name="effort", description="Set Claude's thinking effort level")
 @app_commands.describe(level="Effort: low, medium, high, xhigh, max")
 @app_commands.choices(level=[

--- a/src/clauded/cogs/model.py
+++ b/src/clauded/cogs/model.py
@@ -7,14 +7,58 @@ import logging
 import discord
 from discord import app_commands
 
-from ..discord_renderer import COLOR_INFO
+from ..discord_renderer import COLOR_INFO, COLOR_TOOL_SUCCESS
 
 log = logging.getLogger("clauded.bot")
 
 
-@app_commands.command(name="model", description="Switch Claude model for this thread")
+# #186: hybrid hardcoded table of known model aliases + metadata.
+# Maintained here; reviewer is responsible for refreshing when Anthropic
+# releases new SKUs. Order is intentional — user-facing list preserves
+# this ordering (most-common balanced first, then deep, then fast,
+# then context-window-extended variants).
+KNOWN_MODELS: dict[str, dict[str, str | int]] = {
+    "sonnet":   {"id": "claude-sonnet-4-5",     "context": 200_000, "tier": "balanced"},
+    "opus":     {"id": "claude-opus-4-1",       "context": 200_000, "tier": "deep"},
+    "haiku":    {"id": "claude-haiku-3-5",      "context": 200_000, "tier": "fast"},
+    "sonnet-1m":{"id": "claude-sonnet-4-5-1m",  "context": 1_000_000, "tier": "balanced"},
+}
+
+
+def _fmt_context(n: int) -> str:
+    """`200000` -> `200k`; `1000000` -> `1M`. Defensive on non-ints."""
+    try:
+        n = int(n)
+    except (TypeError, ValueError):
+        return "?"
+    if n >= 1_000_000:
+        return f"{n // 1_000_000}M"
+    if n >= 1_000:
+        return f"{n // 1_000}k"
+    return str(n)
+
+
+def _current_model_for_thread(bot, thread_id: int | None) -> str | None:
+    """Return the active model name for ``thread_id`` if a session exists,
+    else None. Resolves through ``bridge.model`` which already follows
+    the override > sdk-reported > config-default chain."""
+    if thread_id is None:
+        return None
+    bridge = bot.session_manager.get_session(thread_id)
+    if bridge is None:
+        return None
+    return getattr(bridge, "model", None)
+
+
+model_group = app_commands.Group(
+    name="model",
+    description="View / switch Claude model for this thread",
+)
+
+
+@model_group.command(name="switch", description="Switch Claude model for this thread")
 @app_commands.describe(name="Model: sonnet, opus, haiku, or full model ID")
-async def switch_model(interaction: discord.Interaction, name: str) -> None:
+async def model_switch(interaction: discord.Interaction, name: str) -> None:
     from ..bot import ClaudedBot
     bot = interaction.client
     if not isinstance(bot, ClaudedBot):
@@ -31,11 +75,103 @@ async def switch_model(interaction: discord.Interaction, name: str) -> None:
         )
 
 
-async def model_autocomplete(interaction: discord.Interaction, current: str) -> list[app_commands.Choice[str]]:
-    models = ["sonnet", "opus", "haiku", "claude-sonnet-4-20250514", "claude-opus-4-20250514"]
-    return [app_commands.Choice(name=m, value=m) for m in models if current.lower() in m.lower()][:25]
+@model_group.command(name="list", description="List available models + show current")
+async def model_list(interaction: discord.Interaction) -> None:
+    from ..bot import ClaudedBot
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    thread_id = getattr(interaction.channel, "id", None)
+    current = _current_model_for_thread(bot, thread_id)
+    # Build the rendered list
+    lines = []
+    for alias, info in KNOWN_MODELS.items():
+        ctx = _fmt_context(info["context"])
+        tier = info["tier"]
+        model_id = info["id"]
+        # Mark currently-active model (match alias OR id)
+        marker = "🟢 " if current and (current == alias or current == model_id) else "• "
+        lines.append(f"{marker}**{alias}** (`{model_id}`) \u2014 {tier}, {ctx} context")
+    desc = "\n".join(lines)
+    if current:
+        header = f"**Current**: `{current}`\n\n**Available models**:\n"
+    else:
+        header = "_No active session in this channel; current model unknown._\n\n**Available models**:\n"
+    embed = discord.Embed(
+        title="🤖 Model Selection",
+        description=header + desc + "\n\nUse `/model switch <name>` to switch.\n-# Switching resets the conversation context.",
+        color=COLOR_INFO,
+    )
+    await interaction.response.send_message(embed=embed)
 
-switch_model.autocomplete("name")(model_autocomplete)
+
+@model_group.command(name="current", description="Show current Claude model for this thread")
+async def model_current(interaction: discord.Interaction) -> None:
+    from ..bot import ClaudedBot
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    thread_id = getattr(interaction.channel, "id", None)
+    current = _current_model_for_thread(bot, thread_id)
+    if current is None:
+        await interaction.response.send_message(
+            "ℹ️ No active session in this channel. Send a message to start one.",
+            ephemeral=True,
+        )
+        return
+    # Try to find the matching KNOWN_MODELS entry for metadata
+    matched = None
+    for alias, info in KNOWN_MODELS.items():
+        if current == alias or current == info["id"]:
+            matched = (alias, info)
+            break
+    if matched:
+        alias, info = matched
+        ctx = _fmt_context(info["context"])
+        desc = (
+            f"• **alias**: `{alias}`\n"
+            f"• **id**: `{info['id']}`\n"
+            f"• **tier**: {info['tier']}\n"
+            f"• **context**: {ctx}"
+        )
+    else:
+        # Unknown model (full id / experimental)
+        desc = f"• **id**: `{current}`\n• _(not in known-models table)_"
+    embed = discord.Embed(
+        title="🤖 Current Model",
+        description=desc,
+        color=COLOR_TOOL_SUCCESS,
+    )
+    await interaction.response.send_message(embed=embed)
+
+
+async def model_switch_autocomplete(interaction: discord.Interaction, current: str) -> list[app_commands.Choice[str]]:
+    """#186 enhanced: include metadata in the choice display so users see
+    context / tier / id before committing."""
+    out: list[app_commands.Choice[str]] = []
+    cur_low = (current or "").lower()
+    for alias, info in KNOWN_MODELS.items():
+        if cur_low and cur_low not in alias.lower():
+            continue
+        display = f"{alias} \u2014 {info['tier']}, {_fmt_context(info['context'])} ({info['id']})"
+        # Discord choice name cap = 100 chars
+        out.append(app_commands.Choice(name=display[:100], value=alias))
+        if len(out) >= 25:
+            break
+    return out
+
+model_switch.autocomplete("name")(model_switch_autocomplete)
+
+
+# ----- backward-compat top-level alias (#186 migration safety) -----
+# Keep ``switch_model`` symbol exported so bot.py's existing add_command
+# call continues to work BUT route to a thin shim that just calls the
+# group's switch. We do NOT re-register it under the top-level ``model``
+# name (that would conflict with the group). Instead we shadow the
+# import-time variable name only — bot.py's import is updated below.
+switch_model = model_switch  # alias for any external lookup
 
 
 @app_commands.command(name="effort", description="Set Claude's thinking effort level")

--- a/tests/test_model_cmd.py
+++ b/tests/test_model_cmd.py
@@ -1,0 +1,176 @@
+"""#186 — /model group: list, current, switch + metadata-rich autocomplete."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+
+def test_known_models_has_required_metadata():
+    """Every entry must carry id + context + tier."""
+    from clauded.cogs.model import KNOWN_MODELS
+    assert KNOWN_MODELS, "KNOWN_MODELS table must not be empty"
+    for alias, info in KNOWN_MODELS.items():
+        assert "id" in info, f"{alias} missing 'id'"
+        assert "context" in info, f"{alias} missing 'context'"
+        assert "tier" in info, f"{alias} missing 'tier'"
+        assert isinstance(info["context"], int) and info["context"] > 0
+        assert info["tier"] in ("fast", "balanced", "deep"), f"unknown tier: {info['tier']}"
+
+
+def test_fmt_context_renders_k_and_m():
+    from clauded.cogs.model import _fmt_context
+    assert _fmt_context(200_000) == "200k"
+    assert _fmt_context(1_000_000) == "1M"
+    assert _fmt_context(150_000) == "150k"
+    assert _fmt_context(500) == "500"
+    # defensive
+    assert _fmt_context(None) == "?"  # type: ignore[arg-type]
+    assert _fmt_context("garbage") == "?"  # type: ignore[arg-type]
+
+
+def test_current_model_for_thread_returns_bridge_model():
+    from clauded.cogs.model import _current_model_for_thread
+    bot = MagicMock()
+    bridge = MagicMock(model="claude-sonnet-4-5")
+    bot.session_manager.get_session = MagicMock(return_value=bridge)
+    assert _current_model_for_thread(bot, 42) == "claude-sonnet-4-5"
+
+
+def test_current_model_for_thread_none_when_no_session():
+    from clauded.cogs.model import _current_model_for_thread
+    bot = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=None)
+    assert _current_model_for_thread(bot, 42) is None
+    # thread_id None -> short-circuit
+    assert _current_model_for_thread(bot, None) is None
+
+
+@pytest.mark.asyncio
+async def test_model_list_with_active_session_marks_current():
+    """`/model list` highlights the current model with 🟢 marker."""
+    from clauded.cogs.model import model_list
+    from clauded.bot import ClaudedBot
+    bot_spec = MagicMock(spec=ClaudedBot)
+    bot_spec.session_manager = MagicMock()
+    bot_spec.session_manager.get_session = MagicMock(
+        return_value=MagicMock(model="opus")
+    )
+    interaction = MagicMock()
+    interaction.client = bot_spec
+    interaction.channel.id = 99
+    interaction.response.send_message = AsyncMock()
+    await model_list.callback(interaction)
+    interaction.response.send_message.assert_awaited_once()
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    assert "Current" in embed.description
+    assert "opus" in embed.description
+    assert "🟢" in embed.description, f"Current model marker missing; desc={embed.description!r}"
+
+
+@pytest.mark.asyncio
+async def test_model_list_without_session_shows_unknown_current():
+    from clauded.cogs.model import model_list
+    from clauded.bot import ClaudedBot
+    bot_spec = MagicMock(spec=ClaudedBot)
+    bot_spec.session_manager = MagicMock()
+    bot_spec.session_manager.get_session = MagicMock(return_value=None)
+    interaction = MagicMock()
+    interaction.client = bot_spec
+    interaction.channel.id = 99
+    interaction.response.send_message = AsyncMock()
+    await model_list.callback(interaction)
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    assert "No active session" in embed.description
+    # Still shows the model list
+    assert "sonnet" in embed.description
+    assert "opus" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_model_current_with_session_renders_metadata():
+    from clauded.cogs.model import model_current
+    from clauded.bot import ClaudedBot
+    bot_spec = MagicMock(spec=ClaudedBot)
+    bot_spec.session_manager = MagicMock()
+    bot_spec.session_manager.get_session = MagicMock(
+        return_value=MagicMock(model="haiku")
+    )
+    interaction = MagicMock()
+    interaction.client = bot_spec
+    interaction.channel.id = 1
+    interaction.response.send_message = AsyncMock()
+    await model_current.callback(interaction)
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    assert "haiku" in embed.description
+    assert "fast" in embed.description  # haiku's tier
+    assert "200k" in embed.description  # haiku's context
+
+
+@pytest.mark.asyncio
+async def test_model_current_with_no_session_says_so():
+    from clauded.cogs.model import model_current
+    from clauded.bot import ClaudedBot
+    bot_spec = MagicMock(spec=ClaudedBot)
+    bot_spec.session_manager = MagicMock()
+    bot_spec.session_manager.get_session = MagicMock(return_value=None)
+    interaction = MagicMock()
+    interaction.client = bot_spec
+    interaction.channel.id = 1
+    interaction.response.send_message = AsyncMock()
+    await model_current.callback(interaction)
+    call = interaction.response.send_message.await_args
+    assert "No active session" in call.args[0] or "No active session" in call.kwargs.get("content", "")
+    assert call.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_model_current_unknown_model_shows_id_only():
+    """If active model isn't in KNOWN_MODELS (full id / future SKU), still
+    display its id rather than 'unknown'."""
+    from clauded.cogs.model import model_current
+    from clauded.bot import ClaudedBot
+    bot_spec = MagicMock(spec=ClaudedBot)
+    bot_spec.session_manager = MagicMock()
+    bot_spec.session_manager.get_session = MagicMock(
+        return_value=MagicMock(model="claude-future-7-9-xl")
+    )
+    interaction = MagicMock()
+    interaction.client = bot_spec
+    interaction.channel.id = 1
+    interaction.response.send_message = AsyncMock()
+    await model_current.callback(interaction)
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    assert "claude-future-7-9-xl" in embed.description
+    assert "not in known-models" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_model_switch_autocomplete_includes_metadata():
+    from clauded.cogs.model import model_switch_autocomplete
+    interaction = MagicMock()
+    out = await model_switch_autocomplete(interaction, "")
+    assert out  # non-empty
+    # Each choice name should include the tier + context
+    for c in out:
+        assert "—" in c.name  # the em-dash separator
+        assert "k" in c.name or "M" in c.name  # context format
+    # Value remains the simple alias for backward compat
+    aliases = {c.value for c in out}
+    assert "sonnet" in aliases
+    assert "opus" in aliases
+
+
+@pytest.mark.asyncio
+async def test_model_switch_autocomplete_filters_by_current_input():
+    from clauded.cogs.model import model_switch_autocomplete
+    interaction = MagicMock()
+    out = await model_switch_autocomplete(interaction, "haik")
+    aliases = {c.value for c in out}
+    assert "haiku" in aliases
+    assert "sonnet" not in aliases
+    assert "opus" not in aliases
+
+
+def test_model_group_has_three_subcommands():
+    """Pin: the group has exactly switch/list/current."""
+    from clauded.cogs.model import model_group
+    names = {c.name for c in model_group.commands}
+    assert names == {"switch", "list", "current"}, f"Unexpected subcommands: {names}"


### PR DESCRIPTION
Closes #186.

## Bug
`/model` had no list view and no current-model display. User had to guess via autocomplete.

## Fix
Convert `/model` to a group with 3 subs:
- `/model list` — embed showing all KNOWN_MODELS (id, context, tier) + 🟢 highlight on current
- `/model current` — current model + metadata for this thread (ephemeral refusal w/o session)
- `/model switch <name>` — existing switch behavior (was top-level)

Autocomplete enhanced with metadata display.

## Backward compat
Top-level `/model <name>` removed; users must use `/model switch <name>`. Per-guild sync (#188) propagates instantly.

## Tests
+12 in `test_model_cmd.py`. 596 / 2 pre-existing P1.
