### PR TITLE
feat(renderer): 🧠 N% context-window usage in cost footer (#182)

### DIFF
--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -211,6 +211,48 @@ def _fmt_tokens(n: int) -> str:
     return str(n)
 
 
+def _format_context_segment(stats: dict[str, Any] | None) -> str | None:
+    """Return ``│ 🧠 N%`` (or thresholded ⚠️ / 🔥) for the cost footer, or
+    ``None`` when no usable percentage is available.
+
+    #182: stats may have ``context_percentage`` populated from
+    ``bridge.get_context_usage()`` (#163 sub-task 3 reuse). The renderer
+    silently omits the segment on missing / invalid data so we never
+    break the existing footer for legacy bridges or transient errors.
+
+    Thresholds (boundary inclusive on the lower bound):
+      - < 75%   → 🧠 (calm)
+      - 75-89%  → ⚠️ (warning)
+      - >= 90%  → 🔥 (critical)
+
+    Floor: percentages > 0 but < 1% render as ``<1%`` (otherwise
+    ``int(0.4) == 0`` would mislead the user into thinking they've
+    used nothing).
+    """
+    if not stats:
+        return None
+    pct = stats.get("context_percentage")
+    if pct is None:
+        return None
+    try:
+        pct_f = float(pct)
+    except (TypeError, ValueError):
+        return None
+    if pct_f < 0 or pct_f > 100:
+        return None  # invalid range, omit silently
+    # Threshold-colored emoji
+    if pct_f >= 90:
+        emoji = "🔥"
+    elif pct_f >= 75:
+        emoji = "⚠️"
+    else:
+        emoji = "🧠"
+    # Floor sub-1% to ``<1%`` so a 0.4% turn doesn't render as ``0%``.
+    if 0 < pct_f < 1:
+        return f" │ {emoji} <1%"
+    return f" │ {emoji} {int(pct_f)}%"
+
+
 def _extract_subagent_stats(input_value: Any) -> dict[str, Any] | None:
     """Extract stats from a sub-agent ``UserMessage.tool_use_result`` payload.
 
@@ -566,6 +608,23 @@ class DiscordRenderer:
                         'model': getattr(event, 'model', '') or '',
                         'stop_reason': _last_stop_reason,
                     }
+                    # #182: pull context-window usage and fold percentage
+                    # into stats so the footer can render `🧠 N%` segment.
+                    # ResultMessage.usage carries per-turn API tokens only;
+                    # the cumulative-vs-max ratio lives on a separate SDK
+                    # control-plane call (already wired for /context cmd,
+                    # #163 sub-task 3). Mirrors #160's graceful-fallback
+                    # discipline — any exception logs at DEBUG and the
+                    # footer simply omits the segment.
+                    try:
+                        cu = await bridge.get_context_usage()
+                        if cu and "percentage" in cu:
+                            stats["context_percentage"] = cu["percentage"]
+                    except Exception:
+                        log.debug(
+                            "get_context_usage failed; footer omits 🧠",
+                            exc_info=True,
+                        )
                     break
 
 
@@ -1408,6 +1467,11 @@ class DiscordRenderer:
                     f" │ 📤 {_fmt_tokens(stats.get('output_tokens', 0))}"
                     f" │ ⏱️ {duration_s:.1f}s"
                 )
+                # #182: append `│ 🧠 N%` context-window segment when
+                # available. Graceful-omit when not (helper returns None).
+                ctx_seg = _format_context_segment(stats)
+                if ctx_seg:
+                    footer_text += ctx_seg
                 if _last_stop_reason and _last_stop_reason != "end_turn":
                     footer_text += f" │ ⚠️ {_last_stop_reason}"
 

--- a/tests/test_context_footer.py
+++ b/tests/test_context_footer.py
@@ -1,0 +1,277 @@
+"""#182 — context-window usage `🧠 N%` segment in cost footer."""
+import pytest
+import sys
+sys.path.insert(0, "src")
+from unittest.mock import MagicMock, AsyncMock
+
+from clauded.discord_renderer import _format_context_segment
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the helper
+# ---------------------------------------------------------------------------
+
+
+def test_format_context_returns_none_when_missing():
+    assert _format_context_segment(None) is None
+    assert _format_context_segment({}) is None
+    assert _format_context_segment({"context_percentage": None}) is None
+
+
+def test_format_context_returns_none_on_invalid():
+    assert _format_context_segment({"context_percentage": "abc"}) is None
+    assert _format_context_segment({"context_percentage": -1}) is None
+    assert _format_context_segment({"context_percentage": 101}) is None
+
+
+@pytest.mark.parametrize("pct,emoji", [
+    (0, "🧠"),
+    (1, "🧠"),
+    (50, "🧠"),
+    (74, "🧠"),
+    (74.9, "🧠"),
+    (75, "⚠️"),
+    (75.0, "⚠️"),
+    (80, "⚠️"),
+    (89, "⚠️"),
+    (89.9, "⚠️"),
+    (90, "🔥"),
+    (90.0, "🔥"),
+    (95, "🔥"),
+    (99, "🔥"),
+    (100, "🔥"),
+])
+def test_format_context_emoji_thresholds(pct, emoji):
+    """Boundary check: 89.9 → ⚠️, 90.0 → 🔥, 74.9 → 🧠, 75.0 → ⚠️."""
+    out = _format_context_segment({"context_percentage": pct})
+    assert out is not None
+    assert emoji in out, f"pct={pct} expected {emoji!r} in {out!r}"
+
+
+def test_format_context_sub_1_percent_floor():
+    """0 < pct < 1 → display `<1%` instead of `0%`."""
+    assert _format_context_segment({"context_percentage": 0.4}) == " │ 🧠 <1%"
+    assert _format_context_segment({"context_percentage": 0.99}) == " │ 🧠 <1%"
+    # 0% exact stays as 0% (haven't started the session)
+    assert _format_context_segment({"context_percentage": 0}) == " │ 🧠 0%"
+    # 1.0% rounds to 1%
+    assert _format_context_segment({"context_percentage": 1.0}) == " │ 🧠 1%"
+
+
+def test_format_context_shape():
+    """The segment must START with `\\u2502 ` (space separator) so it can
+    be concatenated to the existing footer without breaking layout."""
+    out = _format_context_segment({"context_percentage": 50})
+    assert out.startswith(" │ "), f"separator missing: {out!r}"
+    assert out.endswith("%")
+
+
+# ---------------------------------------------------------------------------
+# Integration test using real SDK shape (per #160 / #172 lesson)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_footer_includes_context_segment_e2e():
+    """Drive render_response end-to-end with a mock bridge whose
+    get_context_usage returns a realistic dict shape; assert the final
+    footer contains `🧠 73%`."""
+    from claude_agent_sdk.types import AssistantMessage, TextBlock, ResultMessage
+    from clauded.discord_renderer import DiscordRenderer
+
+    class FakeBridge:
+        def __init__(self, events, ctx):
+            self._events = events
+            self.is_active = True
+            self._client = MagicMock()
+            self._ctx = ctx
+        async def send_message(self, _text):
+            for ev in self._events:
+                yield ev
+        async def get_context_usage(self):
+            return self._ctx
+
+    class FakeMessage:
+        def __init__(self):
+            self.content = ""
+            self.embeds = []
+        async def edit(self, **kwargs):
+            if "content" in kwargs:
+                self.content = kwargs["content"]
+            return self
+        async def delete(self):
+            return None
+
+    class FakeTarget:
+        def __init__(self):
+            self.id = 1
+            self._sent = []
+        async def send(self, *args, **kwargs):
+            msg = FakeMessage()
+            if "content" in kwargs:
+                msg.content = kwargs["content"]
+            self._sent.append(msg)
+            return msg
+
+    events = [
+        AssistantMessage(
+            content=[TextBlock(text="response text")],
+            model="claude-sonnet-4-5",
+            parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result", duration_ms=100, duration_api_ms=80,
+            is_error=False, num_turns=1, session_id="sess-ctx",
+            total_cost_usd=0.012,
+            usage={"input_tokens": 1200, "output_tokens": 340},
+        ),
+    ]
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+    # Realistic ContextUsageResponse shape from SDK 0.1.80
+    ctx_response = {
+        "percentage": 73.4,
+        "totalTokens": 145000,
+        "maxTokens": 200000,
+        "rawMaxTokens": 200000,
+        "model": "claude-sonnet-4-5",
+    }
+    bridge = FakeBridge(events, ctx_response)
+    await renderer.render_response(bridge, "hello")
+
+    # Collect all message content
+    all_content = " ".join(m.content for m in target._sent if m.content)
+    # The footer should contain 🧠 73%
+    assert "🧠 73%" in all_content, (
+        f"Expected '🧠 73%' in footer; got: {all_content!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_footer_omits_context_segment_on_get_context_usage_failure():
+    """If bridge.get_context_usage raises, footer renders without 🧠
+    segment and no exception escapes."""
+    from claude_agent_sdk.types import AssistantMessage, TextBlock, ResultMessage
+    from clauded.discord_renderer import DiscordRenderer
+
+    class FailingBridge:
+        is_active = True
+        _client = MagicMock()
+        def __init__(self, events):
+            self._events = events
+        async def send_message(self, _text):
+            for ev in self._events:
+                yield ev
+        async def get_context_usage(self):
+            raise RuntimeError("synthetic CLI failure")
+
+    class FakeMessage:
+        def __init__(self):
+            self.content = ""
+            self.embeds = []
+        async def edit(self, **kwargs):
+            if "content" in kwargs:
+                self.content = kwargs["content"]
+            return self
+        async def delete(self):
+            return None
+
+    class FakeTarget:
+        id = 1
+        def __init__(self):
+            self._sent = []
+        async def send(self, *args, **kwargs):
+            msg = FakeMessage()
+            if "content" in kwargs:
+                msg.content = kwargs["content"]
+            self._sent.append(msg)
+            return msg
+
+    events = [
+        AssistantMessage(
+            content=[TextBlock(text="result")],
+            model="claude-sonnet-4-5", parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result", duration_ms=50, duration_api_ms=30,
+            is_error=False, num_turns=1, session_id="sess-fail",
+            total_cost_usd=0.005,
+            usage={"input_tokens": 100, "output_tokens": 50},
+        ),
+    ]
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+    bridge = FailingBridge(events)
+    # MUST NOT raise
+    await renderer.render_response(bridge, "hello")
+    all_content = " ".join(m.content for m in target._sent if m.content)
+    # Footer present (other segments)
+    assert "💰" in all_content
+    assert "⏱️" in all_content
+    # But no 🧠 / ⚠️ / 🔥 segment
+    assert "🧠" not in all_content
+    # Note: ⚠️ may appear from stop_reason — verify it's not the context one
+    # by checking absence of `%` near a context emoji
+    for emoji in ("🧠", "🔥"):
+        assert emoji not in all_content, f"{emoji} leaked into footer despite get_context_usage failure"
+
+
+@pytest.mark.asyncio
+async def test_footer_omits_context_when_get_context_usage_returns_none():
+    """If bridge.get_context_usage returns None (force-dropped bridge per
+    #146), footer renders without segment."""
+    from claude_agent_sdk.types import AssistantMessage, TextBlock, ResultMessage
+    from clauded.discord_renderer import DiscordRenderer
+
+    class NoneBridge:
+        is_active = True
+        _client = MagicMock()
+        def __init__(self, events):
+            self._events = events
+        async def send_message(self, _text):
+            for ev in self._events:
+                yield ev
+        async def get_context_usage(self):
+            return None
+
+    class FakeMessage:
+        def __init__(self):
+            self.content = ""
+            self.embeds = []
+        async def edit(self, **kwargs):
+            if "content" in kwargs:
+                self.content = kwargs["content"]
+            return self
+        async def delete(self):
+            return None
+
+    class FakeTarget:
+        id = 1
+        def __init__(self):
+            self._sent = []
+        async def send(self, *args, **kwargs):
+            msg = FakeMessage()
+            if "content" in kwargs:
+                msg.content = kwargs["content"]
+            self._sent.append(msg)
+            return msg
+
+    events = [
+        AssistantMessage(
+            content=[TextBlock(text="result")],
+            model="claude-sonnet-4-5", parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result", duration_ms=50, duration_api_ms=30,
+            is_error=False, num_turns=1, session_id="sess-none",
+            total_cost_usd=0.001,
+            usage={"input_tokens": 50, "output_tokens": 20},
+        ),
+    ]
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+    bridge = NoneBridge(events)
+    await renderer.render_response(bridge, "hi")
+    all_content = " ".join(m.content for m in target._sent if m.content)
+    assert "🧠" not in all_content
+    assert "🔥" not in all_content


### PR DESCRIPTION
Closes #182.

## Feature
Append `│ 🧠 N%` context-window usage to the cost footer with threshold-colored emoji (🧠 < 75%, ⚠️ 75-89%, 🔥 ≥ 90%).

```
-# 💰 $0.0123 │ 📥 1.2k │ 📤 340 │ ⏱️ 5.2s │ 🧠 73%
```

## Implementation
- `_format_context_segment(stats)` helper (None-safe, threshold logic, sub-1% floor)
- `await bridge.get_context_usage()` in ResultMessage block, reuses #163's SDK call
- Graceful fallback per #160: any exception → log.debug + omit segment

## Scope (per acceptance criteria)
- Main thread footer only (sub-thread mini-footer #172 unchanged)
- Boundary-inclusive: 75.0 → ⚠️, 90.0 → 🔥
- Sub-1% floor: 0.4% → `<1%` not `0%`

## Tests
+22 in `test_context_footer.py` covering 15 threshold boundaries + 3 fallback paths + 1 e2e integration. 618 / 2 pre-existing P1.
