### PR TITLE
fix(renderer): Subtask Complete embed clean text + meta strip + async-dispatch detection (#192)

### DIFF
--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -253,6 +253,99 @@ def _format_context_segment(stats: dict[str, Any] | None) -> str | None:
     return f" │ {emoji} {int(pct_f)}%"
 
 
+# ---------------------------------------------------------------------------
+# #192 Fix A: normalize SDK ToolResultBlock.content shapes to plain text.
+# ---------------------------------------------------------------------------
+# Claude SDK 0.1.80 returns ``ToolResultBlock.content`` in 3 shapes depending
+# on the tool:
+#   - ``str``                            — most Bash/Read/Grep results
+#   - ``list[dict]`` with TextBlock dicts — Task/Agent tool family, async
+#     sub-agents, multi-modal results: ``[{"type": "text", "text": "..."}]``
+#   - ``dict``                            — rare; some structured responses
+#
+# Before #192, the renderer did ``str(block.content)``, which produced the
+# Python repr (``[{'type': 'text', 'text': '...'}]``) on shape #2 — user saw
+# raw brackets + quotes + ``\n`` literals. Prod-impact concentrated on the
+# Subtask Complete embed (#161 D.1 latent bug, escalated to P0 via #192).
+
+# Pre-compiled patterns for CLI-internal meta-instructions that leak into
+# user-facing text. Claude CLI scaffolds async-agent / Task tool results
+# with hints intended for the LLM's reasoning ("do not mention to user"),
+# never for display. Strip best-effort; the pattern list is extensible.
+_INTERNAL_META_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # ``(internal ID - do not mention to user. Use SendMessage with to:
+    # 'xxx' to continue this agent.)`` — wrapped in parens
+    re.compile(r"\((?:internal ID|internal id) - do not mention to user[^)]*\)", re.IGNORECASE),
+    # Standalone ``do not mention ... to user ...`` sentence (no paren
+    # wrapping). Bounded by sentence end so we don't eat following content.
+    re.compile(r"\bdo not mention[^.]*?to user[^.]*?\.", re.IGNORECASE),
+)
+
+
+def _extract_block_content_text(content: Any) -> str:
+    """Normalize a ``ToolResultBlock.content`` payload to a plain text string.
+
+    Handles SDK's documented shapes (#192 Fix A):
+    - ``None``                                 → ``""`` (no-op)
+    - ``str``                                  → the string itself
+    - ``list[dict]`` with ``{"type":"text","text":"..."}``  → join ``text``s
+    - ``list[str]``                            → join with ``"\\n"``
+    - ``list[mixed]``                          → best-effort element repr
+    - ``dict`` with ``"text"`` key             → return that
+    - anything else                            → ``str(content)`` fallback
+
+    No exception escapes; the worst-case fallback (``str``) preserves the
+    pre-#192 behavior for unrecognized shapes.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                if "text" in item:
+                    parts.append(str(item["text"]))
+                else:
+                    parts.append(str(item))
+            else:
+                parts.append(str(item))
+        return "\n".join(parts)
+    if isinstance(content, dict) and "text" in content:
+        return str(content["text"])
+    return str(content)
+
+
+def _strip_internal_metadata(text: str) -> str:
+    """Remove known CLI-internal meta-instruction phrases from user-facing
+    text (#192 Fix B). Best-effort — pattern list lives at module scope
+    (``_INTERNAL_META_PATTERNS``) for easy extension as new CLI quirks
+    surface. Idempotent on already-clean text.
+    """
+    if not text:
+        return text
+    for pat in _INTERNAL_META_PATTERNS:
+        text = pat.sub("", text)
+    # Collapse any double-space artifacts left behind
+    text = re.sub(r"  +", " ", text)
+    return text.strip()
+
+
+def _is_async_agent_dispatch(text: str) -> bool:
+    """Detect async-agent launch acknowledgments (#192 Fix C).
+
+    Claude CLI's async-agent tool emits a ``Async agent launched
+    successfully.`` text payload as a tool RESULT (not a completion).
+    The actual sub-agent work continues in the background. Marking this
+    as "✅ Subtask Complete" was misleading; the renderer instead shows
+    "🚀 Sub-agent dispatched" so users know the work is still running.
+    """
+    if not text:
+        return False
+    return "async agent launched" in text.lower()
+
+
 def _extract_subagent_stats(input_value: Any) -> dict[str, Any] | None:
     """Extract stats from a sub-agent ``UserMessage.tool_use_result`` payload.
 
@@ -1122,14 +1215,35 @@ class DiscordRenderer:
                                     )
                                     sub_footer = _format_subagent_footer(sub_stats)
 
-                                    # Completion embed in sub-thread
-                                    description = str(block.content)[:300] if block.content else "Done"
+                                    # #192 Fix A: extract list-of-dict
+                                    # content to plain text (was leaking
+                                    # Python repr). Fix B: strip CLI's
+                                    # "do not mention to user" meta
+                                    # instructions. Fix C: detect async-
+                                    # agent dispatch and label it as such
+                                    # rather than "Complete".
+                                    raw_text = _extract_block_content_text(block.content)
+                                    cleaned = _strip_internal_metadata(raw_text)
+                                    is_dispatch = (
+                                        not is_err
+                                        and _is_async_agent_dispatch(cleaned)
+                                    )
+                                    description = (cleaned[:300] if cleaned else "Done")
                                     if sub_footer:
                                         description = f"{description}\n\n{sub_footer}"
+                                    if is_dispatch:
+                                        embed_title = "🚀 Sub-agent dispatched (running in background)"
+                                        embed_color = COLOR_INFO
+                                    elif is_err:
+                                        embed_title = "❌ Subtask Failed"
+                                        embed_color = COLOR_TOOL_FAILURE
+                                    else:
+                                        embed_title = "✅ Subtask Complete"
+                                        embed_color = COLOR_TOOL_SUCCESS
                                     done = discord.Embed(
-                                        title="✅ Subtask Complete" if not is_err else "❌ Subtask Failed",
+                                        title=embed_title,
                                         description=description,
-                                        color=COLOR_TOOL_SUCCESS if not is_err else COLOR_TOOL_FAILURE,
+                                        color=embed_color,
                                     )
                                     await subagent_renderers[tool_id]._safe_send(embed=done)
 
@@ -1139,10 +1253,13 @@ class DiscordRenderer:
                                     # so users browsing the main thread aren't
                                     # double-shown the cost data.
                                     if tool_id in tool_msgs:
+                                        # Mirror the title computed above
+                                        # so main-thread summary matches
+                                        # the sub-thread completion state.
                                         summary = discord.Embed(
-                                            title="✅ Subtask Complete" if not is_err else "❌ Subtask Failed",
+                                            title=embed_title,
                                             description=f"📎 {sub_thread.mention}",
-                                            color=COLOR_TOOL_SUCCESS if not is_err else COLOR_TOOL_FAILURE,
+                                            color=embed_color,
                                         )
                                         await self._safe_edit(tool_msgs[tool_id], embed=summary)
                                 elif tool_id in tool_msgs:
@@ -1155,13 +1272,29 @@ class DiscordRenderer:
                                         tool_use_results.get(tool_id)
                                     )
                                     sub_footer = _format_subagent_footer(sub_stats)
-                                    description = str(block.content)[:300] if block.content else "Done"
+                                    # #192 Fix A/B/C applied here too.
+                                    raw_text = _extract_block_content_text(block.content)
+                                    cleaned = _strip_internal_metadata(raw_text)
+                                    is_dispatch = (
+                                        not is_err
+                                        and _is_async_agent_dispatch(cleaned)
+                                    )
+                                    description = (cleaned[:300] if cleaned else "Done")
                                     if sub_footer:
                                         description = f"{description}\n\n{sub_footer}"
+                                    if is_dispatch:
+                                        embed_title = "🚀 Sub-agent dispatched (running in background)"
+                                        embed_color = COLOR_INFO
+                                    elif is_err:
+                                        embed_title = "❌ Subtask Failed"
+                                        embed_color = COLOR_TOOL_FAILURE
+                                    else:
+                                        embed_title = "✅ Subtask Complete"
+                                        embed_color = COLOR_TOOL_SUCCESS
                                     done_embed = discord.Embed(
-                                        title=f"{'✅' if not is_err else '❌'} Subtask Complete",
+                                        title=embed_title,
                                         description=description,
-                                        color=COLOR_TOOL_SUCCESS if not is_err else COLOR_TOOL_FAILURE,
+                                        color=embed_color,
                                     )
                                     await self._safe_edit(tool_msgs[tool_id], embed=done_embed)
                                 continue
@@ -1219,7 +1352,7 @@ class DiscordRenderer:
                                     # collapse to ``line1 │ line2 │ line3``
                                     # so they fit in the rolling-log embed
                                     # without ballooning vertical height.
-                                    content_str = str(block.content) if block.content else ""
+                                    content_str = _extract_block_content_text(block.content)
                                     is_short = (
                                         len(content_str) < 200
                                         and content_str.strip() != ""
@@ -1398,7 +1531,7 @@ class DiscordRenderer:
                                         title=f"❌ {name}",
                                         color=COLOR_TOOL_FAILURE,
                                     )
-                                    error_text = str(block.content)[:500] if block.content else "Failed"
+                                    error_text = _extract_block_content_text(block.content)[:500] or "Failed"
                                     result_embed.description = f"```\n{error_text}\n```"
                                 else:
                                     result_embed = discord.Embed(

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -340,10 +340,16 @@ def _is_async_agent_dispatch(text: str) -> bool:
     The actual sub-agent work continues in the background. Marking this
     as "✅ Subtask Complete" was misleading; the renderer instead shows
     "🚀 Sub-agent dispatched" so users know the work is still running.
+
+    Uses word-boundary anchoring on "async agent" (case-insensitive)
+    so a stray substring elsewhere doesn't false-trigger.
     """
     if not text:
         return False
-    return "async agent launched" in text.lower()
+    return bool(_ASYNC_DISPATCH_PATTERN.search(text))
+
+
+_ASYNC_DISPATCH_PATTERN = re.compile(r"\basync agent launched\b", re.IGNORECASE)
 
 
 def _extract_subagent_stats(input_value: Any) -> dict[str, Any] | None:

--- a/tests/test_subtask_complete_render.py
+++ b/tests/test_subtask_complete_render.py
@@ -1,0 +1,392 @@
+"""#192 — sub-agent Subtask Complete embed leaked Python repr + CLI meta.
+
+Fixes:
+- A: _extract_block_content_text normalizes list[dict] → plain text
+- B: _strip_internal_metadata removes "(internal ID - do not mention to user...)" patterns
+- C: _is_async_agent_dispatch + new "🚀 Sub-agent dispatched" embed title
+"""
+import pytest
+from unittest.mock import MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Fix A: _extract_block_content_text — content shape normalization
+# ---------------------------------------------------------------------------
+
+
+def test_extract_str_returns_str_as_is():
+    from clauded.discord_renderer import _extract_block_content_text
+    assert _extract_block_content_text("plain string") == "plain string"
+
+
+def test_extract_none_returns_empty_string():
+    from clauded.discord_renderer import _extract_block_content_text
+    assert _extract_block_content_text(None) == ""
+
+
+def test_extract_list_of_text_dicts():
+    """The prod failure mode: ``[{'type': 'text', 'text': '...'}]`` was
+    leaking as Python repr before #192. Must extract clean text."""
+    from clauded.discord_renderer import _extract_block_content_text
+    out = _extract_block_content_text([
+        {"type": "text", "text": "first line"},
+        {"type": "text", "text": "second line"},
+    ])
+    assert out == "first line\nsecond line"
+    assert "[" not in out
+    assert "{" not in out
+    assert "'type'" not in out
+
+
+def test_extract_list_of_strings():
+    from clauded.discord_renderer import _extract_block_content_text
+    assert _extract_block_content_text(["a", "b", "c"]) == "a\nb\nc"
+
+
+def test_extract_list_mixed_dict_without_text_key():
+    from clauded.discord_renderer import _extract_block_content_text
+    out = _extract_block_content_text([{"foo": "bar"}])
+    assert isinstance(out, str)
+    assert out != ""
+
+
+def test_extract_dict_with_text_key():
+    from clauded.discord_renderer import _extract_block_content_text
+    assert _extract_block_content_text({"text": "single dict"}) == "single dict"
+
+
+def test_extract_unknown_shape_str_fallback():
+    from clauded.discord_renderer import _extract_block_content_text
+    assert _extract_block_content_text(42) == "42"
+
+
+def test_extract_does_not_raise_on_pathological_input():
+    from clauded.discord_renderer import _extract_block_content_text
+    pathological = [
+        object(), {}, [], "", 0, 0.5, True, False,
+        [None, None], [{"text": None}],
+    ]
+    for p in pathological:
+        try:
+            out = _extract_block_content_text(p)
+            assert isinstance(out, str)
+        except Exception as e:
+            pytest.fail(f"Unexpected exception for {p!r}: {e!r}")
+
+
+# ---------------------------------------------------------------------------
+# Fix B: _strip_internal_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_strip_internal_id_paren_pattern():
+    """The exact prod-screenshot pattern must be removed."""
+    from clauded.discord_renderer import _strip_internal_metadata
+    text = (
+        "Async agent launched successfully.\n"
+        "agentId: aae5405f50ce90137 (internal ID - do not mention to user. "
+        "Use SendMessage with to: 'aae5405f50ce90137' to continue this agent.)\n"
+        "The agent is working in the background."
+    )
+    cleaned = _strip_internal_metadata(text)
+    assert "internal ID" not in cleaned
+    assert "do not mention" not in cleaned
+    assert "SendMessage" not in cleaned
+    assert "Async agent launched successfully" in cleaned
+    assert "background" in cleaned
+    assert "aae5405f50ce90137" in cleaned
+
+
+def test_strip_standalone_do_not_mention_sentence():
+    from clauded.discord_renderer import _strip_internal_metadata
+    text = "Result: success. Do not mention this internal detail to user. Goodbye."
+    cleaned = _strip_internal_metadata(text)
+    assert "Do not mention" not in cleaned
+    assert "Result: success." in cleaned
+    assert "Goodbye." in cleaned
+
+
+def test_strip_does_not_over_strip_legitimate_content():
+    """Negative test: user content that incidentally contains the word
+    'mention' or 'internal' must NOT be stripped."""
+    from clauded.discord_renderer import _strip_internal_metadata
+    text = (
+        "Documentation: this internal API is now public. "
+        "Please mention it in the changelog."
+    )
+    cleaned = _strip_internal_metadata(text)
+    assert "internal API" in cleaned
+    assert "mention it in the changelog" in cleaned
+
+
+def test_strip_idempotent_on_clean_text():
+    from clauded.discord_renderer import _strip_internal_metadata
+    clean = "Hello, World! This is fine."
+    assert _strip_internal_metadata(clean) == clean
+
+
+def test_strip_handles_empty_string():
+    from clauded.discord_renderer import _strip_internal_metadata
+    assert _strip_internal_metadata("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Fix C: _is_async_agent_dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_detection_matches_canonical_phrase():
+    from clauded.discord_renderer import _is_async_agent_dispatch
+    assert _is_async_agent_dispatch("Async agent launched successfully.")
+    assert _is_async_agent_dispatch("async agent launched successfully")
+
+
+def test_dispatch_detection_rejects_unrelated_text():
+    from clauded.discord_renderer import _is_async_agent_dispatch
+    assert not _is_async_agent_dispatch("Subtask done")
+    assert not _is_async_agent_dispatch("")
+    assert not _is_async_agent_dispatch("agent task running")
+
+
+# ---------------------------------------------------------------------------
+# Integration: end-to-end render with real SDK shape
+# ---------------------------------------------------------------------------
+
+
+class _FakeMessage:
+    def __init__(self, msg_id=1):
+        self.id = msg_id
+        self.content = ""
+        self.embeds = []
+    async def edit(self, **kwargs):
+        if "content" in kwargs:
+            self.content = kwargs["content"]
+        if "embed" in kwargs:
+            self.embeds = [kwargs["embed"]]
+        return self
+    async def delete(self):
+        return None
+    async def create_thread(self, name, auto_archive_duration=None, **kwargs):
+        # Return a fake thread that has the necessary fields
+        return _FakeThread(name=name)
+
+
+class _FakeThread:
+    """Minimal thread stub for the Task tool path."""
+    def __init__(self, name):
+        import random
+        self.id = random.randint(10_000, 99_999)
+        self.name = name
+        self.mention = f"<#{self.id}>"
+        self.parent = None
+        self._sent = []
+    async def send(self, *args, **kwargs):
+        msg = _FakeMessage(msg_id=self.id * 100 + len(self._sent))
+        if "content" in kwargs:
+            msg.content = kwargs["content"]
+        if "embed" in kwargs:
+            msg.embeds = [kwargs["embed"]]
+        self._sent.append(msg)
+        return msg
+
+
+class _FakeTarget:
+    """Top-level channel/thread stub for Sub-agent dispatch path."""
+    def __init__(self):
+        self.id = 1
+        self.name = "main-thread"
+        self.mention = "<#1>"
+        self.parent = None
+        self._sent = []
+    async def send(self, *args, **kwargs):
+        msg = _FakeMessage(msg_id=len(self._sent) + 1)
+        if "content" in kwargs:
+            msg.content = kwargs["content"]
+        if "embed" in kwargs:
+            msg.embeds = [kwargs["embed"]]
+        self._sent.append(msg)
+        return msg
+
+
+class _FakeBridge:
+    is_active = True
+    _client = MagicMock()
+    def __init__(self, events):
+        self._events = events
+    async def send_message(self, _text):
+        for ev in self._events:
+            yield ev
+    async def get_context_usage(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_subtask_complete_renders_clean_text_from_list_of_dicts():
+    """E2E: ToolResultBlock with list[dict] content (the prod-failure
+    shape) must produce a clean text description, not a Python repr."""
+    import sys
+    sys.path.insert(0, "src")
+    from claude_agent_sdk.types import (
+        AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
+    )
+    from clauded.discord_renderer import DiscordRenderer
+
+    leaky_text = (
+        "Async agent launched successfully.\n"
+        "agentId: aae5405f50ce90137 (internal ID - do not mention to user. "
+        "Use SendMessage with to: 'aae5405f50ce90137' to continue this agent.)\n"
+        "The agent is working in the background."
+    )
+    events = [
+        AssistantMessage(
+            content=[ToolUseBlock(id="task-1", name="Task", input={"prompt": "do stuff", "description": "test task"})],
+            model="claude-sonnet-4-5", parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[
+                ToolResultBlock(
+                    tool_use_id="task-1",
+                    content=[{"type": "text", "text": leaky_text}],
+                    is_error=False,
+                )
+            ],
+            model="claude-sonnet-4-5", parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result", duration_ms=100, duration_api_ms=80,
+            is_error=False, num_turns=1, session_id="sess-subtask",
+            total_cost_usd=0.001,
+        ),
+    ]
+
+    target = _FakeTarget()
+    renderer = DiscordRenderer(target)
+    await renderer.render_response(_FakeBridge(events), "run task")
+
+    # Embeds may have been sent to either the main target OR the sub-thread.
+    # Collect from both.
+    all_embeds = list(target._sent)
+    # Find the sub-thread (was created on _FakeMessage.create_thread)
+    # by walking through anchor messages
+    # Actually FakeMessage.create_thread returns FakeThread instances; collect their sent too.
+    # Simpler: also scan FakeThread instances via the renderer/subagent_renderers
+    # (those are not exposed). For this test, embeds we care about end up on the
+    # sub-thread via subagent_renderers[tool_id]._safe_send.
+    # Hack: monkey-patch FakeMessage.create_thread to record threads globally
+    threads_created: list[_FakeThread] = []
+    orig_create = _FakeMessage.create_thread
+    async def _record_create(self, name, **kw):
+        t = _FakeThread(name=name)
+        threads_created.append(t)
+        return t
+
+    # Re-run with patched create_thread
+    _FakeMessage.create_thread = _record_create  # type: ignore[method-assign]
+    try:
+        target2 = _FakeTarget()
+        renderer2 = DiscordRenderer(target2)
+        await renderer2.render_response(_FakeBridge(events), "run task")
+    finally:
+        _FakeMessage.create_thread = orig_create  # type: ignore[method-assign]
+
+    # Now scan target2._sent + threads_created._sent
+    all_msgs = list(target2._sent)
+    for t in threads_created:
+        all_msgs.extend(t._sent)
+    embeds = []
+    for m in all_msgs:
+        for e in m.embeds:
+            embeds.append(e)
+    subtask_embeds = [
+        e for e in embeds
+        if (e.title or "").startswith(("✅ Subtask", "❌ Subtask", "🚀 Sub-agent"))
+    ]
+    assert subtask_embeds, (
+        f"Expected a Subtask embed; got titles: "
+        f"{[(e.title or '') for e in embeds]}"
+    )
+    # Find the dispatch-marked embed
+    dispatch_embeds = [e for e in subtask_embeds if "Sub-agent dispatched" in (e.title or "") and not (e.description or "").startswith("📎 ")]
+    assert dispatch_embeds, (
+        f"Async-launch must be marked 'Sub-agent dispatched'; "
+        f"got: {[(e.title or '') for e in subtask_embeds]}"
+    )
+    embed = dispatch_embeds[0]
+    desc = embed.description or ""
+    # Fix A: no Python repr leakage
+    assert "[{'type':" not in desc, f"Python repr leaked: {desc!r}"
+    assert "'text':" not in desc, f"dict key visible: {desc!r}"
+    # Fix B: meta-instruction stripped
+    assert "do not mention" not in desc.lower(), f"meta instruction leaked: {desc!r}"
+    assert "internal ID" not in desc, f"meta instruction leaked: {desc!r}"
+    # Legitimate content preserved
+    assert "Async agent launched" in desc or "background" in desc, (
+        f"Legitimate content stripped: {desc!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_subtask_complete_normal_path_still_works():
+    """Backward compat: when content is a plain string (most tools), the
+    existing Subtask Complete rendering still produces correct output."""
+    import sys
+    sys.path.insert(0, "src")
+    from claude_agent_sdk.types import (
+        AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
+    )
+    from clauded.discord_renderer import DiscordRenderer
+
+    plain_text = "Task finished. Result: 42 items processed successfully."
+    events = [
+        AssistantMessage(
+            content=[ToolUseBlock(id="task-2", name="Task", input={"prompt": "count", "description": "count items"})],
+            model="claude-sonnet-4-5", parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[
+                ToolResultBlock(tool_use_id="task-2", content=plain_text, is_error=False)
+            ],
+            model="claude-sonnet-4-5", parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result", duration_ms=100, duration_api_ms=80,
+            is_error=False, num_turns=1, session_id="sess-norm",
+            total_cost_usd=0.001,
+        ),
+    ]
+
+    threads_created: list[_FakeThread] = []
+    orig = _FakeMessage.create_thread
+    async def _record(self, name, **kw):
+        t = _FakeThread(name=name)
+        threads_created.append(t)
+        return t
+    _FakeMessage.create_thread = _record  # type: ignore[method-assign]
+    try:
+        target = _FakeTarget()
+        renderer = DiscordRenderer(target)
+        await renderer.render_response(_FakeBridge(events), "run task")
+    finally:
+        _FakeMessage.create_thread = orig  # type: ignore[method-assign]
+
+    all_msgs = list(target._sent)
+    for t in threads_created:
+        all_msgs.extend(t._sent)
+    embeds = [e for m in all_msgs for e in m.embeds]
+    subtask_embeds = [
+        e for e in embeds
+        if (e.title or "").startswith(("✅ Subtask", "❌ Subtask", "🚀 Sub-agent"))
+    ]
+    assert subtask_embeds
+    # NOT a dispatch (no "Async agent launched" in plain text)
+    dispatch_marks = [e for e in subtask_embeds if "Sub-agent dispatched" in (e.title or "")]
+    assert not dispatch_marks, (
+        f"Plain text MUST NOT be marked as 'Sub-agent dispatched'; "
+        f"got: {[(e.title or '') for e in subtask_embeds]}"
+    )
+    # Standard "✅ Subtask Complete"
+    complete_marks = [e for e in subtask_embeds if "✅ Subtask Complete" in (e.title or "") and not (e.description or "").startswith("📎 ")]
+    assert complete_marks, f"Expected '✅ Subtask Complete'; got: {[(e.title or '') for e in subtask_embeds]}"
+    embed = complete_marks[0]
+    # Plain text preserved
+    assert "42 items processed" in (embed.description or "")

--- a/tests/test_subtask_complete_render.py
+++ b/tests/test_subtask_complete_render.py
@@ -390,3 +390,88 @@ async def test_subtask_complete_normal_path_still_works():
     embed = complete_marks[0]
     # Plain text preserved
     assert "42 items processed" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_subtask_failed_with_list_of_dicts_renders_clean_error():
+    """R1 tester gap: error-path (is_error=True) + list-of-dict content
+    must also extract clean text, not leak Python repr. The embed title
+    flips to '❌ Subtask Failed' (not Sub-agent dispatched, since we
+    only dispatch-detect on the non-error path)."""
+    import sys
+    sys.path.insert(0, "src")
+    from claude_agent_sdk.types import (
+        AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
+    )
+    from clauded.discord_renderer import DiscordRenderer
+
+    err_text = "Task crashed: ValueError(\"missing required arg 'name'\")"
+    events = [
+        AssistantMessage(
+            content=[ToolUseBlock(id="task-err", name="Task", input={"prompt": "bad", "description": "buggy"})],
+            model="claude-sonnet-4-5", parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[
+                ToolResultBlock(
+                    tool_use_id="task-err",
+                    content=[{"type": "text", "text": err_text}],
+                    is_error=True,
+                )
+            ],
+            model="claude-sonnet-4-5", parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result", duration_ms=100, duration_api_ms=80,
+            is_error=True, num_turns=1, session_id="sess-err",
+            total_cost_usd=0.001,
+        ),
+    ]
+
+    threads_created: list[_FakeThread] = []
+    orig = _FakeMessage.create_thread
+    async def _record(self, name, **kw):
+        t = _FakeThread(name=name)
+        threads_created.append(t)
+        return t
+    _FakeMessage.create_thread = _record  # type: ignore[method-assign]
+    try:
+        target = _FakeTarget()
+        renderer = DiscordRenderer(target)
+        await renderer.render_response(_FakeBridge(events), "run task")
+    finally:
+        _FakeMessage.create_thread = orig  # type: ignore[method-assign]
+
+    all_msgs = list(target._sent)
+    for t in threads_created:
+        all_msgs.extend(t._sent)
+    embeds = [e for m in all_msgs for e in m.embeds]
+    failed_embeds = [
+        e for e in embeds
+        if (e.title or "").startswith("❌ Subtask Failed")
+        and not (e.description or "").startswith("📎 ")
+    ]
+    assert failed_embeds, (
+        f"Expected '❌ Subtask Failed' embed; got titles: "
+        f"{[(e.title or '') for e in embeds]}"
+    )
+    embed = failed_embeds[0]
+    desc = embed.description or ""
+    # No Python repr leak
+    assert "[{'type':" not in desc
+    assert "'text':" not in desc
+    # The actual error text comes through
+    assert "ValueError" in desc or "missing required arg" in desc
+
+
+def test_dispatch_detection_word_boundary():
+    """R1 engineer: word-boundary anchor prevents false positives where
+    'async agent' appears as a substring in unrelated context."""
+    from clauded.discord_renderer import _is_async_agent_dispatch
+    # Positive: canonical phrase
+    assert _is_async_agent_dispatch("Async agent launched successfully.")
+    assert _is_async_agent_dispatch("ASYNC AGENT LAUNCHED")
+    # Negative: substring without word boundary
+    assert not _is_async_agent_dispatch("synchronizedasync agentlauncher started")
+    # Negative: missing 'launched' verb
+    assert not _is_async_agent_dispatch("async agent is running")


### PR DESCRIPTION
Closes #192 (P0).

## Bug
Sub-agent "✅ Subtask Complete" embed leaked **3 issues simultaneously**:
1. Python repr: `[{'type': 'text', 'text': '...'}]` visible in the embed
2. CLI meta: "(internal ID - do not mention to user. Use SendMessage with...)" leaked
3. Mislabel: async-dispatch ack marked as completion

User: "啥意思？这个为啥显示这个？子 agent 坏了？"

## Fix
Three small helpers in `discord_renderer.py`:
- `_extract_block_content_text(content)` — normalizes SDK content shapes (str / list[dict] / list[str] / dict / None / pathological) to plain text
- `_strip_internal_metadata(text)` — regex-removes "(internal ID - do not mention to user...)" patterns; negative-tested against legitimate content
- `_is_async_agent_dispatch(text)` — detects "Async agent launched" payload → new embed title `🚀 Sub-agent dispatched (running in background)` in COLOR_INFO

Applied at all 4 leaky sites (2× Subtask Complete embed, inline-fallback, rolling-log).

## Tests
+17 in `test_subtask_complete_render.py` (8 unit shape coverage + 5 unit strip patterns + 2 unit dispatch detection + 2 integration with **real SDK shape** + 1 backward-compat).

pytest 635 / 2 pre-existing P1.
