### PR TITLE
test(subagent): align 2 P1 tests with post-2608502 StreamEvent contract

### DIFF
--- a/tests/test_subagent_threads.py
+++ b/tests/test_subagent_threads.py
@@ -422,7 +422,20 @@ async def test_non_subagent_messages_stay_in_main():
     parent_channel = FakeChannel()
     main_thread = FakeMainThread(parent_channel=parent_channel, name="main")
 
+    # Per commit 2608502: text arrives via StreamEvent (real SDK behavior
+    # with include_partial_messages=True). AssistantMessage TextBlock is
+    # skipped as a streaming duplicate. Test must feed a matching
+    # text_delta StreamEvent so the renderer's buffer actually receives
+    # the text.
     events = [
+        StreamEvent(
+            uuid="sev-1",
+            session_id="sess-7",
+            event={
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "Hello from main agent"},
+            },
+        ),
         AssistantMessage(
             content=[TextBlock(text="Hello from main agent")],
             model="claude-sonnet",
@@ -498,7 +511,21 @@ async def test_unknown_parent_tool_use_id_not_routed():
     parent_channel = FakeChannel()
     main_thread = FakeMainThread(parent_channel=parent_channel, name="main")
 
+    # Per commit 2608502: same as test_non_subagent_messages_stay_in_main —
+    # text comes via StreamEvent. The unknown parent_tool_use_id on the
+    # AssistantMessage doesn't change that path (parent_tool_use_id is a
+    # sub-thread routing key on AssistantMessage only, not on StreamEvent;
+    # StreamEvent text always lands on the main thread when no sub-thread
+    # mapping exists for the active block).
     events = [
+        StreamEvent(
+            uuid="sev-2",
+            session_id="sess-10",
+            event={
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "Unknown parent message"},
+            },
+        ),
         AssistantMessage(
             content=[TextBlock(text="Unknown parent message")],
             model="claude-sonnet",


### PR DESCRIPTION
Closes 2 P1 test failures that have been red since commit `2608502` (#110 shipped 2026-05-08).

## Why they were red
`2608502` codified: text arrives via `StreamEvent`, not `AssistantMessage TextBlock` (which is skipped as a duplicate under `include_partial_messages=True`). The 2 tests synthesized only the `AssistantMessage TextBlock` and no matching `StreamEvent` → no text ever reached the buffer.

## Fix
Add the matching `StreamEvent(content_block_delta / text_delta)` before the `AssistantMessage` in each test's event list. Mirrors the real SDK wire shape.

## Result
**pytest 639 / 0** (was 637 / 2 pre-existing P1). First all-green run of the v1.18 session.

No production behavior change. Test scaffolding only.
