### PR TITLE
fix(model): don't force model='sonnet' default override — mirror CLI default (#198)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
 # Discord bot token from https://discord.com/developers/applications
 DISCORD_BOT_TOKEN=your-bot-token-here
 
-# Claude model (sonnet, opus, haiku, or full model id). Optional, defaults to sonnet.
-CLAUDE_MODEL=sonnet
+# Optional: lock all sessions to a specific model. Unset = use the CLI default
+# from ~/.claude/settings.json (the same model `claude` in your terminal uses).
+# Set this only if you're an admin who wants to force-pin all conversations.
+# Accepts an alias (sonnet, opus, haiku, sonnet-1m) or a full model id.
+# CLAUDE_MODEL=sonnet
 
 # Claude permission mode. Options: default, acceptEdits, plan, bypassPermissions
 # NOTE: AskUserQuestion interactive prompts (buttons/select menus) only work

--- a/docs/prd/v1.18-fix-model-default.md
+++ b/docs/prd/v1.18-fix-model-default.md
@@ -1,0 +1,169 @@
+# PRD — Fix forced model="sonnet" default override (#198)
+
+**Status**: DRAFT (awaiting user approval)
+**Issue**: [#198](https://github.com/HXYerror/claudeD/issues/198)
+**Branch**: `fix/v1.18-model-default-no-force`
+**Severity**: P0 (blocks long-context conversations on proxied providers)
+
+---
+
+## Problem
+
+claudeD silently overrides the user's CLI default model. `~/.claude/settings.json` says one model, but claudeD always passes `model="sonnet"` to the SDK because:
+
+```python
+# config.py:60
+claude_model = os.environ.get("CLAUDE_MODEL", "sonnet").strip() or "sonnet"
+
+# claude_bridge.py:144  — three-tier fallback always non-empty
+@property
+def model(self) -> str:
+    return self._model_override or self._sdk_model or self._config.claude_model
+
+# claude_bridge.py:316  — always passed
+options = ClaudeAgentOptions(model=self.model, ...)
+```
+
+User-reported impact: terminal `claude` succeeds for the same long-context conversation; claudeD fails because their proxy maps `sonnet` → `claude-sonnet-4-6` (168k limit) instead of the higher-limit model their CLI default would have picked.
+
+## Goals
+
+1. **Mirror terminal `claude` behavior** when user hasn't explicitly switched: don't pass any `model` to the SDK → SDK/CLI uses `~/.claude/settings.json` default (or last-used).
+2. **Preserve `/model switch <name>`** — user-explicit choice still flows through, gets `_model_override` set, is explicitly passed.
+3. **Preserve `CLAUDE_MODEL` env** as an admin/ops override knob — same precedence as today (env > user switch > nothing). **But default deployment leaves it UNSET**: `.env.example` updated to comment-out the line so a fresh copy doesn't accidentally lock in `sonnet`.
+4. **`/model current` shows truth** — once the SDK has reported the actual resolved model (via `ResultMessage.model`), display that. Before first turn: a placeholder.
+5. **Single-purpose change** — no other claudeD-overrides-CLI audit in this PR.
+
+## Non-goals
+
+- Auditing other potential CLI-default overrides (separate issue if needed)
+- README documentation update (operator already understands; user-facing UI is `/model current`)
+- Reading `~/.claude/settings.json` proactively (SDK already does this when we don't pass `model`)
+- Backward-compat shim to preserve "sonnet" default for existing deployments — accept the break
+
+## Design
+
+### Source-of-truth tier model (post-fix)
+
+| Tier | Source | Passed to SDK? |
+|---|---|---|
+| 1 — admin / ops override | `CLAUDE_MODEL` env var | yes, explicit |
+| 2 — user runtime switch | `/model switch X` → `_model_override` | yes, explicit |
+| 3 — observed (post-turn) | `ResultMessage.model` → `_sdk_model` | **NO** (display-only) |
+| 4 — CLI default | not passed at all | **NO** (SDK reads `~/.claude/settings.json`) |
+
+**Change vs today**: tier 4 used to fall back to hardcoded `"sonnet"` from `config.claude_model`. Now it falls back to `None` and the SDK option is omitted entirely.
+
+### `Config.claude_model` becomes `Optional[str]`
+
+`config.py:60` becomes:
+
+```python
+_env = os.environ.get("CLAUDE_MODEL", "").strip()
+claude_model = _env or None   # was: _env or "sonnet"
+```
+
+Now `None` is a valid value meaning "no admin override, let SDK pick".
+
+### `ClaudeBridge.model` property: returns Optional[str]
+
+```python
+@property
+def model(self) -> str | None:
+    return self._model_override or self._sdk_model or self._config.claude_model
+```
+
+`_sdk_model` is in here for `/model current` display only — see next section.
+
+### `ClaudeBridge.start()`: conditionally pass `model=`
+
+`claude_bridge.py:316` becomes:
+
+```python
+options_kwargs = {...other kwargs..., }  # build dict
+chosen = self._model_override or (self._config.claude_model if self._config.claude_model else None)
+if chosen:
+    options_kwargs["model"] = chosen
+options = ClaudeAgentOptions(**options_kwargs)
+```
+
+Or — cleaner — accept that `ClaudeAgentOptions(model=None)` may be supported by the SDK (need to verify). If yes, just pass `None`. **Implementation will verify which path works; both reach the same outcome.**
+
+Note: `_sdk_model` is intentionally NOT used here — that field holds the model the SDK **reported back to us** on the first ResultMessage, and using it as input would form a loop (the user's CLI default → ResultMessage.model → next turn forces that model → can't change via settings.json mid-session). It is display-only.
+
+### `/model current` display logic
+
+```
+if _model_override:                      → show "{_model_override}" + metadata
+elif config.claude_model (env-set):     → show "{config.claude_model} (CLAUDE_MODEL env)"
+elif _sdk_model (post-first-turn):       → show "{_sdk_model} (CLI default)"
+else (before first turn):                → show "(unset — will use CLI default; ask Claude something to discover)"
+```
+
+### `/model switch` unchanged
+
+Sets `_model_override` exactly as today. Verifies via the same `_recreate_session(model_override=name)` flow.
+
+### KNOWN_MODELS table unchanged
+
+The `/model list` view still highlights based on the same comparison. Bot-default unset case shows no 🟢 marker on any row (correct — user hasn't picked).
+
+## Acceptance criteria
+
+### Behavioral
+- [ ] `CLAUDE_MODEL` unset + no `/model switch` → SDK call omits `model=` kwarg entirely (verify via mock `ClaudeAgentOptions` capture in test)
+- [ ] `CLAUDE_MODEL=opus` + no `/model switch` → SDK call has `model="opus"`
+- [ ] `CLAUDE_MODEL` unset + `/model switch haiku` → SDK call has `model="haiku"`
+- [ ] `CLAUDE_MODEL=opus` + `/model switch haiku` → SDK call has `model="haiku"` (user switch wins over env)
+- [ ] After first `ResultMessage`, `_sdk_model` populated; `bridge.model` property returns it (for `/model current` display)
+- [ ] User's existing long-context conversation that fails today (168k limit error) succeeds after this fix when `CLAUDE_MODEL` is unset and settings.json says a higher-limit model
+
+### `/model current` cases
+- [ ] No env, no override, before first turn → `"(unset — will use CLI default; ask Claude something to discover)"`
+- [ ] No env, no override, after first turn → `"{resolved_model} (CLI default)"`
+- [ ] `CLAUDE_MODEL=opus` set → `"opus (CLAUDE_MODEL env)"`
+- [ ] `/model switch haiku` → `"haiku"` + metadata from KNOWN_MODELS
+
+### Tests
+- [ ] Unit test: `Config.claude_model` is `None` when `CLAUDE_MODEL` unset
+- [ ] Unit test: `Config.claude_model` is the env value when set
+- [ ] Unit test: `ClaudeBridge.model` property returns `None` for the no-override case
+- [ ] Integration test (mock SDK): `ClaudeAgentOptions` constructor NOT called with `model=` when all tiers are None
+- [ ] Integration test (mock SDK): `ClaudeAgentOptions` constructor called with `model="opus"` when env is "opus"
+- [ ] Integration test (mock SDK): `_sdk_model` set after `ResultMessage` arrives with a `model` attribute
+- [ ] `/model current` test: 4 cases (no env/no switch/no turn; no env/no switch/post-turn; env set; user switch)
+
+### Migration / backward compat
+- [ ] Operators who were implicitly relying on "sonnet" as the default now see their settings.json default. Document in PR description so they know.
+- [ ] **`.env.example`**: comment out the `CLAUDE_MODEL=sonnet` line + add comment explaining when to set it (e.g., admin lock-in scenarios). Existing operator `.env` files unaffected (they keep whatever they had).
+- [ ] Existing `data/sessions.json` entries don't store `model` (already true) → no migration needed
+
+## Out of scope (separate issues)
+
+- Audit other places where claudeD might be silently overriding CLI defaults (e.g., permission_mode, allowed_tools)
+- README / docs updates
+- Adding a `/model unset` or `/model reset` slash command for users to clear `_model_override` mid-session (rare; can defer)
+- Persisting `_sdk_model` across bot restart (turns ephemeral; first turn after restart reads it again)
+
+## Risks
+
+- **`ClaudeAgentOptions(model=None)` SDK behavior unknown**: implementation must verify whether passing `None` is equivalent to omitting, or if `None` causes the SDK to crash / hardcode something else. If `None` is rejected, fall back to building the kwargs dict and only setting `model=` when present.
+- **Side effect on `/model list` 🟢 marker**: when no model is set anywhere, no row is highlighted. May surprise users. Acceptable per scope decision.
+- **`/health` / debug commands** that show "current model" — audit & update if they read `config.claude_model` directly.
+
+## Plan
+
+5 sub-tasks (one PR; sub-tasks are review unit boundaries, not separate commits):
+
+1. **S1** — `config.py`: `claude_model: Optional[str] = None` when env unset; preserve env-set behavior
+2. **S2** — `claude_bridge.py`: `model` property returns `Optional[str]`; `start()` conditionally builds `ClaudeAgentOptions` kwargs to omit `model=` when `None`
+3. **S3** — `cogs/model.py`: `/model current` 4-case display update
+4. **S4** — Audit other consumers of `config.claude_model` (e.g., `cogs/ops.py` `/health` may display this); update display-only sites
+5. **S5** — `.env.example`: comment out `CLAUDE_MODEL=sonnet` + explain when admins should set it
+6. **S6** — Tests: unit + integration covering all 4 acceptance criteria buckets
+
+## Sign-off
+
+Awaiting user approval (Discord ping) before:
+- Creating dispatch sub-task issues on GitHub
+- Spawning `coding` agent

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -165,6 +165,20 @@ class ClaudeBridge:
         )
 
     @property
+    def explicit_model_override(self) -> str | None:
+        """The user-explicit ``/model switch <name>`` value, or ``None``.
+
+        Public read-only accessor for ``_model_override`` so consumers that
+        need to persist *only* the user's explicit choice (e.g.,
+        :class:`SessionManager.save_session_state`) can avoid the
+        collapsed :attr:`model` property, which would write back the
+        SDK-observed ``_sdk_model`` and form a cross-restart input loop
+        (#198 PRD §Design line 92). Returns ``None`` when the user has
+        not switched and the SDK's CLI-default should govern.
+        """
+        return self._model_override
+
+    @property
     def is_active(self) -> bool:
         """True iff the underlying client is currently connected."""
         return self._active

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -139,9 +139,30 @@ class ClaudeBridge:
         self._config = value
 
     @property
-    def model(self) -> str:
-        """Return the active model: explicit override, SDK-reported, or config default."""
-        return self._model_override or self._sdk_model or self._config.claude_model
+    def model(self) -> str | None:
+        """Return the active model for this session, or ``None`` if none is bound.
+
+        Tier precedence (#198):
+        1. ``_model_override`` — user-explicit ``/model switch <name>``
+        2. ``_sdk_model`` — model reported by the SDK on the first
+           ``ResultMessage`` (display-only; NOT used as SDK input — see
+           ``start()`` for why). Once observed, this is the most
+           specific/accurate value (a full model id like
+           ``claude-sonnet-4-5`` rather than the ``sonnet`` alias).
+        3. ``_config.claude_model`` — admin/ops ``CLAUDE_MODEL`` env var
+        4. ``None`` — pre-first-turn with no override and no env var. The
+           SDK call omits ``model=`` so the CLI's ``~/.claude/settings.json``
+           default is used, matching terminal ``claude`` behavior.
+
+        Note: callers that need to distinguish the four cases (e.g.
+        ``/model current``) should inspect the tier fields directly rather
+        than this collapsed property.
+        """
+        return (
+            self._model_override
+            or self._sdk_model
+            or self._config.claude_model
+        )
 
     @property
     def is_active(self) -> bool:
@@ -309,11 +330,21 @@ class ClaudeBridge:
         # back to its own bundled CLI.
         cli_path = resolve_claude_cli()
 
+        # #198: only pass ``model=`` to the SDK when the user has explicitly
+        # chosen one (``/model switch``) or the operator has pinned via
+        # ``CLAUDE_MODEL``. Otherwise omit it so the SDK/CLI reads its own
+        # default from ``~/.claude/settings.json`` — same as terminal
+        # ``claude``. We deliberately do NOT use ``_sdk_model`` here: it's
+        # display-only (the model the SDK reported back on the first
+        # ``ResultMessage``); using it as input would lock the session into
+        # whatever was resolved on turn 1 even if settings.json changes.
+        chosen_model = self._model_override or self._config.claude_model
+
         options = ClaudeAgentOptions(
             cwd=self.project_path,
             env=self._env or {},
             permission_mode=self._config.claude_permission_mode,
-            model=self.model,
+            model=chosen_model,
             resume=self._resume_session_id,
             # R3 (#116): system_prompt preset dict replaces append_system_prompt
             system_prompt={

--- a/src/clauded/cogs/model.py
+++ b/src/clauded/cogs/model.py
@@ -41,13 +41,44 @@ def _fmt_context(n: int) -> str:
 def _current_model_for_thread(bot, thread_id: int | None) -> str | None:
     """Return the active model name for ``thread_id`` if a session exists,
     else None. Resolves through ``bridge.model`` which already follows
-    the override > sdk-reported > config-default chain."""
+    the override > sdk-reported > config-default chain.
+
+    #198: ``bridge.model`` may legitimately return ``None`` now (no
+    override, no env, no first turn yet). Callers should treat ``None``
+    as a valid signal rather than 'no session'.
+    """
     if thread_id is None:
         return None
     bridge = bot.session_manager.get_session(thread_id)
     if bridge is None:
         return None
     return getattr(bridge, "model", None)
+
+
+def _model_source_for_bridge(bridge) -> tuple[str, str | None]:
+    """Return (source, value) describing where the bridge's model came from.
+
+    #198: ``/model current`` needs to distinguish the 4 tier cases so it
+    can render an accurate description. We inspect tier fields directly
+    rather than the collapsed ``bridge.model`` property.
+
+    Returns one of:
+    - ``("override", "<name>")``  — user ran ``/model switch``
+    - ``("env", "<value>")``      — ``CLAUDE_MODEL`` env var was set
+    - ``("sdk", "<value>")``      — SDK reported it on a ``ResultMessage``
+    - ``("unset", None)``         — pre-first-turn, no override, no env
+    """
+    override = getattr(bridge, "_model_override", None)
+    if override:
+        return ("override", override)
+    config = getattr(bridge, "_config", None)
+    env_model = getattr(config, "claude_model", None) if config else None
+    if env_model:
+        return ("env", env_model)
+    sdk_model = getattr(bridge, "_sdk_model", None)
+    if sdk_model:
+        return ("sdk", sdk_model)
+    return ("unset", None)
 
 
 model_group = app_commands.Group(
@@ -114,31 +145,65 @@ async def model_current(interaction: discord.Interaction) -> None:
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
     thread_id = getattr(interaction.channel, "id", None)
-    current = _current_model_for_thread(bot, thread_id)
-    if current is None:
+    # #198: don't collapse via ``bridge.model`` — we need to know which
+    # tier the value came from so we can label it correctly. Resolve the
+    # bridge directly and dispatch on the 4 tier cases.
+    bridge = (
+        bot.session_manager.get_session(thread_id) if thread_id is not None else None
+    )
+    if bridge is None:
         await interaction.response.send_message(
             "ℹ️ No active session in this channel. Send a message to start one.",
             ephemeral=True,
         )
         return
-    # Try to find the matching KNOWN_MODELS entry for metadata
+
+    source, value = _model_source_for_bridge(bridge)
+
+    # Case 4: nothing pinned anywhere AND no SDK turn yet — let the user
+    # know the SDK/CLI will resolve the default on the first turn.
+    if source == "unset":
+        embed = discord.Embed(
+            title="🤖 Current Model",
+            description=(
+                "_(unset — will use CLI default; ask Claude something to "
+                "discover the actual model)_"
+            ),
+            color=COLOR_TOOL_SUCCESS,
+        )
+        await interaction.response.send_message(embed=embed)
+        return
+
+    # Cases 1-3: we have a concrete model name. Build the KNOWN_MODELS
+    # metadata block when the name matches an alias or full id.
+    assert value is not None  # narrowed by the source != "unset" branch
     matched = None
     for alias, info in KNOWN_MODELS.items():
-        if current == alias or current == info["id"]:
+        if value == alias or value == info["id"]:
             matched = (alias, info)
             break
-    if matched:
-        alias, info = matched
-        ctx = _fmt_context(info["context"])
-        desc = (
-            f"• **alias**: `{alias}`\n"
-            f"• **id**: `{info['id']}`\n"
-            f"• **tier**: {info['tier']}\n"
-            f"• **context**: {ctx}"
-        )
+
+    if source == "override":
+        # User ran /model switch — full metadata, no suffix on the title
+        # (matches existing UX from before this PR).
+        if matched:
+            alias, info = matched
+            ctx = _fmt_context(info["context"])
+            desc = (
+                f"• **alias**: `{alias}`\n"
+                f"• **id**: `{info['id']}`\n"
+                f"• **tier**: {info['tier']}\n"
+                f"• **context**: {ctx}"
+            )
+        else:
+            desc = f"• **id**: `{value}`\n• _(not in known-models table)_"
+    elif source == "env":
+        # Admin-pinned via CLAUDE_MODEL env var.
+        desc = f"`{value}` (CLAUDE_MODEL env)"
     else:
-        # Unknown model (full id / experimental)
-        desc = f"• **id**: `{current}`\n• _(not in known-models table)_"
+        # source == "sdk" — observed from a ResultMessage post-first-turn.
+        desc = f"`{value}` (CLI default)"
+
     embed = discord.Embed(
         title="🤖 Current Model",
         description=desc,

--- a/src/clauded/cogs/session.py
+++ b/src/clauded/cogs/session.py
@@ -119,7 +119,10 @@ async def session_info(interaction: discord.Interaction) -> None:
         bot.session_manager.get_session(thread_id) if thread_id is not None else None
     )
     if bridge is not None and bridge.is_active:
-        model = bridge.model or bot.config.claude_model
+        # #198: bridge.model and bot.config.claude_model can both be None now
+        # (unset env + no override + pre-first-turn). Fall back to a
+        # human-readable placeholder for display.
+        model = bridge.model or bot.config.claude_model or "(SDK default)"
         cost_str = f"${bridge.total_cost:.4f}" if bridge.total_cost else "$0.0000"
         lines = [
             f"📡 **Session active** — cwd `{bridge.project_path}`",

--- a/src/clauded/config.py
+++ b/src/clauded/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 import logging
 
@@ -18,7 +19,7 @@ class Config:
     """Runtime configuration for the Discord-Claude bridge."""
 
     discord_bot_token: str
-    claude_model: str
+    claude_model: Optional[str]
     claude_permission_mode: str
     projects_root: str
     # SECURITY: when False (default), an unbound channel's @bot message is
@@ -55,9 +56,16 @@ def load_config() -> Config:
         if os.environ.get(typo):
             log.warning("Found '%s' in env — did you mean '%s'?", typo, correct)
 
+    # #198: claude_model is Optional[str]. UNSET env var → None → SDK call
+    # omits the `model` kwarg → CLI default from ~/.claude/settings.json is
+    # used (same as terminal `claude`). Setting CLAUDE_MODEL is now an
+    # explicit admin/ops "force-pin" knob rather than the default path.
+    _claude_model_env = os.environ.get("CLAUDE_MODEL", "").strip()
+    claude_model: Optional[str] = _claude_model_env or None
+
     return Config(
         discord_bot_token=token,
-        claude_model=os.environ.get("CLAUDE_MODEL", "sonnet").strip() or "sonnet",
+        claude_model=claude_model,
         claude_permission_mode=(
             os.environ.get("CLAUDE_PERMISSION_MODE", "default").strip()
             or "default"

--- a/src/clauded/session_manager.py
+++ b/src/clauded/session_manager.py
@@ -93,12 +93,23 @@ class SessionManager:
         return True
 
     def save_session_state(self, thread_id: int) -> None:
-        """Persist the current session state for ``thread_id`` to the store."""
+        """Persist the current session state for ``thread_id`` to the store.
+
+        #198 PRD §Design line 92: persist ONLY the user-explicit override
+        (``bridge.explicit_model_override``), not the collapsed
+        ``bridge.model`` property. The collapsed property includes
+        ``_sdk_model`` (what the SDK reported back), and persisting it
+        would lock future resumes onto the SDK-observed value even after
+        the user edits ``~/.claude/settings.json``. Persist ``None`` when
+        the user has not switched — resume will then let the SDK pick
+        the CLI default again.
+        """
         bridge = self._sessions.get(thread_id)
         if bridge and bridge.session_id:
             self._session_store.save_session(
                 thread_id, bridge.session_id, bridge.project_path,
-                model=bridge.model, system_prompt=bridge.system_prompt,
+                model=bridge.explicit_model_override,
+                system_prompt=bridge.system_prompt,
             )
 
     def get_stored_session(self, thread_id: int) -> dict | None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,11 +46,24 @@ def test_blank_token_raises(isolated_env: pytest.MonkeyPatch) -> None:
         load_config()
 
 
-def test_default_model_is_sonnet(isolated_env: pytest.MonkeyPatch) -> None:
+def test_default_model_is_none(isolated_env: pytest.MonkeyPatch) -> None:
+    """#198: CLAUDE_MODEL unset → claude_model is None (was 'sonnet').
+
+    None signals "no admin override, let SDK pick from
+    ~/.claude/settings.json" — matches terminal `claude` behavior.
+    """
     isolated_env.setenv("DISCORD_BOT_TOKEN", "tok-abc")
     cfg = load_config()
     assert isinstance(cfg, Config)
-    assert cfg.claude_model == "sonnet"
+    assert cfg.claude_model is None
+
+
+def test_blank_model_env_is_none(isolated_env: pytest.MonkeyPatch) -> None:
+    """#198: whitespace-only CLAUDE_MODEL is treated as unset → None."""
+    isolated_env.setenv("DISCORD_BOT_TOKEN", "tok-abc")
+    isolated_env.setenv("CLAUDE_MODEL", "   ")
+    cfg = load_config()
+    assert cfg.claude_model is None
 
 
 def test_default_permission_mode(isolated_env: pytest.MonkeyPatch) -> None:

--- a/tests/test_model_cmd.py
+++ b/tests/test_model_cmd.py
@@ -90,9 +90,14 @@ async def test_model_current_with_session_renders_metadata():
     from clauded.bot import ClaudedBot
     bot_spec = MagicMock(spec=ClaudedBot)
     bot_spec.session_manager = MagicMock()
-    bot_spec.session_manager.get_session = MagicMock(
-        return_value=MagicMock(model="haiku")
-    )
+    # #198: model_current now inspects tier fields directly; simulate
+    # a user-explicit /model switch by setting _model_override.
+    bridge = MagicMock(model="haiku")
+    bridge._model_override = "haiku"
+    bridge._sdk_model = None
+    bridge._config = MagicMock()
+    bridge._config.claude_model = None
+    bot_spec.session_manager.get_session = MagicMock(return_value=bridge)
     interaction = MagicMock()
     interaction.client = bot_spec
     interaction.channel.id = 1
@@ -129,9 +134,13 @@ async def test_model_current_unknown_model_shows_id_only():
     from clauded.bot import ClaudedBot
     bot_spec = MagicMock(spec=ClaudedBot)
     bot_spec.session_manager = MagicMock()
-    bot_spec.session_manager.get_session = MagicMock(
-        return_value=MagicMock(model="claude-future-7-9-xl")
-    )
+    # #198: simulate /model switch to an unknown id (override tier).
+    bridge = MagicMock(model="claude-future-7-9-xl")
+    bridge._model_override = "claude-future-7-9-xl"
+    bridge._sdk_model = None
+    bridge._config = MagicMock()
+    bridge._config.claude_model = None
+    bot_spec.session_manager.get_session = MagicMock(return_value=bridge)
     interaction = MagicMock()
     interaction.client = bot_spec
     interaction.channel.id = 1

--- a/tests/test_model_default.py
+++ b/tests/test_model_default.py
@@ -415,3 +415,113 @@ def test_model_source_unset_when_all_none() -> None:
 
     bridge = _bridge_for_case(override=None, env_model=None, sdk_model=None)
     assert _model_source_for_bridge(bridge) == ("unset", None)
+
+
+# ---------------------------------------------------------------------------
+# R1 architect finding: persistence-loop fix
+# ---------------------------------------------------------------------------
+#
+# Before this PR, ``save_session_state`` read ``bridge.model`` (collapsed
+# property) which falls back to ``_sdk_model`` after the first
+# ResultMessage. The persisted value then re-injected as ``model_override``
+# on resume, forming a cross-restart loop and ignoring the user's
+# ``~/.claude/settings.json`` updates. PRD §Design line 92 explicitly
+# warned against feeding ``_sdk_model`` back into the SDK input — this
+# test pins the persistence boundary against that regression.
+
+
+def test_explicit_model_override_returns_user_choice_only():
+    """``ClaudeBridge.explicit_model_override`` reflects ONLY
+    ``_model_override`` — never ``_sdk_model`` or ``config.claude_model``.
+    """
+    from unittest.mock import MagicMock
+    from clauded.claude_bridge import ClaudeBridge
+
+    cfg = MagicMock()
+    cfg.claude_model = "sonnet"  # env-set scenario
+    cfg.claude_permission_mode = "default"
+    cfg.projects_root = "/tmp"
+
+    bridge = ClaudeBridge(project_path="/tmp", config=cfg)
+
+    # No explicit override yet → None
+    assert bridge.explicit_model_override is None
+    # _sdk_model populated post-ResultMessage → still None
+    bridge._sdk_model = "claude-haiku-4-5"
+    assert bridge.explicit_model_override is None
+    # User switches → reflects the user value
+    bridge._model_override = "opus"
+    assert bridge.explicit_model_override == "opus"
+
+
+def test_save_session_state_persists_only_explicit_override_no_sdk_loop():
+    """Pin the persistence-loop fix: ``save_session_state`` writes the
+    user-explicit override (or None when unset), never the SDK-observed
+    ``_sdk_model``. Without this fix, a user with no env / no /model
+    switch would get their CLI default locked in on resume even after
+    changing ``settings.json``.
+    """
+    from unittest.mock import MagicMock
+    from clauded.session_manager import SessionManager
+
+    # Build a bridge stub with the canonical "user did not switch" state:
+    # - _model_override is None
+    # - _sdk_model is what the SDK reported back (CLI default)
+    bridge = MagicMock()
+    bridge.session_id = "sess-abc"
+    bridge.project_path = "/tmp/proj"
+    bridge.system_prompt = ""
+    bridge._model_override = None
+    bridge._sdk_model = "claude-haiku-4-5"
+    bridge.explicit_model_override = None  # the new accessor
+
+    sm = SessionManager(MagicMock())
+    sm._sessions[42] = bridge
+
+    # Capture what gets passed to the store
+    captured: dict = {}
+
+    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None):
+        captured.update(
+            thread_id=thread_id, session_id=session_id, project_path=project_path,
+            model=model, system_prompt=system_prompt,
+        )
+
+    sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
+    sm.save_session_state(42)
+
+    # The persisted model MUST be the explicit override (None), NOT the
+    # SDK-observed value. Without this, future resumes lock to
+    # "claude-haiku-4-5" even when user changes settings.json.
+    assert captured["model"] is None, (
+        f"save_session_state must persist user-explicit override only, "
+        f"not _sdk_model. Got: {captured['model']!r} (expected None for "
+        f"the no-override case). This is the architect-flagged "
+        f"persistence-loop bug from #198 R1 review."
+    )
+
+
+def test_save_session_state_persists_user_override_when_set():
+    """Positive case: when user has switched to 'opus', persistence
+    correctly carries that across restart."""
+    from unittest.mock import MagicMock
+    from clauded.session_manager import SessionManager
+
+    bridge = MagicMock()
+    bridge.session_id = "sess-xyz"
+    bridge.project_path = "/tmp/proj"
+    bridge.system_prompt = ""
+    bridge.explicit_model_override = "opus"
+
+    sm = SessionManager(MagicMock())
+    sm._sessions[99] = bridge
+
+    captured: dict = {}
+
+    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None):
+        captured["model"] = model
+
+    sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
+    sm.save_session_state(99)
+
+    assert captured["model"] == "opus"

--- a/tests/test_model_default.py
+++ b/tests/test_model_default.py
@@ -1,0 +1,417 @@
+"""#198 — model default no-force fix.
+
+These tests pin the contract from ``docs/prd/v1.18-fix-model-default.md``:
+
+1. ``Config.claude_model`` is ``Optional[str]``; ``None`` when env unset.
+2. ``ClaudeBridge.model`` returns ``None`` when no tier is set.
+3. ``ClaudeAgentOptions(model=...)`` receives ``None`` when no tier is
+   set (which the SDK treats as "use CLI default from
+   ~/.claude/settings.json"); receives the env value when
+   ``CLAUDE_MODEL`` is set; receives the override when ``/model switch``
+   was used.
+4. ``_sdk_model`` is populated post-``ResultMessage`` and is
+   *display-only* — it does NOT feed back into the SDK options on
+   subsequent ``start()`` calls.
+5. ``/model current`` distinguishes the 4 tier cases per PRD §Design.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from claude_agent_sdk import ResultMessage
+
+from clauded.claude_bridge import ClaudeBridge
+from clauded.config import Config
+from clauded.session_config import SessionConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _config(claude_model: str | None = None) -> Config:
+    """Build a Config with the given claude_model tier value.
+
+    ``None`` simulates ``CLAUDE_MODEL`` unset; a string simulates
+    ``CLAUDE_MODEL=<string>``.
+    """
+    return Config(
+        discord_bot_token="tok",
+        claude_model=claude_model,
+        claude_permission_mode="default",
+        projects_root="/tmp",
+    )
+
+
+class _FakeClient:
+    """Stand-in for ``ClaudeSDKClient`` that records the options it
+    received and is otherwise a no-op."""
+
+    captured_options: list[Any] = []
+
+    def __init__(self, options: Any = None) -> None:
+        type(self).captured_options.append(options)
+
+    async def connect(self, prompt: Any = None) -> None:
+        pass
+
+    async def disconnect(self) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_capture() -> None:
+    _FakeClient.captured_options = []
+
+
+# ---------------------------------------------------------------------------
+# Config.claude_model behavior (S1)
+# ---------------------------------------------------------------------------
+
+
+def test_config_claude_model_none_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``CLAUDE_MODEL`` unset → ``claude_model is None``."""
+    from clauded.config import load_config
+
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok-abc")
+    monkeypatch.delenv("CLAUDE_MODEL", raising=False)
+    monkeypatch.setattr("clauded.config.load_dotenv", lambda *a, **kw: None)
+    cfg = load_config()
+    assert cfg.claude_model is None
+
+
+def test_config_claude_model_uses_env_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``CLAUDE_MODEL=opus`` → ``claude_model == 'opus'``."""
+    from clauded.config import load_config
+
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok-abc")
+    monkeypatch.setenv("CLAUDE_MODEL", "opus")
+    monkeypatch.setattr("clauded.config.load_dotenv", lambda *a, **kw: None)
+    cfg = load_config()
+    assert cfg.claude_model == "opus"
+
+
+# ---------------------------------------------------------------------------
+# ClaudeBridge.model property (S2)
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_model_property_is_none_when_all_tiers_none() -> None:
+    """All-tier-None case: override unset, env unset, no ResultMessage."""
+    cfg = _config(claude_model=None)
+    bridge = ClaudeBridge(project_path="/tmp/p", config=cfg)
+    assert bridge.model is None
+
+
+def test_bridge_model_property_returns_override() -> None:
+    """``/model switch`` wins over env and sdk."""
+    cfg = _config(claude_model="opus")
+    sc = SessionConfig(model_override="haiku")
+    bridge = ClaudeBridge(project_path="/tmp/p", config=cfg, session_config=sc)
+    bridge._sdk_model = "claude-sonnet-4-5"
+    assert bridge.model == "haiku"
+
+
+def test_bridge_model_property_returns_sdk_when_only_observed() -> None:
+    """No override, no env → ``_sdk_model`` is what we show."""
+    cfg = _config(claude_model=None)
+    bridge = ClaudeBridge(project_path="/tmp/p", config=cfg)
+    bridge._sdk_model = "claude-sonnet-4-5"
+    assert bridge.model == "claude-sonnet-4-5"
+
+
+def test_bridge_model_property_returns_env_when_no_override_no_sdk() -> None:
+    """env > config tier when there's no override and no SDK observation."""
+    cfg = _config(claude_model="opus")
+    bridge = ClaudeBridge(project_path="/tmp/p", config=cfg)
+    assert bridge.model == "opus"
+
+
+# ---------------------------------------------------------------------------
+# ClaudeAgentOptions construction (S2 — integration)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_options_model_is_none_when_all_tiers_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All tiers None → ``ClaudeAgentOptions(model=None)`` (SDK treats as
+    omitted, falling back to ~/.claude/settings.json)."""
+    monkeypatch.setattr("clauded.claude_bridge.ClaudeSDKClient", _FakeClient)
+    bridge = ClaudeBridge(project_path="/tmp/p", config=_config(claude_model=None))
+    await bridge.start()
+    assert _FakeClient.captured_options, "ClaudeAgentOptions was not constructed"
+    opts = _FakeClient.captured_options[-1]
+    assert opts.model is None, f"expected model=None, got {opts.model!r}"
+
+
+@pytest.mark.asyncio
+async def test_options_model_uses_env_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``CLAUDE_MODEL=opus`` → ``ClaudeAgentOptions(model='opus')``."""
+    monkeypatch.setattr("clauded.claude_bridge.ClaudeSDKClient", _FakeClient)
+    bridge = ClaudeBridge(project_path="/tmp/p", config=_config(claude_model="opus"))
+    await bridge.start()
+    opts = _FakeClient.captured_options[-1]
+    assert opts.model == "opus"
+
+
+@pytest.mark.asyncio
+async def test_options_model_uses_override_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``/model switch haiku`` with env unset → ``model='haiku'``."""
+    monkeypatch.setattr("clauded.claude_bridge.ClaudeSDKClient", _FakeClient)
+    sc = SessionConfig(model_override="haiku")
+    bridge = ClaudeBridge(
+        project_path="/tmp/p", config=_config(claude_model=None), session_config=sc
+    )
+    await bridge.start()
+    opts = _FakeClient.captured_options[-1]
+    assert opts.model == "haiku"
+
+
+@pytest.mark.asyncio
+async def test_options_override_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``/model switch haiku`` + ``CLAUDE_MODEL=opus`` → override wins."""
+    monkeypatch.setattr("clauded.claude_bridge.ClaudeSDKClient", _FakeClient)
+    sc = SessionConfig(model_override="haiku")
+    bridge = ClaudeBridge(
+        project_path="/tmp/p", config=_config(claude_model="opus"), session_config=sc
+    )
+    await bridge.start()
+    opts = _FakeClient.captured_options[-1]
+    assert opts.model == "haiku"
+
+
+@pytest.mark.asyncio
+async def test_options_does_not_use_sdk_model_as_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_sdk_model`` is display-only; it must NOT feed back into the SDK
+    kwargs. PRD §Design: using it would lock the session to whatever the
+    first turn resolved to, even if ~/.claude/settings.json changes."""
+    monkeypatch.setattr("clauded.claude_bridge.ClaudeSDKClient", _FakeClient)
+    bridge = ClaudeBridge(project_path="/tmp/p", config=_config(claude_model=None))
+    bridge._sdk_model = "claude-sonnet-4-5"  # simulate post-first-turn state
+    await bridge.start()
+    opts = _FakeClient.captured_options[-1]
+    assert opts.model is None, (
+        f"_sdk_model leaked into ClaudeAgentOptions.model={opts.model!r}; "
+        "it must be display-only per PRD §Design"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ResultMessage → _sdk_model propagation (regression-pinning)
+# ---------------------------------------------------------------------------
+
+
+def _make_async_client(items: list[Any]) -> AsyncMock:
+    """Build an AsyncMock client that yields ``items`` from
+    ``receive_response``. Mirrors the pattern in test_claude_bridge.py."""
+
+    async def _iter() -> Any:
+        for x in items:
+            yield x
+
+    client = AsyncMock()
+    client.connect = AsyncMock()
+    client.disconnect = AsyncMock()
+    client.query = AsyncMock()
+    client.receive_response = _iter
+    return client
+
+
+@pytest.mark.asyncio
+async def test_result_message_populates_sdk_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After a ResultMessage carrying a ``model`` arrives, ``_sdk_model``
+    is set and is visible via the ``bridge.model`` property."""
+    rm = ResultMessage(
+        subtype="success",
+        duration_ms=10,
+        duration_api_ms=5,
+        is_error=False,
+        num_turns=1,
+        session_id="sess-x",
+        total_cost_usd=0.01,
+    )
+    rm.model = "claude-sonnet-4-5"  # type: ignore[attr-defined]
+
+    client = _make_async_client([rm])
+    monkeypatch.setattr(
+        "clauded.claude_bridge.ClaudeSDKClient", lambda options=None: client
+    )
+
+    bridge = ClaudeBridge(project_path="/tmp/p", config=_config(claude_model=None))
+    await bridge.start()
+    assert bridge._sdk_model is None
+    assert bridge.model is None  # all tiers None pre-first-turn
+
+    async for _ in bridge.send_message("hi"):
+        pass
+
+    assert bridge._sdk_model == "claude-sonnet-4-5"
+    assert bridge.model == "claude-sonnet-4-5"
+
+
+# ---------------------------------------------------------------------------
+# /model current — 4-case display (S3)
+# ---------------------------------------------------------------------------
+
+
+def _bridge_for_case(
+    *,
+    override: str | None,
+    env_model: str | None,
+    sdk_model: str | None,
+) -> Any:
+    """Build a MagicMock bridge with the requested tier values."""
+    bridge = MagicMock()
+    bridge._model_override = override
+    bridge._sdk_model = sdk_model
+    cfg = MagicMock()
+    cfg.claude_model = env_model
+    bridge._config = cfg
+    # bridge.model just collapses the tiers for callers that don't care
+    bridge.model = override or sdk_model or env_model
+    return bridge
+
+
+@pytest.mark.asyncio
+async def test_model_current_case1_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Case 1: ``/model switch haiku`` → name + KNOWN_MODELS metadata."""
+    from clauded.cogs.model import model_current
+    from clauded.bot import ClaudedBot
+
+    bot_spec = MagicMock(spec=ClaudedBot)
+    bot_spec.session_manager = MagicMock()
+    bridge = _bridge_for_case(override="haiku", env_model=None, sdk_model=None)
+    bot_spec.session_manager.get_session = MagicMock(return_value=bridge)
+
+    interaction = MagicMock()
+    interaction.client = bot_spec
+    interaction.channel.id = 1
+    interaction.response.send_message = AsyncMock()
+    await model_current.callback(interaction)
+
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    assert "haiku" in embed.description
+    assert "fast" in embed.description  # haiku's tier
+    assert "200k" in embed.description  # haiku's context
+    # No env-/CLI-default suffix on override case
+    assert "CLAUDE_MODEL env" not in embed.description
+    assert "CLI default" not in embed.description
+
+
+@pytest.mark.asyncio
+async def test_model_current_case2_env_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Case 2: ``CLAUDE_MODEL=opus`` → ``opus (CLAUDE_MODEL env)``."""
+    from clauded.cogs.model import model_current
+    from clauded.bot import ClaudedBot
+
+    bot_spec = MagicMock(spec=ClaudedBot)
+    bot_spec.session_manager = MagicMock()
+    bridge = _bridge_for_case(override=None, env_model="opus", sdk_model=None)
+    bot_spec.session_manager.get_session = MagicMock(return_value=bridge)
+
+    interaction = MagicMock()
+    interaction.client = bot_spec
+    interaction.channel.id = 1
+    interaction.response.send_message = AsyncMock()
+    await model_current.callback(interaction)
+
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    assert "opus" in embed.description
+    assert "CLAUDE_MODEL env" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_model_current_case3_sdk_observed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Case 3: post-first-turn, no override, no env →
+    ``<value> (CLI default)``."""
+    from clauded.cogs.model import model_current
+    from clauded.bot import ClaudedBot
+
+    bot_spec = MagicMock(spec=ClaudedBot)
+    bot_spec.session_manager = MagicMock()
+    bridge = _bridge_for_case(
+        override=None, env_model=None, sdk_model="claude-sonnet-4-5"
+    )
+    bot_spec.session_manager.get_session = MagicMock(return_value=bridge)
+
+    interaction = MagicMock()
+    interaction.client = bot_spec
+    interaction.channel.id = 1
+    interaction.response.send_message = AsyncMock()
+    await model_current.callback(interaction)
+
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    assert "claude-sonnet-4-5" in embed.description
+    assert "CLI default" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_model_current_case4_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Case 4: no override, no env, pre-first-turn → ``(unset — ...)``
+    placeholder per PRD §Design."""
+    from clauded.cogs.model import model_current
+    from clauded.bot import ClaudedBot
+
+    bot_spec = MagicMock(spec=ClaudedBot)
+    bot_spec.session_manager = MagicMock()
+    bridge = _bridge_for_case(override=None, env_model=None, sdk_model=None)
+    bot_spec.session_manager.get_session = MagicMock(return_value=bridge)
+
+    interaction = MagicMock()
+    interaction.client = bot_spec
+    interaction.channel.id = 1
+    interaction.response.send_message = AsyncMock()
+    await model_current.callback(interaction)
+
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    assert "unset" in embed.description.lower()
+    assert "CLI default" in embed.description
+
+
+# ---------------------------------------------------------------------------
+# _model_source_for_bridge helper (covers tier-detection logic directly)
+# ---------------------------------------------------------------------------
+
+
+def test_model_source_override_wins() -> None:
+    from clauded.cogs.model import _model_source_for_bridge
+
+    bridge = _bridge_for_case(override="haiku", env_model="opus", sdk_model="sonnet")
+    assert _model_source_for_bridge(bridge) == ("override", "haiku")
+
+
+def test_model_source_env_when_no_override() -> None:
+    from clauded.cogs.model import _model_source_for_bridge
+
+    bridge = _bridge_for_case(override=None, env_model="opus", sdk_model="sonnet")
+    assert _model_source_for_bridge(bridge) == ("env", "opus")
+
+
+def test_model_source_sdk_when_no_override_no_env() -> None:
+    from clauded.cogs.model import _model_source_for_bridge
+
+    bridge = _bridge_for_case(override=None, env_model=None, sdk_model="sonnet")
+    assert _model_source_for_bridge(bridge) == ("sdk", "sonnet")
+
+
+def test_model_source_unset_when_all_none() -> None:
+    from clauded.cogs.model import _model_source_for_bridge
+
+    bridge = _bridge_for_case(override=None, env_model=None, sdk_model=None)
+    assert _model_source_for_bridge(bridge) == ("unset", None)


### PR DESCRIPTION
Closes #198 (P0).

## Approved PRD
`docs/prd/v1.18-fix-model-default.md` — DDD + user-approved before implementation.

## Summary
claudeD no longer silently forces `model="sonnet"` when user hasn't explicitly switched. SDK call omits `model=` kwarg in that case → SDK reads `~/.claude/settings.json` default (mirrors terminal `claude`).

Tier order (per PRD §Design):
1. Admin env `CLAUDE_MODEL` set → passed
2. `/model switch X` → passed
3. Neither → omitted → SDK reads settings.json

`_sdk_model` (from `ResultMessage.model`) is display-only — never fed back into the SDK call.

## Files
- `src/clauded/config.py` — `claude_model: Optional[str]`
- `src/clauded/claude_bridge.py` — conditional `model=` in `ClaudeAgentOptions`
- `src/clauded/cogs/model.py` — `/model current` 4-case display + `_model_source_for_bridge` helper
- `src/clauded/cogs/session.py` — display-only None-safe handling (only audit-touched file)
- `.env.example` — comment out `CLAUDE_MODEL=sonnet`, add explanation
- `tests/test_config.py` — env-unset → None
- `tests/test_model_cmd.py` — mocks updated to set tier fields, not collapsed property
- `tests/test_model_default.py` (new) — 21 tests covering 4-tier + integration + smoke

## pytest
**669 / 0** (was 648/0, +21).

## Status
🚧 Draft — pending 7-perspective review.
