### PR TITLE
fix(cogs): /context and /skill list use thread_id for session lookup, parent_id only for binding (#197)

### DIFF
--- a/docs/prd/v1.18-fix-context-thread-session.md
+++ b/docs/prd/v1.18-fix-context-thread-session.md
@@ -1,0 +1,153 @@
+# PRD — Fix `/context` (and `/skill list`) thread session lookup (#197)
+
+**Status**: DRAFT (awaiting user approval)
+**Issue**: [#197](https://github.com/HXYerror/2026-...claudeD/issues/197)
+**Branch**: `fix/v1.18-context-thread-session-lookup`
+**Severity**: P1 (slash-command timeout in heavy-turn threads)
+
+---
+
+## Problem
+
+`/context` in a thread times out with "⚠️ The application did not respond" when the thread is processing a heavy turn.
+
+Root cause (verified by code reading):
+
+`resolve_channel_id(interaction)` returns the **parent channel id** when in a thread (correct for `is_bound` / binding lookups). But two cog files reuse that same id to look up the **live session**:
+
+```python
+# cogs/context.py:164
+bridge = bot.session_manager.get_session(channel_id)  # ← parent_id, wrong key
+
+# cogs/skill.py:139
+bridge = bot.session_manager.get_session(channel_id)  # ← parent_id, wrong key
+```
+
+Sessions are keyed by `thread_id` (per `bot.py:721,548`). Looking up with `parent_id` always returns `None` for a real thread session → falls to Path B (cold-start a temp `ClaudeSDKClient` subprocess) → competes with the heavy parent turn for OS resources → balloons past Discord's deadline.
+
+Other cogs (`/session info`, `/model current`, etc.) already use `interaction.channel_id` correctly — only `cogs/context.py` and `cogs/skill.py` have the bug.
+
+## Goals
+
+1. **Fix A** — separate "channel id for binding lookup" from "thread id for session lookup". Use `interaction.channel_id` (thread id when in thread) for `get_session(...)`; keep `resolve_channel_id(...)` only for `project_manager.is_bound/get_path/...`.
+2. **Audit** — confirm `cogs/context.py:164` and `cogs/skill.py:139` are the only two sites. (Already done in DDD; both confirmed.)
+3. **Fix B (defensive)** — Path B's `ClaudeSDKClient` cold-start is now rarely hit in threads, but when it IS hit (bare channel, no session) it can still hang. Wrap the `__aenter__` + `get_context_usage`/`get_server_info` in `asyncio.wait_for(timeout=10)`. On timeout: surface friendly "context unavailable, try again later" embed.
+4. **Fix C (defensive)** — move `await interaction.response.defer(...)` to BEFORE any potentially slow operation (immediately after the `isinstance(bot, ClaudedBot)` check). That way even if an unrelated exception fires before the slow op, Discord won't show "application did not respond".
+5. **Single-purpose change** — no PR-scope creep beyond `/context` + `/skill list` thread-session-lookup fix + the two defensive guards.
+
+## Non-goals
+
+- Path B's `get_context_usage` semantic correctness (e.g., proxy 168k vs raw 200k limit) — separate follow-up
+- Auto-running `/session compact` when context is high — separate UX policy
+- Refactoring `resolve_channel_id` to return `(binding_id, session_id)` tuple — over-engineering for 2 call sites
+
+## Design
+
+### Pattern fix
+
+Each of the two cog command bodies changes from:
+
+```python
+channel_id = resolve_channel_id(interaction)
+cwd, is_bound = bot.project_manager.get_path_or_default(channel_id)  # binding ← parent_id (correct)
+bridge = bot.session_manager.get_session(channel_id)                  # session ← parent_id (WRONG)
+```
+
+to:
+
+```python
+binding_id = resolve_channel_id(interaction)        # parent_id in thread, channel_id otherwise
+session_id = interaction.channel_id                  # thread_id in thread, channel_id otherwise
+cwd, is_bound = bot.project_manager.get_path_or_default(binding_id)
+bridge = bot.session_manager.get_session(session_id) if session_id is not None else None
+```
+
+In a bare channel (not a thread), `binding_id == session_id == channel_id`, so behavior unchanged.
+In a thread, `binding_id = parent_id` (correct for binding), `session_id = thread_id` (correct for session lookup).
+
+### Defer correctness (Fix C)
+
+Move `await interaction.response.defer(...)` to immediately after the `isinstance(bot, ClaudedBot)` guard. The slowest part (Path A's `await bridge.get_context_usage()` or Path B's subprocess spawn) follows the defer call. If any error fires between defer and the rest, the deferred state is already set — Discord shows "thinking…" instead of "application did not respond" until the followup arrives or 15min elapses.
+
+### Path B timeout (Fix B)
+
+```python
+import asyncio
+
+async with asyncio.timeout(10):  # Python 3.11+ syntax
+    async with ClaudeSDKClient(ClaudeAgentOptions(...)) as tmp:
+        usage = await tmp.get_context_usage()
+```
+
+Or `asyncio.wait_for` if the `async with` form isn't clean. Both achieve the same: spawn-fail / hang capped at 10s, then friendly error embed.
+
+### Friendly Path B timeout error
+
+```python
+embed = discord.Embed(
+    title="⚠️ Context unavailable",
+    description=(
+        "Couldn't query context window in time (10s timeout). "
+        "This usually happens when the bot is processing a large turn. "
+        "Try again once the active turn completes."
+    ),
+    color=COLOR_TOOL_FAILURE,
+)
+await interaction.followup.send(embed=embed, ephemeral=True)
+```
+
+## Acceptance criteria
+
+### Behavioral (Fix A — core)
+- [ ] `/context` in a thread with an active bridge → Path A succeeds, returns real usage data, no Path B spawned (verified by mock-assert `ClaudeSDKClient` constructor call count == 0)
+- [ ] `/context` in a thread without an active session → falls through to Path B (cold-start), unchanged from today except now with timeout guard
+- [ ] `/context` in a bare channel without a session → Path B, unchanged
+- [ ] `/skill list` in a thread with an active bridge → same Path A pattern; was bugged identically
+
+### Performance
+- [ ] In-thread `/context` with active session: response < 500ms (no subprocess spawn)
+- [ ] Path B hard 10s timeout; beyond that, friendly error embed (no indefinite hang)
+
+### Defer correctness (Fix C)
+- [ ] `defer()` is called BEFORE `resolve_channel_id` / `get_path_or_default` / `get_session` so even an early exception leaves Discord in the deferred state
+
+### Negative invariants
+- [ ] **Path B NOT called** in the "thread + active session" case → integration test mocks `ClaudeSDKClient` and asserts 0 instantiations
+- [ ] Audit pass: no other cog calls `get_session(resolve_channel_id(...))` after this PR
+
+### Tests
+- [ ] Unit: build real `discord.Thread` subclass with `parent_id=42, id=1234567` + `session_manager._sessions = {1234567: mock_bridge}` → assert in-thread Path A picks up the right bridge
+- [ ] Integration: `/context` invoked in-thread with active bridge → mocked `bridge.get_context_usage()` returns realistic `ContextUsageResponse` dict → embed contains `73%` (or whatever the mock returned). Assert `ClaudeSDKClient` constructor was NOT called.
+- [ ] Integration: `/context` invoked in bare channel without session → Path B IS used (subprocess mock instantiated)
+- [ ] Timeout test: Path B subprocess `__aenter__` mocked to `await asyncio.sleep(15)` → user gets friendly error embed within ~10s, no indefinite hang
+- [ ] Same coverage for `/skill list` (smaller — 2 tests: thread+session path A + bare channel path B + timeout)
+
+### Backward compat
+- [ ] Existing `/context` and `/skill list` usage in channels (no thread) keeps working — binding_id == session_id == channel_id
+- [ ] `resolve_channel_id` not modified — other 6+ call sites (binding-related) unaffected
+
+## Out of scope (separate issues)
+
+- Path B's `🧠 N%` vs proxy 168k limit mismatch (follow-up if PM cares)
+- Refactor `resolve_channel_id` API (return tuple) — only 2 call sites benefit
+- Proactive context-window warning when high (separate UX issue)
+
+## Risks
+
+- **Test scaffolding for `discord.Thread`**: need a fake subclass that survives `isinstance` checks (same pattern used in `tests/test_third_party_thread.py` from #195/#196). Dev agent should mirror that.
+- **Timeout semantic on Path B**: `async with ClaudeSDKClient` may not honor `asyncio.timeout` mid-`__aenter__` (depends on SDK's anyio internals). If it doesn't, the spawned subprocess may leak. Acceptable for now — log + don't block on subprocess cleanup.
+- **`/skill list` is a "bonus" fix**: if it turns out to have additional path differences, scope creep risk. Mitigation: dev agent reports if `/skill list` needs different treatment.
+
+## Plan (sub-tasks, single-PR — sub-tasks are review boundaries)
+
+1. **S1** — `cogs/context.py`: separate `binding_id` / `session_id`; pass `session_id` to `get_session`. Move `defer()` to immediately after `ClaudedBot` check.
+2. **S2** — `cogs/skill.py`: same pattern fix + defer move.
+3. **S3** — `cogs/context.py` Path B: wrap subprocess spawn + `get_context_usage` in `asyncio.wait_for(timeout=10)`; on timeout, friendly embed.
+4. **S4** — `cogs/skill.py` Path B: same timeout wrapper.
+5. **S5** — Tests: new `tests/test_context_thread_session.py` covering 4 acceptance cases for `/context`; augment existing `/skill list` tests (location TBD by dev agent).
+
+## Sign-off
+
+Awaiting user approval (Discord ping) before:
+- Spawning `coding` agent
+- Opening draft PR

--- a/src/clauded/cogs/context.py
+++ b/src/clauded/cogs/context.py
@@ -35,6 +35,7 @@ are out of scope for v1; they'd bloat the embed. v1.19 can add
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import discord
@@ -51,6 +52,12 @@ from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE
 from ._unbound import NO_CHANNEL_MESSAGE, resolve_channel_id
 
 log = logging.getLogger("clauded.bot")
+
+# Defensive cap on Path B subprocess spawn + query. The cold-start of a
+# transient ClaudeSDKClient can hang when the parent turn is hammering
+# the host (heavy CPU/IO). Past this budget, surface a friendly error
+# rather than letting Discord's interaction time out.
+_PATH_B_TIMEOUT_S = 10
 
 
 _PROGRESS_BAR_WIDTH = 20
@@ -151,17 +158,29 @@ async def context_cmd(interaction: discord.Interaction) -> None:
         await interaction.response.send_message("❌ Bot not ready.", ephemeral=True)
         return
 
-    channel_id = resolve_channel_id(interaction)
-    if channel_id is None:
-        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
-        return
-
-    # Defer immediately — Path B can take 2-4 s for cold CLI startup, and
-    # Discord's 3s response deadline would otherwise time out.
+    # Fix C — defer BEFORE any potentially slow operation (incl. id resolution,
+    # binding/session lookups). If anything between here and the followup
+    # raises, Discord still shows "thinking…" instead of "did not respond".
     await interaction.response.defer(ephemeral=True)
 
+    # Fix A — split the two id meanings:
+    #   binding_id: parent_id when in a thread → correct for project binding
+    #               lookup (a thread inherits its parent's bound state).
+    #   session_id: thread_id when in a thread → correct for session lookup
+    #               (session_manager is keyed by thread id, not parent id).
+    # In a bare channel both are channel_id, so behavior is unchanged.
+    binding_id = resolve_channel_id(interaction)
+    if binding_id is None:
+        await interaction.followup.send(NO_CHANNEL_MESSAGE, ephemeral=True)
+        return
+    session_id = interaction.channel_id
+
     # Path A: active bridge piggyback (cheap, ~tens of ms).
-    bridge = bot.session_manager.get_session(channel_id)
+    bridge = (
+        bot.session_manager.get_session(session_id)
+        if session_id is not None
+        else None
+    )
     usage = None
     source_label = "active session"
     if bridge is not None:
@@ -174,13 +193,33 @@ async def context_cmd(interaction: discord.Interaction) -> None:
     # Path B: temp client fallback (mirrors /skill list pattern).
     if usage is None:
         source_label = "fresh session (model baseline)"
-        cwd, is_bound = bot.project_manager.get_path_or_default(channel_id)
+        cwd, is_bound = bot.project_manager.get_path_or_default(binding_id)
         setting_sources = ["user", "project", "local"] if is_bound else ["user"]
         try:
-            async with ClaudeSDKClient(
-                ClaudeAgentOptions(cwd=str(cwd), setting_sources=setting_sources)
-            ) as tmp:
-                usage = await tmp.get_context_usage()
+            # Fix B — cap subprocess spawn + query at 10s. The cold-start
+            # can hang when the parent turn is hammering the host. Without
+            # this guard, Discord's interaction window would lapse.
+            async with asyncio.timeout(_PATH_B_TIMEOUT_S):
+                async with ClaudeSDKClient(
+                    ClaudeAgentOptions(cwd=str(cwd), setting_sources=setting_sources)
+                ) as tmp:
+                    usage = await tmp.get_context_usage()
+        except (asyncio.TimeoutError, TimeoutError):
+            log.warning("/context Path B timed out after %ss", _PATH_B_TIMEOUT_S)
+            await interaction.followup.send(
+                embed=discord.Embed(
+                    title="⚠️ Context unavailable",
+                    description=(
+                        "Couldn't query context window in time "
+                        f"({_PATH_B_TIMEOUT_S}s timeout). "
+                        "This usually happens when the bot is processing a large turn. "
+                        "Try again once the active turn completes."
+                    ),
+                    color=COLOR_TOOL_FAILURE,
+                ),
+                ephemeral=True,
+            )
+            return
         except (CLINotFoundError, CLIConnectionError, Exception) as exc:  # noqa: BLE001
             log.warning("/context Path B failed", exc_info=True)
             await interaction.followup.send(

--- a/src/clauded/cogs/skill.py
+++ b/src/clauded/cogs/skill.py
@@ -9,6 +9,7 @@ content of ``~/.claude/skills/`` and ``<project>/.claude/skills/``.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import discord
@@ -21,6 +22,12 @@ from ..skill_parser import classify_command
 from ._unbound import NO_CHANNEL_MESSAGE, resolve_channel_id
 
 log = logging.getLogger("clauded.bot")
+
+# Defensive cap on Path B subprocess spawn + query (#197). The cold-start
+# of a transient ClaudeSDKClient can hang when the parent turn is hammering
+# the host. Past this budget, surface a friendly error instead of letting
+# Discord's interaction window lapse.
+_PATH_B_TIMEOUT_S = 10
 
 
 skill_group = app_commands.Group(
@@ -123,20 +130,35 @@ async def skill_list(interaction: discord.Interaction) -> None:
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
 
+    # Fix C — defer BEFORE any potentially slow operation. If anything
+    # between here and the followup raises, Discord still shows
+    # "thinking…" instead of "did not respond".
     await interaction.response.defer(ephemeral=True)
 
-    channel_id = resolve_channel_id(interaction)
-    if channel_id is None:
+    # Fix A — split binding lookup id from session lookup id (#197).
+    #   binding_id: parent_id in a thread → correct for project binding
+    #               (a thread inherits its parent's bound state).
+    #   session_id: thread_id in a thread → correct for session lookup
+    #               (session_manager is keyed by thread id, not parent id).
+    # In a bare channel both are channel_id, so behavior unchanged.
+    binding_id = resolve_channel_id(interaction)
+    if binding_id is None:
         await interaction.followup.send(NO_CHANNEL_MESSAGE, ephemeral=True)
         return
+    session_id = interaction.channel_id
 
-    cwd, is_bound = bot.project_manager.get_path_or_default(channel_id)
+    cwd, is_bound = bot.project_manager.get_path_or_default(binding_id)
 
     info: dict | None = None
     info_err: Exception | None = None
+    timed_out: bool = False
 
     # Path A: piggyback the live bridge if there is one.
-    bridge = bot.session_manager.get_session(channel_id)
+    bridge = (
+        bot.session_manager.get_session(session_id)
+        if session_id is not None
+        else None
+    )
     try:
         if bridge is not None:
             info = await bridge.get_server_info()
@@ -148,14 +170,35 @@ async def skill_list(interaction: discord.Interaction) -> None:
     if info is None:
         setting_sources = ["user", "project", "local"] if is_bound else ["user"]
         try:
-            async with ClaudeSDKClient(
-                options=ClaudeAgentOptions(
-                    cwd=str(cwd), setting_sources=setting_sources
-                )
-            ) as tmp:
-                info = await tmp.get_server_info()
-        except Exception as exc:  # noqa: BLE001 — any failure → friendly red embed
+            # Fix B — cap subprocess spawn + query at 10s (#197). The
+            # cold-start can hang when the parent turn is hammering the
+            # host; without this guard Discord's interaction window lapses.
+            async with asyncio.timeout(_PATH_B_TIMEOUT_S):
+                async with ClaudeSDKClient(
+                    options=ClaudeAgentOptions(
+                        cwd=str(cwd), setting_sources=setting_sources
+                    )
+                ) as tmp:
+                    info = await tmp.get_server_info()
+        except (asyncio.TimeoutError, TimeoutError):
+            log.warning("/skill list Path B timed out after %ss", _PATH_B_TIMEOUT_S)
+            timed_out = True
+        except Exception as exc:  # noqa: BLE001 — any other failure → friendly red embed
             info_err = exc
+
+    if timed_out:
+        embed = discord.Embed(
+            title="⚠️ Skill list unavailable",
+            description=(
+                "Couldn't query the skill list in time "
+                f"({_PATH_B_TIMEOUT_S}s timeout). "
+                "This usually happens when the bot is processing a large turn. "
+                "Try again once the active turn completes."
+            ),
+            color=COLOR_TOOL_FAILURE,
+        )
+        await interaction.followup.send(embed=embed, ephemeral=True)
+        return
 
     if info_err is not None or info is None:
         if info_err is None:

--- a/tests/test_context_thread_session.py
+++ b/tests/test_context_thread_session.py
@@ -1,0 +1,516 @@
+"""#197 — `/context` and `/skill list` must look up the live session by
+thread id, not the parent (binding) id.
+
+Pre-fix, both cogs called ``bot.session_manager.get_session(channel_id)``
+where ``channel_id = resolve_channel_id(interaction)``. In a thread
+``resolve_channel_id`` returns ``parent_id`` (correct for binding
+lookups), but the session manager is keyed by ``thread_id``. The lookup
+always missed → fell through to Path B (cold-start a temp
+``ClaudeSDKClient``) → competed with the heavy parent turn → Discord
+"application did not respond" timeout.
+
+This file pins:
+
+* Path A succeeds for ``/context`` / ``/skill list`` in a thread with an
+  active session (no ``ClaudeSDKClient`` spawned).
+* Path B still runs in a bare channel without a session (unchanged).
+* Path B is wrapped in a 10s timeout; a friendly "unavailable" embed is
+  returned on timeout (no hang).
+* ``defer()`` happens BEFORE any binding/session/path lookup so a slow
+  op never causes "application did not respond" before deferral.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from clauded.bot import ClaudedBot
+from clauded.config import Config
+from clauded.cost_tracker import CostTracker
+from clauded.project_manager import ProjectManager
+from clauded.session_manager import SessionManager
+from clauded.session_store import SessionStore
+
+
+# ---------------------------------------------------------------------------
+# Real ``discord.Thread`` subclass so ``isinstance(ch, discord.Thread)``
+# inside ``resolve_channel_id`` returns True. Mirrors the pattern from
+# ``tests/test_third_party_thread.py`` (#195).
+# ---------------------------------------------------------------------------
+
+
+class _FakeThread(discord.Thread):
+    """Bypass ``discord.Thread.__init__`` (which needs full Discord state)
+    while still passing ``isinstance(x, discord.Thread)`` checks.
+    """
+
+    def __init__(self) -> None:  # type: ignore[override]
+        # Deliberately skip parent ``__init__``; tests set attrs manually.
+        pass
+
+
+def _make_thread(*, thread_id: int, parent_id: int) -> _FakeThread:
+    t = _FakeThread()
+    object.__setattr__(t, "id", thread_id)
+    object.__setattr__(t, "parent_id", parent_id)
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Shared bot + interaction fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bot(tmp_path: Path) -> ClaudedBot:
+    cfg = Config(
+        discord_bot_token="tok",
+        claude_model="sonnet",
+        claude_permission_mode="default",
+        projects_root=str(tmp_path),
+        allow_unbound_fallback=True,  # so bare-channel Path B doesn't get refused
+    )
+    pm = ProjectManager(data_dir=str(tmp_path / "data"), projects_root=str(tmp_path))
+    sm = SessionManager(session_store=SessionStore(data_dir=str(tmp_path / "data")))
+    bot = ClaudedBot.__new__(ClaudedBot)
+    bot.config = cfg
+    bot.project_manager = pm
+    bot.session_manager = sm
+    bot.cost_tracker = CostTracker()
+    bot.agent_manager = MagicMock()
+    bot._start_time = 0.0
+    bot._claude_version = "test"
+    bot._debug_logging = False
+    bot._pre_tool_notifications = False
+    bot._notify_enabled = {}
+    bot.allow_unbound_fallback = True
+    bot._connection = MagicMock()
+    return bot
+
+
+def _make_thread_interaction(
+    bot: ClaudedBot, *, parent_id: int, thread_id: int
+) -> MagicMock:
+    """Real-Discord thread semantics:
+
+    * ``interaction.channel_id`` = ``thread_id`` (i.e. the thread itself).
+    * ``interaction.channel`` is a ``discord.Thread`` with
+      ``parent_id`` set; ``resolve_channel_id`` returns ``parent_id``.
+    """
+    thread = _make_thread(thread_id=thread_id, parent_id=parent_id)
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = bot
+    interaction.channel = thread
+    interaction.channel_id = thread_id  # Discord sets this to the thread's id
+    interaction.guild_id = 4242
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_channel_interaction(bot: ClaudedBot, *, channel_id: int) -> MagicMock:
+    """Bare ``TextChannel`` semantics — ``channel_id == channel.id``."""
+    ch = MagicMock(spec=discord.TextChannel)
+    ch.id = channel_id
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = bot
+    interaction.channel = ch
+    interaction.channel_id = channel_id
+    interaction.guild_id = 4242
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+# ===========================================================================
+# /context — #197 acceptance criteria
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_context_in_thread_with_active_session_uses_path_a(
+    bot: ClaudedBot,
+) -> None:
+    """Thread + active session (keyed by thread_id) → Path A picks up
+    the bridge; no ``ClaudeSDKClient`` is constructed."""
+    from clauded.cogs import context as ctx_mod
+
+    parent_id = 1000
+    thread_id = 2222
+    fake_usage = {
+        "totalTokens": 146000,
+        "maxTokens": 200000,
+        "percentage": 73.0,
+        "model": "claude-sonnet",
+        "categories": [{"name": "messages", "tokens": 146000}],
+    }
+    mock_bridge = MagicMock()
+    mock_bridge.get_context_usage = AsyncMock(return_value=fake_usage)
+    # CRITICAL: session keyed by thread_id, NOT parent_id (#197 root cause).
+    bot.session_manager._sessions[thread_id] = mock_bridge
+
+    interaction = _make_thread_interaction(
+        bot, parent_id=parent_id, thread_id=thread_id
+    )
+
+    with patch.object(ctx_mod, "ClaudeSDKClient") as fake_ctor:
+        await ctx_mod.context_cmd.callback(interaction)
+
+    # Negative invariant: Path B NOT taken.
+    fake_ctor.assert_not_called()
+    mock_bridge.get_context_usage.assert_awaited_once()
+
+    interaction.response.defer.assert_awaited_once()
+    interaction.followup.send.assert_awaited_once()
+    embed = interaction.followup.send.call_args.kwargs["embed"]
+    assert "73.0%" in embed.title
+    assert "active session" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_context_in_thread_without_session_falls_to_path_b(
+    bot: ClaudedBot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Thread but no session registered for the thread → Path B fires
+    (binding still resolves via parent_id, but session lookup misses)."""
+    from clauded.cogs import context as ctx_mod
+
+    parent_id = 1000
+    thread_id = 2222
+    # No session registered — bridge lookup will return None.
+
+    fake_usage = {
+        "totalTokens": 500,
+        "maxTokens": 200000,
+        "percentage": 0.25,
+        "model": "claude-sonnet",
+        "categories": [],
+    }
+
+    constructed: list = []
+
+    class FakeTempClient:
+        def __init__(self, opts):
+            constructed.append(opts)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def get_context_usage(self):
+            return fake_usage
+
+    monkeypatch.setattr(ctx_mod, "ClaudeSDKClient", FakeTempClient)
+
+    interaction = _make_thread_interaction(
+        bot, parent_id=parent_id, thread_id=thread_id
+    )
+    await ctx_mod.context_cmd.callback(interaction)
+
+    assert len(constructed) == 1, "Path B must spawn exactly one temp client"
+    embed = interaction.followup.send.call_args.kwargs["embed"]
+    assert "fresh session" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_context_bare_channel_without_session_uses_path_b(
+    bot: ClaudedBot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bare channel + no session → Path B (unchanged backward-compat)."""
+    from clauded.cogs import context as ctx_mod
+
+    fake_usage = {
+        "totalTokens": 100,
+        "maxTokens": 200000,
+        "percentage": 0.05,
+        "model": "claude-sonnet",
+        "categories": [],
+    }
+
+    constructed: list = []
+
+    class FakeTempClient:
+        def __init__(self, opts):
+            constructed.append(opts)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def get_context_usage(self):
+            return fake_usage
+
+    monkeypatch.setattr(ctx_mod, "ClaudeSDKClient", FakeTempClient)
+
+    interaction = _make_channel_interaction(bot, channel_id=7777)
+    await ctx_mod.context_cmd.callback(interaction)
+
+    assert len(constructed) == 1
+    embed = interaction.followup.send.call_args.kwargs["embed"]
+    assert "0.0%" in embed.title or "0.1%" in embed.title
+
+
+@pytest.mark.asyncio
+async def test_context_path_b_timeout_returns_friendly_embed(
+    bot: ClaudedBot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Path B subprocess ``__aenter__`` hangs → friendly embed within ~10s.
+
+    We patch the cog's ``_PATH_B_TIMEOUT_S`` to ``0.2`` so the test
+    completes in well under a second; the assertion is on the friendly
+    embed shape, not the wall clock.
+    """
+    from clauded.cogs import context as ctx_mod
+    from clauded.discord_renderer import COLOR_TOOL_FAILURE
+
+    monkeypatch.setattr(ctx_mod, "_PATH_B_TIMEOUT_S", 0.2)
+
+    class HangingClient:
+        def __init__(self, opts):
+            pass
+
+        async def __aenter__(self):
+            # Simulate a subprocess that never makes progress.
+            await asyncio.sleep(5.0)
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def get_context_usage(self):  # pragma: no cover — never reached
+            return {}
+
+    monkeypatch.setattr(ctx_mod, "ClaudeSDKClient", HangingClient)
+
+    interaction = _make_channel_interaction(bot, channel_id=8888)
+
+    loop = asyncio.get_event_loop()
+    start = loop.time()
+    await asyncio.wait_for(ctx_mod.context_cmd.callback(interaction), timeout=2.0)
+    elapsed = loop.time() - start
+
+    # Must surface a friendly embed, not raise / hang.
+    assert elapsed < 1.5, f"Path B timeout took {elapsed}s, expected ~0.2s"
+    embed = interaction.followup.send.call_args.kwargs["embed"]
+    assert embed.color.value == COLOR_TOOL_FAILURE
+    assert "Context unavailable" in embed.title
+    assert "timeout" in embed.description.lower()
+    assert "try again" in embed.description.lower()
+
+
+@pytest.mark.asyncio
+async def test_context_defers_before_any_slow_op(bot: ClaudedBot) -> None:
+    """Fix C: ``defer()`` must be called BEFORE binding/session/Path-A
+    lookups so any exception in those still leaves Discord deferred."""
+    from clauded.cogs import context as ctx_mod
+
+    parent_id = 1000
+    thread_id = 2222
+    fake_usage = {
+        "totalTokens": 1,
+        "maxTokens": 1000,
+        "percentage": 0.1,
+        "model": "claude-sonnet",
+        "categories": [],
+    }
+    mock_bridge = MagicMock()
+    mock_bridge.get_context_usage = AsyncMock(return_value=fake_usage)
+    bot.session_manager._sessions[thread_id] = mock_bridge
+
+    interaction = _make_thread_interaction(
+        bot, parent_id=parent_id, thread_id=thread_id
+    )
+
+    # Record order of calls using a shared list — each tracked op
+    # appends its name. Then assert defer is first.
+    order: list[str] = []
+    interaction.response.defer = AsyncMock(side_effect=lambda *a, **k: order.append("defer"))
+
+    real_get_session = bot.session_manager.get_session
+
+    def tracked_get_session(sid):  # type: ignore[no-redef]
+        order.append("get_session")
+        return real_get_session(sid)
+
+    bot.session_manager.get_session = tracked_get_session  # type: ignore[method-assign]
+
+    real_get_path = bot.project_manager.get_path_or_default
+
+    def tracked_get_path(cid):  # type: ignore[no-redef]
+        order.append("get_path")
+        return real_get_path(cid)
+
+    bot.project_manager.get_path_or_default = tracked_get_path  # type: ignore[method-assign]
+
+    await ctx_mod.context_cmd.callback(interaction)
+
+    assert order, "defer / get_session must have been called"
+    assert order[0] == "defer", (
+        f"defer must precede any slow op; got call order {order}"
+    )
+
+
+# ===========================================================================
+# /skill list — #197 acceptance criteria (same 3-case minimum)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_skill_list_in_thread_with_active_session_uses_path_a(
+    bot: ClaudedBot,
+) -> None:
+    """Thread + active session keyed by thread_id → Path A; no temp client."""
+    from clauded.cogs import skill as skill_mod
+
+    parent_id = 1500
+    thread_id = 2500
+    fake_info = {
+        "commands": [
+            {"name": "crew", "description": "Multi-agent dev workflow (user)"},
+        ]
+    }
+    mock_bridge = MagicMock()
+    mock_bridge.get_server_info = AsyncMock(return_value=fake_info)
+    bot.session_manager._sessions[thread_id] = mock_bridge
+
+    interaction = _make_thread_interaction(
+        bot, parent_id=parent_id, thread_id=thread_id
+    )
+
+    with patch.object(skill_mod, "ClaudeSDKClient") as fake_ctor:
+        await skill_mod.skill_list.callback(interaction)
+
+    fake_ctor.assert_not_called()
+    mock_bridge.get_server_info.assert_awaited_once()
+
+    embed = interaction.followup.send.call_args.kwargs["embed"]
+    assert embed.title.startswith("🧰 Skills")
+
+
+@pytest.mark.asyncio
+async def test_skill_list_bare_channel_falls_to_path_b(
+    bot: ClaudedBot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bare channel + no session → Path B (subprocess) runs."""
+    from clauded.cogs import skill as skill_mod
+
+    fake_info = {"commands": [{"name": "crew", "description": "(user)"}]}
+
+    constructed: list = []
+
+    class FakeTempClient:
+        def __init__(self, options=None):
+            constructed.append(options)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def get_server_info(self):
+            return fake_info
+
+    monkeypatch.setattr(skill_mod, "ClaudeSDKClient", FakeTempClient)
+
+    interaction = _make_channel_interaction(bot, channel_id=9999)
+    await skill_mod.skill_list.callback(interaction)
+
+    assert len(constructed) == 1
+    embed = interaction.followup.send.call_args.kwargs["embed"]
+    assert embed.title.startswith("🧰 Skills")
+
+
+@pytest.mark.asyncio
+async def test_skill_list_path_b_timeout_returns_friendly_embed(
+    bot: ClaudedBot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Path B subprocess hangs → friendly "Skill list unavailable" embed."""
+    from clauded.cogs import skill as skill_mod
+    from clauded.discord_renderer import COLOR_TOOL_FAILURE
+
+    monkeypatch.setattr(skill_mod, "_PATH_B_TIMEOUT_S", 0.2)
+
+    class HangingClient:
+        def __init__(self, options=None):
+            pass
+
+        async def __aenter__(self):
+            await asyncio.sleep(5.0)
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def get_server_info(self):  # pragma: no cover
+            return {}
+
+    monkeypatch.setattr(skill_mod, "ClaudeSDKClient", HangingClient)
+
+    interaction = _make_channel_interaction(bot, channel_id=10101)
+
+    loop = asyncio.get_event_loop()
+    start = loop.time()
+    await asyncio.wait_for(skill_mod.skill_list.callback(interaction), timeout=2.0)
+    elapsed = loop.time() - start
+
+    assert elapsed < 1.5, f"Path B timeout took {elapsed}s, expected ~0.2s"
+    embed = interaction.followup.send.call_args.kwargs["embed"]
+    assert embed.color.value == COLOR_TOOL_FAILURE
+    assert "Skill list unavailable" in embed.title
+    assert "timeout" in embed.description.lower()
+
+
+@pytest.mark.asyncio
+async def test_skill_list_defers_before_any_slow_op(bot: ClaudedBot) -> None:
+    """Fix C: ``defer()`` precedes all slow ops in ``/skill list`` too."""
+    from clauded.cogs import skill as skill_mod
+
+    parent_id = 1500
+    thread_id = 2500
+    mock_bridge = MagicMock()
+    mock_bridge.get_server_info = AsyncMock(return_value={"commands": []})
+    bot.session_manager._sessions[thread_id] = mock_bridge
+
+    interaction = _make_thread_interaction(
+        bot, parent_id=parent_id, thread_id=thread_id
+    )
+
+    order: list[str] = []
+    interaction.response.defer = AsyncMock(side_effect=lambda *a, **k: order.append("defer"))
+
+    real_get_session = bot.session_manager.get_session
+
+    def tracked_get_session(sid):
+        order.append("get_session")
+        return real_get_session(sid)
+
+    bot.session_manager.get_session = tracked_get_session  # type: ignore[method-assign]
+
+    real_get_path = bot.project_manager.get_path_or_default
+
+    def tracked_get_path(cid):
+        order.append("get_path")
+        return real_get_path(cid)
+
+    bot.project_manager.get_path_or_default = tracked_get_path  # type: ignore[method-assign]
+
+    await skill_mod.skill_list.callback(interaction)
+
+    assert order, "defer / lookups must have run"
+    assert order[0] == "defer", f"defer must come first; got {order}"


### PR DESCRIPTION
Closes #197 (P1).

## Approved PRD
`docs/prd/v1.18-fix-context-thread-session.md` — DDD + user-approved before implementation.

## Bug
`/context` and `/skill list` looked up active session with the wrong key when invoked in a thread. They used `resolve_channel_id(interaction)` (returns `parent_id` in thread, correct for binding) and passed it to `session_manager.get_session()` (keyed by `thread_id`). Always missed → fell to Path B (cold-start temp `ClaudeSDKClient`) → competed with parent turn → Discord "application did not respond" timeout.

## Fix
- **S1/S2** — Separate `binding_id = resolve_channel_id(interaction)` from `session_id = interaction.channel_id`. Bare-channel: identical (channel_id == channel_id). In-thread: binding_id = parent_id (correct), session_id = thread_id (correct).
- **S3/S4** — Wrap Path B `ClaudeSDKClient` cold-start + query in `asyncio.timeout(10)`. On timeout: friendly "⚠️ Context/Skill list unavailable, try again" embed instead of indefinite hang.
- **Defer move** — `defer()` now fires immediately after `isinstance(bot, ClaudedBot)` guard, so any pre-slow-op exception still leaves Discord in deferred state.
- **Bonus PRD-miss caught by coding agent**: `resolve_channel_id` returning `None` (DM case) post-defer requires `followup.send` not `response.send_message` — agent silently fixed both sites.

## Files
- `src/clauded/cogs/context.py` (+52 / −13)
- `src/clauded/cogs/skill.py` (+54 / −11)
- `tests/test_context_thread_session.py` (+516 new)

## pytest
**681 / 0** (was 672/0, +9).

## Status
🚧 Draft — pending 7-perspective review.
