### PR TITLE
chore: 4 R1-review nits cleanup bundle (v1.18 polish)

### DIFF
--- a/docs/prd/v1.18-r1-nits-bundle.md
+++ b/docs/prd/v1.18-r1-nits-bundle.md
@@ -1,0 +1,175 @@
+# PRD — Bundle of 4 R1 review nits cleanup (v1.18 polish)
+
+**Status**: APPROVED (self-decide 5/12 + taskmaster 5/14 directive)
+**Issue**: no GitHub issue (manager-driven cleanup of accepted-but-deferred R1 review items)
+**Branch**: `chore/v1.18-r1-nits-bundle`
+**Severity**: chore (no behavior change for users; code-quality / future-regression-prevention)
+
+---
+
+## Problem
+
+Several PRs merged this session left R1-review-flagged "non-blocking" / "v1.19 follow-up" nits. They're ≤30 LOC each, accepted by the original reviewer, and accumulating on the backlog. Bundle 4 atomic ones in one PR for efficient cleanup.
+
+## Goals
+
+1. **#1 — `/skill list` `timed_out` flag inline cleanup** (PR #200 R1 simplicity finding). Match `cogs/context.py`'s pattern of inline timeout-embed-then-return inside the `except` clause; drop the `timed_out` boolean indirection.
+2. **#2 — API-error contract pin** (PR #193 R1 architect finding). `from claude_agent_sdk.types import AssistantMessageError` to make the `getattr(event, "error", ...)` detection explicitly contract-aware. Add 1 negative test that fails if SDK ever moves the `error` field.
+3. **#3 — Cross-reference comment on `#N` index sites** (PR #189 R1 engineer finding). One-line "must match" comment at each of `discord_renderer.py:1218` and `:2694` so a future refactor at one site discovers the other.
+4. **#4 — `setup_hook` no-global-sync regression pin** (PR #188 R1 tester finding). Source-level test that `inspect.getsource(ClaudedBot.setup_hook)` does not contain `self.tree.sync(` so a future PR adding `await self.tree.sync()` is caught immediately.
+
+## Non-goals
+
+- New features
+- Touching production behavior
+- Going further back than the v1.18 session's R1 reviews (don't dig up R3 carry-overs from older PRs)
+- Refactoring beyond what each nit prescribes
+
+## Design
+
+### Nit #1 — `/skill list` inline timeout (cogs/skill.py)
+
+Current shape (post-#200):
+```python
+timed_out = False
+try:
+    async with asyncio.timeout(_PATH_B_TIMEOUT_S):
+        async with ClaudeSDKClient(...) as tmp:
+            info = await tmp.get_server_info()
+except (asyncio.TimeoutError, TimeoutError):
+    timed_out = True
+except Exception as exc:
+    info_err = exc
+    info = None
+
+if timed_out:
+    embed = discord.Embed(title="⚠️ Skill list unavailable", ...)
+    await interaction.followup.send(embed=embed, ephemeral=True)
+    return
+# ... existing info_err handling continues
+```
+
+Target shape (mirrors cogs/context.py:194-209):
+```python
+try:
+    async with asyncio.timeout(_PATH_B_TIMEOUT_S):
+        async with ClaudeSDKClient(...) as tmp:
+            info = await tmp.get_server_info()
+except (asyncio.TimeoutError, TimeoutError):
+    embed = discord.Embed(title="⚠️ Skill list unavailable", ...)
+    await interaction.followup.send(embed=embed, ephemeral=True)
+    return
+except Exception as exc:
+    info_err = exc
+    info = None
+# ... existing info_err handling continues
+```
+
+Saves ~4 LOC, drops `timed_out` local, removes a control-flow gap between sister cogs.
+
+### Nit #2 — AssistantMessageError contract pin
+
+Current detection (`discord_renderer.py:653-654`):
+```python
+api_error = getattr(event, "error", None) if isinstance(event, AssistantMessage) else None
+if api_error is not None:
+    ...
+```
+
+This is duck-typed; if the SDK renames `error` → `error_info.kind`, detection silently no-ops with no test failure. Mitigation:
+
+1. Top of file: `from claude_agent_sdk.types import AssistantMessageError` (already exists for `AssistantMessage`/`UserMessage` etc — just add the type)
+2. New test in `tests/test_api_error_render.py`:
+```python
+def test_assistant_message_error_field_exists_on_sdk():
+    """Pin: SDK's AssistantMessage MUST expose `.error` attribute (or
+    rename triggers this test failure, alerting maintainers to update
+    discord_renderer's getattr detection)."""
+    from dataclasses import fields
+    from claude_agent_sdk.types import AssistantMessage
+    field_names = {f.name for f in fields(AssistantMessage)}
+    assert "error" in field_names, (
+        "claude_agent_sdk.types.AssistantMessage no longer has an "
+        "`error` field; update discord_renderer.py's API-error detection."
+    )
+```
+
+This catches SDK contract drift at test time, not at production runtime.
+
+### Nit #3 — Cross-reference comment at the two #N index sites
+
+Two physical files share the medium-tier `#N` numbering invariant:
+- `src/clauded/discord_renderer.py:1218` (rolling-log line: `f"... #{medium_index}: ...")
+- `src/clauded/discord_renderer.py:2694` (button label: `f"📄 #{index} {tool_name[:18]}"`)
+
+If either changes its numbering source (e.g., one switches to per-tool-type indexing), the other silently drifts and breaks the user-facing mapping (#187 entire PR was about exactly this hazard).
+
+Add a 1-line comment at each site:
+```python
+# Line 1218 (rolling-log site):
+# #187 invariant: must match ToolResultsView.add_result numbering
+# at discord_renderer.py:~2694. If you change one, audit the other.
+
+# Line 2694 (ToolResultsView.add_result site):
+# #187 invariant: must match medium-tier rolling-log numbering at
+# discord_renderer.py:~1218. If you change one, audit the other.
+```
+
+### Nit #4 — setup_hook no-global-sync pin (tests/test_slash_command_sync.py)
+
+Add to existing test file:
+```python
+import inspect
+from clauded.bot import ClaudedBot
+
+def test_setup_hook_does_not_call_global_tree_sync():
+    """#185 regression pin: ``setup_hook`` must NOT contain
+    ``self.tree.sync(`` (without a guild kwarg). Per-guild sync is
+    deferred to ``on_ready``; a global sync here would re-introduce
+    the duplicate-commands bug across all 26 commands.
+
+    Source-level test because ``commands.Bot.tree`` is a read-only
+    ``@property`` that's awkward to mock at instance level. Cheap
+    and bullet-proof: any reintroduction of `tree.sync()` in
+    setup_hook fails this test immediately.
+    """
+    src = inspect.getsource(ClaudedBot.setup_hook)
+    assert "self.tree.sync(" not in src, (
+        "setup_hook must not call self.tree.sync(...) — that would "
+        "global-sync commands and reintroduce #185 (duplicate "
+        "autocomplete entries). Per-guild sync lives in on_ready."
+    )
+```
+
+Adapts the tester's recommendation from the #188 R1 review verbatim.
+
+## Acceptance criteria
+
+- [ ] Nit #1: `/skill list` Path B timeout block matches `/context`'s pattern (no `timed_out` local)
+- [ ] Nit #2: `AssistantMessageError` imported from SDK; new contract-pin test passes; if SDK renames the field, test fails
+- [ ] Nit #3: 2 cross-reference comments present at lines ~1218 and ~2694 (or wherever those features land after this PR)
+- [ ] Nit #4: source-level test added; passes against current `setup_hook`; would fail if `await self.tree.sync()` were re-introduced
+- [ ] All existing tests still pass: 681/0
+- [ ] No production behavior changes (this PR is pure polish)
+
+## Tests
+
+- Augment `tests/test_skill_list.py` (or wherever skill timeout test lives — dev to find): existing timeout test should still pass with the new inline pattern
+- New: `tests/test_api_error_render.py::test_assistant_message_error_field_exists_on_sdk`
+- New: `tests/test_slash_command_sync.py::test_setup_hook_does_not_call_global_tree_sync`
+- Comment-only changes for Nit #3 — no test needed
+
+## Out of scope
+
+- Older R3-carryover nits from pre-v1.18 PRs
+- Engineer's "split `display_model` vs `input_model`" suggestion from #199 R1 (deferred — it's a design-level change, not a 5-line nit)
+- All product-side UX wording polish ("(unset — will use CLI default; ask Claude something to discover)" etc.)
+- Subprocess-zombie tracking from #200 R1 security (architectural, not a nit)
+
+## Plan
+
+Single coding agent, ≤15 min. 4 sub-tasks atomic in 1 PR. Manager will run 7-perspective review.
+
+## Sign-off
+
+Self-approved per taskmaster directive 2026-05-14 ("self-decide 5/12 授权过, 开 PRD 别等 approve").

--- a/src/clauded/cogs/skill.py
+++ b/src/clauded/cogs/skill.py
@@ -151,7 +151,6 @@ async def skill_list(interaction: discord.Interaction) -> None:
 
     info: dict | None = None
     info_err: Exception | None = None
-    timed_out: bool = False
 
     # Path A: piggyback the live bridge if there is one.
     bridge = (
@@ -181,24 +180,23 @@ async def skill_list(interaction: discord.Interaction) -> None:
                 ) as tmp:
                     info = await tmp.get_server_info()
         except (asyncio.TimeoutError, TimeoutError):
+            # Mirror /context Path B: emit the timeout embed inline and
+            # return, instead of routing through a `timed_out` flag.
             log.warning("/skill list Path B timed out after %ss", _PATH_B_TIMEOUT_S)
-            timed_out = True
+            embed = discord.Embed(
+                title="⚠️ Skill list unavailable",
+                description=(
+                    "Couldn't query the skill list in time "
+                    f"({_PATH_B_TIMEOUT_S}s timeout). "
+                    "This usually happens when the bot is processing a large turn. "
+                    "Try again once the active turn completes."
+                ),
+                color=COLOR_TOOL_FAILURE,
+            )
+            await interaction.followup.send(embed=embed, ephemeral=True)
+            return
         except Exception as exc:  # noqa: BLE001 — any other failure → friendly red embed
             info_err = exc
-
-    if timed_out:
-        embed = discord.Embed(
-            title="⚠️ Skill list unavailable",
-            description=(
-                "Couldn't query the skill list in time "
-                f"({_PATH_B_TIMEOUT_S}s timeout). "
-                "This usually happens when the bot is processing a large turn. "
-                "Try again once the active turn completes."
-            ),
-            color=COLOR_TOOL_FAILURE,
-        )
-        await interaction.followup.send(embed=embed, ephemeral=True)
-        return
 
     if info_err is not None or info is None:
         if info_err is None:

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -49,7 +49,7 @@ from .claude_bridge import (
     ToolResultBlock,
     ToolUseBlock,
 )
-from claude_agent_sdk.types import StreamEvent, UserMessage
+from claude_agent_sdk.types import AssistantMessageError, StreamEvent, UserMessage  # noqa: F401 — AssistantMessageError documents the contract pinned by tests/test_api_error_render.py::test_assistant_message_error_field_exists_on_sdk; runtime detection uses getattr() for duck-typing flexibility.
 from .stream_logger import log_event as _log_stream
 from .cogs._table_view import CopyTableTextView
 from ._errors import is_transient_discord_error
@@ -1414,6 +1414,7 @@ class DiscordRenderer:
                                             medium_index = list(medium_results.keys()).index(tool_id) + 1
                                         else:
                                             medium_index = len(medium_results) + 1
+                                        # #187 invariant: must match ToolResultsView.add_result numbering at ~line 2902. If you change one, audit the other.
                                         tool_log_lines[i] = (
                                             f"{status} {name} #{medium_index}: "
                                             f"{line_count} lines / "
@@ -2897,6 +2898,7 @@ class ToolResultsView(discord.ui.View):
         index = len(self._results)
         # Custom_id must be unique per button across the bot's active
         # views; embed the tool_use_id so callbacks can dispatch.
+        # #187 invariant: must match medium-tier rolling-log numbering at ~line 1417. If you change one, audit the other.
         button = discord.ui.Button(  # type: ignore[var-annotated]
             label=f"📄 #{index} {tool_name[:18]}",
             style=discord.ButtonStyle.secondary,

--- a/tests/test_api_error_render.py
+++ b/tests/test_api_error_render.py
@@ -321,10 +321,25 @@ async def test_api_error_with_triple_backticks_in_body_does_not_break_fence():
 
 
 def test_assistant_message_error_field_exists_on_sdk():
-    """Pin: SDK's AssistantMessage MUST expose `.error` attribute."""
-    from dataclasses import fields
+    """Pin: SDK's AssistantMessage MUST expose `.error` attribute, so the
+    duck-typed ``getattr(event, "error", None)`` detection in
+    ``discord_renderer.py`` keeps catching synthetic API errors. If the
+    SDK ever renames or removes the field (e.g., switches to
+    ``error_info.kind``), this test fails with the actionable message
+    below — alerting maintainers to update the renderer.
+
+    Defensive: also wraps ``dataclasses.fields()`` so a future SDK
+    switch from ``@dataclass`` to ``TypedDict``/Pydantic doesn't show
+    up as a confusing ``TypeError`` (R1 engineer #2 follow-up).
+    """
     from claude_agent_sdk.types import AssistantMessage
-    field_names = {f.name for f in fields(AssistantMessage)}
+    try:
+        from dataclasses import fields
+        field_names = {f.name for f in fields(AssistantMessage)}
+    except TypeError:
+        # AssistantMessage is no longer a dataclass; fall back to
+        # attribute introspection.
+        field_names = {n for n in dir(AssistantMessage) if not n.startswith("_")}
     assert "error" in field_names, (
         "claude_agent_sdk.types.AssistantMessage no longer has an "
         "`error` field; update discord_renderer.py's API-error detection."

--- a/tests/test_api_error_render.py
+++ b/tests/test_api_error_render.py
@@ -318,3 +318,14 @@ async def test_api_error_with_triple_backticks_in_body_does_not_break_fence():
     # affect visual reading)
     assert "python" in inner
     assert "print" in inner
+
+
+def test_assistant_message_error_field_exists_on_sdk():
+    """Pin: SDK's AssistantMessage MUST expose `.error` attribute."""
+    from dataclasses import fields
+    from claude_agent_sdk.types import AssistantMessage
+    field_names = {f.name for f in fields(AssistantMessage)}
+    assert "error" in field_names, (
+        "claude_agent_sdk.types.AssistantMessage no longer has an "
+        "`error` field; update discord_renderer.py's API-error detection."
+    )

--- a/tests/test_slash_command_sync.py
+++ b/tests/test_slash_command_sync.py
@@ -115,19 +115,3 @@ def test_setup_hook_source_has_no_global_tree_sync():
             f"twice in autocomplete). Per-guild sync from on_ready instead."
         )
 
-
-import inspect
-
-def test_setup_hook_does_not_call_global_tree_sync():
-    """#185 regression pin: ``setup_hook`` must NOT contain
-    ``self.tree.sync(`` (without a guild kwarg). Per-guild sync is
-    deferred to ``on_ready``; a global sync here would re-introduce
-    the duplicate-commands bug across all 26 commands.
-    """
-    from clauded.bot import ClaudedBot
-    src = inspect.getsource(ClaudedBot.setup_hook)
-    assert "self.tree.sync(" not in src, (
-        "setup_hook must not call self.tree.sync(...) — that would "
-        "global-sync commands and reintroduce #185 (duplicate "
-        "autocomplete entries). Per-guild sync lives in on_ready."
-    )

--- a/tests/test_slash_command_sync.py
+++ b/tests/test_slash_command_sync.py
@@ -114,3 +114,20 @@ def test_setup_hook_source_has_no_global_tree_sync():
             f"GLOBALLY, which is what caused #185 (every command appeared "
             f"twice in autocomplete). Per-guild sync from on_ready instead."
         )
+
+
+import inspect
+
+def test_setup_hook_does_not_call_global_tree_sync():
+    """#185 regression pin: ``setup_hook`` must NOT contain
+    ``self.tree.sync(`` (without a guild kwarg). Per-guild sync is
+    deferred to ``on_ready``; a global sync here would re-introduce
+    the duplicate-commands bug across all 26 commands.
+    """
+    from clauded.bot import ClaudedBot
+    src = inspect.getsource(ClaudedBot.setup_hook)
+    assert "self.tree.sync(" not in src, (
+        "setup_hook must not call self.tree.sync(...) — that would "
+        "global-sync commands and reintroduce #185 (duplicate "
+        "autocomplete entries). Per-guild sync lives in on_ready."
+    )


### PR DESCRIPTION
chore: cleanup of 4 R1-flagged "non-blocking" / "v1.19 follow-up" nits from this session.

## Approved PRD
`docs/prd/v1.18-r1-nits-bundle.md` — self-approved per taskmaster directive 2026-05-14.

## Nits (each ≤ 30 LOC)
1. **`/skill list` `timed_out` flag inline** (PR #200 R1 simplicity) — match `/context`'s pattern; drop one local
2. **API-error SDK contract pin** (PR #193 R1 architect) — `from claude_agent_sdk.types import AssistantMessageError` + dataclass-fields negative test
3. **`#N` cross-reference comments** (PR #189 R1 engineer) — 1-line "must match" notes at `discord_renderer.py:1417` (rolling-log) and `:2901` (ToolResultsView.add_result)
4. **`setup_hook` no-global-sync stricter pin** (PR #188 R1 tester) — source-level test forbidding any `self.tree.sync(` substring (catches `self.tree.sync(guild=...)` too)

## Files
- `src/clauded/cogs/skill.py` (+13 / −16)
- `src/clauded/discord_renderer.py` (+3 / −1)
- `tests/test_api_error_render.py` (+11)
- `tests/test_slash_command_sync.py` (+18)

## pytest
**683 / 0** (was 681/0, +2).

No production behavior change. Pure polish. Status: 🚧 Draft — pending R1 review.
