### PR TITLE
chore: stage-28 trim — extract _logging_setup + dedup test fakes (-177 LOC net)

### DIFF
--- a/docs/prd/v1.18-stage28-trim.md
+++ b/docs/prd/v1.18-stage28-trim.md
@@ -1,0 +1,173 @@
+# PRD — Stage-28 trim: extract `_logging_setup` + dedup test fakes
+
+**Status**: APPROVED (self-decide per taskmaster directive 2026-05-14)
+**Issue**: no GitHub issue (manager-driven cleanup)
+**Branch**: `chore/v1.18-stage28-trim`
+**Severity**: chore (no behavior change; reduces LOC + improves test maintainability)
+
+---
+
+## Problem
+
+Two cleanup targets that have grown across this session and are worth claiming now:
+
+1. **`_configure_logging` lives at `bot.py:1069-1115`** (47 LOC). It's tightly scoped, has nothing to do with the bot's `commands.Bot` subclass, and bot.py is already 1100+ lines. Extracting it makes bot.py focused and gives logging setup its own home for future tweaks.
+
+2. **Test scaffolding duplication**: `FakeBridge`, `FakeMessage`, `FakeTarget` are copy-pasted across 6 test files, with `test_tool_result_shorttier.py` alone containing **5 separate copies**. Each copy carries the same essentials with minor per-test deltas. A shared conftest.py with helper factories collapses ~250 LOC of dup.
+
+## Goals
+
+1. Extract `_configure_logging` + `_LOG_DIR` + `_ensure_runtime_dirs` (the cluster of module-level logging/dir state) into `src/clauded/_logging_setup.py`. `bot.py` imports from it. No behavior change — same RotatingFileHandler, same stderr fallback, same pytest-detection.
+2. Centralize test fakes into `tests/conftest.py` (or `tests/_fakes.py` imported by tests — pytest both work). Migrate the 6 affected test files to use the shared helpers. Per-test customization stays inline (constructor kwargs).
+3. **Single PR** with both changes. They're orthogonal but small enough to bundle.
+
+## Non-goals
+
+- Renaming or restructuring beyond the two extractions
+- Touching production logging behavior (format, level, rotation policy)
+- Migrating tests that don't have FakeBridge/FakeMessage/FakeTarget patterns
+- Changing test semantics or coverage
+
+## Design
+
+### Goal #1 — `_logging_setup.py`
+
+Move from `bot.py`:
+- `_LOG_DIR = Path.home() / "Library" / "Logs" / "clauded"` (line 60)
+- `_ensure_runtime_dirs() -> None` (line 65) — best-effort directory creation
+- `_configure_logging() -> None` (line 1069) — basicConfig vs RotatingFileHandler logic
+
+Into new `src/clauded/_logging_setup.py`. `bot.py` adds:
+```python
+from ._logging_setup import _LOG_DIR, _ensure_runtime_dirs, _configure_logging
+```
+
+`_HEARTBEAT_FILE` etc. **stay in bot.py** — they belong with the heartbeat task, not with logging setup. Only the logging-cluster moves.
+
+### Goal #2 — test fakes
+
+Create `tests/conftest.py` (pytest auto-discovers) with:
+
+```python
+from unittest.mock import MagicMock
+from typing import Any, AsyncIterator
+import discord
+
+
+class FakeBridge:
+    """Minimal ClaudeBridge stand-in for renderer tests.
+
+    `events` is the iterable yielded by `send_message`; tests pass any list
+    of SDK event objects (AssistantMessage, UserMessage, ResultMessage, etc).
+
+    Keyword args:
+      get_context_usage_returns -- value to return from get_context_usage()
+                                   (None = mock returns None; callable = call it)
+      get_context_usage_raises  -- exception to raise instead of returning
+    """
+    def __init__(self, events, *, get_context_usage_returns=None,
+                 get_context_usage_raises=None):
+        self._events = events
+        self._gcu_returns = get_context_usage_returns
+        self._gcu_raises = get_context_usage_raises
+        self.is_active = True
+        self._client = MagicMock()
+
+    async def send_message(self, _text):
+        for ev in self._events:
+            yield ev
+
+    async def get_context_usage(self):
+        if self._gcu_raises is not None:
+            raise self._gcu_raises
+        return self._gcu_returns
+
+
+class FakeMessage:
+    """Minimal discord.Message stand-in. Captures content/embeds/view via edit/send."""
+    def __init__(self, msg_id=1):
+        self.id = msg_id
+        self.content = ""
+        self.embeds = []
+        self.attached_view = None
+        self.attachments = []
+
+    async def edit(self, **kwargs):
+        if "content" in kwargs:
+            self.content = kwargs["content"]
+        if "embed" in kwargs:
+            self.embeds = [kwargs["embed"]]
+        if "view" in kwargs:
+            self.attached_view = kwargs["view"]
+        return self
+
+    async def delete(self):
+        return None
+
+    async def create_thread(self, name, auto_archive_duration=None, **kwargs):
+        # Default no-op; tests override at class level if they need a real thread
+        return None
+
+
+class FakeTarget:
+    """Minimal channel/thread stand-in. Records every send() into _sent."""
+    def __init__(self, target_id=1):
+        self.id = target_id
+        self.name = "fake-target"
+        self.mention = f"<#{target_id}>"
+        self.parent = None
+        self._sent: list[FakeMessage] = []
+        self._next_id = target_id * 1000
+
+    async def send(self, *args, **kwargs):
+        self._next_id += 1
+        msg = FakeMessage(msg_id=self._next_id)
+        if "content" in kwargs:
+            msg.content = kwargs["content"]
+        if "embed" in kwargs:
+            msg.embeds = [kwargs["embed"]]
+        if "view" in kwargs:
+            msg.attached_view = kwargs["view"]
+        if "file" in kwargs:
+            msg.attachments = [kwargs["file"]]
+        self._sent.append(msg)
+        return msg
+```
+
+Migrate the 6 test files:
+- `tests/test_api_error_render.py` — replace 1 FakeBridge/FakeMessage/FakeTarget cluster (top-level)
+- `tests/test_context_footer.py` — replace inline definitions in 3 tests
+- `tests/test_subtask_complete_render.py` — replace `_FakeBridge`/`_FakeMessage`/`_FakeThread`/`_FakeTarget` cluster
+- `tests/test_tool_result_shorttier.py` — collapse 5 inline definitions into shared `FakeBridge` import
+- `tests/test_subagent_threads.py` — has its own `FakeMainThread`/`FakeChannel` shapes that are MORE complex (parent_channel routing + thread.create_thread invocation tracking); leave alone (out-of-scope, would expand the migration)
+- `tests/test_session_manager.py` — different shape (manager-level test fixtures); leave alone
+
+Per-test customization (e.g., `FailingSendTarget` that returns None on certain sends) stays as a per-test subclass of `FakeTarget`.
+
+## Acceptance criteria
+
+- [ ] `src/clauded/_logging_setup.py` exists with `_LOG_DIR`, `_ensure_runtime_dirs`, `_configure_logging`
+- [ ] `bot.py` imports those from `_logging_setup`; no behavior change in logging output (verify by `grep "RotatingFileHandler\|basicConfig" src/clauded/bot.py` returning 0 hits)
+- [ ] `tests/conftest.py` exists with `FakeBridge`, `FakeMessage`, `FakeTarget`
+- [ ] 4 affected test files (`test_api_error_render`, `test_context_footer`, `test_subtask_complete_render`, `test_tool_result_shorttier`) import the shared helpers and don't redefine the base classes
+- [ ] All existing tests still pass: 682/0
+- [ ] No new tests required (this is a refactor; behavior is preserved)
+
+## Tests
+
+No new tests. Existing tests must continue to pass after migration.
+
+## Out of scope
+
+- `tests/test_subagent_threads.py` migration (different fake shapes, would expand the work substantially)
+- `tests/test_session_manager.py` migration (different fixture style)
+- Renaming `_logging_setup.py` to something user-facing
+- Restructuring `bot.py` further
+
+## Plan
+
+Single coding agent, ≤15 min. 2 sub-tasks atomic in 1 PR.
+
+## Sign-off
+
+Self-approved per taskmaster directive 2026-05-14.

--- a/src/clauded/_logging_setup.py
+++ b/src/clauded/_logging_setup.py
@@ -1,0 +1,87 @@
+"""Logging + runtime-dir setup, extracted from ``bot.py`` (v1.18 stage-28 trim).
+
+Owns the three pieces of module-level state that ``commands.Bot`` does not need
+to know about:
+
+* :data:`_LOG_DIR` — production rotating-log destination (``~/Library/Logs/clauded``)
+* :data:`_CACHE_DIR` — companion runtime cache dir (heartbeat lives here); kept
+  alongside ``_LOG_DIR`` so :func:`_ensure_runtime_dirs` can do both with one
+  Darwin guard. ``bot.py`` re-exports it for ``_HEARTBEAT_PATH`` composition.
+* :func:`_ensure_runtime_dirs` — one-shot mkdir at startup
+* :func:`_configure_logging` — pytest-aware ``basicConfig``/``RotatingFileHandler``
+
+Behavior is unchanged from the in-``bot.py`` version (PR #149 R2 contract): same
+RotatingFileHandler params, same stderr fallback, same ``PYTEST_CURRENT_TEST``
+detection, same swallowed ``OSError`` for read-only homes.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+# --------------------------------------------------------------------------
+# macOS LaunchAgent paths (mirrors scripts/install-launchagent.sh etc.).
+# When changing any of these, grep the repo for the matching string in the
+# bash scripts + plist template.
+# --------------------------------------------------------------------------
+_LOG_DIR = Path.home() / "Library" / "Logs" / "clauded"
+_CACHE_DIR = Path.home() / "Library" / "Caches" / "clauded"
+
+
+def _ensure_runtime_dirs() -> None:
+    """Create ``_LOG_DIR`` and ``_CACHE_DIR`` once at process start.
+
+    Replaces the per-tick ``parent.mkdir`` calls in ``_touch_heartbeat`` and
+    ``_configure_logging`` so a 30 s heartbeat loop and a 1-call logging-setup
+    don't each redo the dir checks (PR #149 R2 engineer suggestion). Swallows
+    ``OSError`` so a read-only or sandboxed home doesn't crash startup; the
+    individual write call sites handle the consequence.
+    """
+    if sys.platform != "darwin":
+        return
+    for d in (_LOG_DIR, _CACHE_DIR):
+        try:
+            d.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass
+
+
+def _configure_logging() -> None:
+    """Set up app logging — RotatingFileHandler in production, stderr-only in tests.
+
+    Detects pytest via ``PYTEST_CURRENT_TEST`` so test runs don't pollute
+    ``~/Library/Logs/clauded/``. In production on macOS, attaches a 10 MB × 7
+    rotating file handler plus a stderr handler so launchd's
+    ``StandardErrorPath`` still captures boot diagnostics. On non-Darwin
+    (Linux/Windows dev boxes) and on ``OSError`` (e.g. read-only ``$HOME``)
+    falls back to ``basicConfig`` to stderr — same path as pytest — to avoid
+    silently creating macOS-shaped junk directories outside macOS.
+    """
+    fmt = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        logging.basicConfig(level=logging.INFO, format=fmt)
+        return
+    if sys.platform != "darwin":
+        logging.basicConfig(level=logging.INFO, format=fmt)
+        return
+    # _LOG_DIR was created at startup by _ensure_runtime_dirs(); if it's still
+    # absent (e.g. read-only home, sandboxed test runner) fall back to stderr.
+    if not _LOG_DIR.exists():
+        logging.basicConfig(level=logging.INFO, format=fmt)
+        return
+    handler = RotatingFileHandler(
+        _LOG_DIR / "clauded.log",
+        maxBytes=10 * 1024 * 1024,
+        backupCount=7,
+        encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter(fmt))
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(logging.Formatter(fmt))
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(handler)
+    root.addHandler(stderr_handler)

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -14,7 +14,6 @@ import tempfile
 import time
 import sys
 import asyncio
-from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 import discord
@@ -38,6 +37,12 @@ from ._http_retry import (
     safe_remove_reaction,
     safe_add_reaction,
 )
+from ._logging_setup import (
+    _LOG_DIR,
+    _CACHE_DIR,
+    _ensure_runtime_dirs,
+    _configure_logging,
+)
 
 # Re-export SystemPromptModal so existing ``from clauded.bot import
 # SystemPromptModal`` continues to work (tests rely on this).
@@ -57,27 +62,10 @@ _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
 # repo for the matching string in those files.
 # --------------------------------------------------------------------------
 _LAUNCHD_LABEL = "com.hxy.clauded"
-_LOG_DIR = Path.home() / "Library" / "Logs" / "clauded"
-_CACHE_DIR = Path.home() / "Library" / "Caches" / "clauded"
+# _LOG_DIR and _CACHE_DIR live in _logging_setup.py (v1.18 stage-28 trim);
+# imported above. _HEARTBEAT_PATH stays here because it belongs to the
+# heartbeat task, not to logging setup.
 _HEARTBEAT_PATH = _CACHE_DIR / "heartbeat"
-
-
-def _ensure_runtime_dirs() -> None:
-    """Create ``_LOG_DIR`` and ``_CACHE_DIR`` once at process start.
-
-    Replaces the per-tick ``parent.mkdir`` calls in ``_touch_heartbeat`` and
-    ``_configure_logging`` so a 30 s heartbeat loop and a 1-call logging-setup
-    don't each redo the dir checks (PR #149 R2 engineer suggestion). Swallows
-    ``OSError`` so a read-only or sandboxed home doesn't crash startup; the
-    individual write call sites handle the consequence.
-    """
-    if sys.platform != "darwin":
-        return
-    for d in (_LOG_DIR, _CACHE_DIR):
-        try:
-            d.mkdir(parents=True, exist_ok=True)
-        except OSError:
-            pass
 
 
 def _touch_heartbeat() -> None:
@@ -1065,44 +1053,6 @@ class ClaudedBot(commands.Bot):
 # ---------------------------------------------------------------------------
 # Entrypoint
 # ---------------------------------------------------------------------------
-
-def _configure_logging() -> None:
-    """Set up app logging — RotatingFileHandler in production, stderr-only in tests.
-
-    Detects pytest via ``PYTEST_CURRENT_TEST`` so test runs don't pollute
-    ``~/Library/Logs/clauded/``. In production on macOS, attaches a 10 MB × 7
-    rotating file handler plus a stderr handler so launchd's
-    ``StandardErrorPath`` still captures boot diagnostics. On non-Darwin
-    (Linux/Windows dev boxes) and on ``OSError`` (e.g. read-only ``$HOME``)
-    falls back to ``basicConfig`` to stderr — same path as pytest — to avoid
-    silently creating macOS-shaped junk directories outside macOS.
-    """
-    fmt = "%(asctime)s %(levelname)s %(name)s: %(message)s"
-    if os.environ.get("PYTEST_CURRENT_TEST"):
-        logging.basicConfig(level=logging.INFO, format=fmt)
-        return
-    if sys.platform != "darwin":
-        logging.basicConfig(level=logging.INFO, format=fmt)
-        return
-    # _LOG_DIR was created at startup by _ensure_runtime_dirs(); if it's still
-    # absent (e.g. read-only home, sandboxed test runner) fall back to stderr.
-    if not _LOG_DIR.exists():
-        logging.basicConfig(level=logging.INFO, format=fmt)
-        return
-    handler = RotatingFileHandler(
-        _LOG_DIR / "clauded.log",
-        maxBytes=10 * 1024 * 1024,
-        backupCount=7,
-        encoding="utf-8",
-    )
-    handler.setFormatter(logging.Formatter(fmt))
-    stderr_handler = logging.StreamHandler(sys.stderr)
-    stderr_handler.setFormatter(logging.Formatter(fmt))
-    root = logging.getLogger()
-    root.setLevel(logging.INFO)
-    root.addHandler(handler)
-    root.addHandler(stderr_handler)
-
 
 def main() -> None:
     """Console-script entry point: load config and run the bot."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,9 +98,20 @@ class FakeTarget:
         self._sent: list[FakeMessage] = []
         self._next_id = target_id * 1000
 
+    def _make_message(self, msg_id: int) -> FakeMessage:
+        """Hook subclasses can override to mint a custom message subclass.
+
+        Default returns the shared ``FakeMessage``. Tests that need
+        per-message-class behavior (e.g.,
+        ``test_subtask_complete_render._FakeMessage`` overriding
+        ``create_thread``) override this method instead of duplicating
+        the entire ``send()`` body.
+        """
+        return FakeMessage(msg_id=msg_id)
+
     async def send(self, *args, **kwargs):
         self._next_id += 1
-        msg = FakeMessage(msg_id=self._next_id)
+        msg = self._make_message(self._next_id)
         if "content" in kwargs:
             msg.content = kwargs["content"]
         if "embed" in kwargs:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,113 @@
+"""Shared pytest fixtures + minimal fakes for renderer tests.
+
+v1.18 stage-28: centralize the ``FakeBridge`` / ``FakeMessage`` / ``FakeTarget``
+trio that was being copy-pasted across 4 test files (5 copies in
+``test_tool_result_shorttier.py`` alone). Per-test customization stays as
+inline subclasses near the test that uses it.
+
+NOT covered by these helpers (different shapes, out of scope):
+- ``tests/test_subagent_threads.py`` has its own ``FakeMainThread`` /
+  ``FakeChannel`` with parent-channel routing + thread.create_thread
+  invocation tracking.
+- ``tests/test_session_manager.py`` uses manager-level fixtures.
+
+Per-test customization stays as inline subclass of the base classes here,
+e.g. ``FailingSendTarget(FakeTarget)`` or ``FailingAddViewBot``.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+class FakeBridge:
+    """Minimal ClaudeBridge stand-in for renderer tests.
+
+    ``events`` is the iterable yielded by ``send_message``; tests pass any list
+    of SDK event objects (AssistantMessage, UserMessage, ResultMessage, etc).
+
+    Keyword args:
+      get_context_usage_returns -- value to return from ``get_context_usage()``
+                                   (default ``None``)
+      get_context_usage_raises  -- exception to raise instead of returning
+    """
+
+    def __init__(
+        self,
+        events,
+        *,
+        get_context_usage_returns=None,
+        get_context_usage_raises=None,
+    ):
+        self._events = events
+        self._gcu_returns = get_context_usage_returns
+        self._gcu_raises = get_context_usage_raises
+        self.is_active = True
+        self._client = MagicMock()
+
+    async def send_message(self, _text):
+        for ev in self._events:
+            yield ev
+
+    async def get_context_usage(self):
+        if self._gcu_raises is not None:
+            raise self._gcu_raises
+        return self._gcu_returns
+
+
+class FakeMessage:
+    """Minimal ``discord.Message`` stand-in.
+
+    Captures ``content`` / ``embeds`` / ``view`` / ``attachments`` on
+    ``edit`` and ``send``. ``create_thread`` is a no-op by default; tests
+    that need a real thread override at the class level (see
+    ``tests/test_subtask_complete_render.py``).
+    """
+
+    def __init__(self, msg_id: int = 1):
+        self.id = msg_id
+        self.content = ""
+        self.embeds: list = []
+        self.attached_view = None
+        self.attachments: list = []
+
+    async def edit(self, **kwargs):
+        if "content" in kwargs:
+            self.content = kwargs["content"]
+        if "embed" in kwargs:
+            self.embeds = [kwargs["embed"]]
+        if "view" in kwargs:
+            self.attached_view = kwargs["view"]
+        return self
+
+    async def delete(self):
+        return None
+
+    async def create_thread(self, name, auto_archive_duration=None, **kwargs):
+        # Default no-op; tests override at class level if they need a real thread
+        return None
+
+
+class FakeTarget:
+    """Minimal channel/thread stand-in. Records every ``send()`` into ``_sent``."""
+
+    def __init__(self, target_id: int = 1):
+        self.id = target_id
+        self.name = "fake-target"
+        self.mention = f"<#{target_id}>"
+        self.parent = None
+        self._sent: list[FakeMessage] = []
+        self._next_id = target_id * 1000
+
+    async def send(self, *args, **kwargs):
+        self._next_id += 1
+        msg = FakeMessage(msg_id=self._next_id)
+        if "content" in kwargs:
+            msg.content = kwargs["content"]
+        if "embed" in kwargs:
+            msg.embeds = [kwargs["embed"]]
+        if "view" in kwargs:
+            msg.attached_view = kwargs["view"]
+        if "file" in kwargs:
+            msg.attachments = [kwargs["file"]]
+        self._sent.append(msg)
+        return msg

--- a/tests/test_api_error_render.py
+++ b/tests/test_api_error_render.py
@@ -5,49 +5,12 @@ import pytest
 import sys
 sys.path.insert(0, "src")
 
-from unittest.mock import MagicMock
 from claude_agent_sdk.types import (
     AssistantMessage, TextBlock, ResultMessage,
 )
 from clauded.discord_renderer import DiscordRenderer
 
-
-class FakeBridge:
-    def __init__(self, events):
-        self._events = events
-        self.is_active = True
-        self._client = MagicMock()
-    async def send_message(self, _text):
-        for ev in self._events:
-            yield ev
-
-
-class FakeMessage:
-    def __init__(self):
-        self.content = ""
-        self.embeds = []
-    async def edit(self, **kwargs):
-        if "content" in kwargs:
-            self.content = kwargs["content"]
-        if "embed" in kwargs:
-            self.embeds = [kwargs["embed"]]
-        return self
-    async def delete(self):
-        return None
-
-
-class FakeTarget:
-    def __init__(self):
-        self.id = 1
-        self._sent = []
-    async def send(self, *args, **kwargs):
-        msg = FakeMessage()
-        if "content" in kwargs:
-            msg.content = kwargs["content"]
-        if "embed" in kwargs:
-            msg.embeds = [kwargs["embed"]]
-        self._sent.append(msg)
-        return msg
+from tests.conftest import FakeBridge, FakeTarget  # noqa: E402  (shared fakes)
 
 
 # The exact 400 error from the user's production session

--- a/tests/test_context_footer.py
+++ b/tests/test_context_footer.py
@@ -2,9 +2,10 @@
 import pytest
 import sys
 sys.path.insert(0, "src")
-from unittest.mock import MagicMock, AsyncMock
 
 from clauded.discord_renderer import _format_context_segment
+
+from tests.conftest import FakeBridge, FakeTarget  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -79,40 +80,6 @@ async def test_footer_includes_context_segment_e2e():
     from claude_agent_sdk.types import AssistantMessage, TextBlock, ResultMessage
     from clauded.discord_renderer import DiscordRenderer
 
-    class FakeBridge:
-        def __init__(self, events, ctx):
-            self._events = events
-            self.is_active = True
-            self._client = MagicMock()
-            self._ctx = ctx
-        async def send_message(self, _text):
-            for ev in self._events:
-                yield ev
-        async def get_context_usage(self):
-            return self._ctx
-
-    class FakeMessage:
-        def __init__(self):
-            self.content = ""
-            self.embeds = []
-        async def edit(self, **kwargs):
-            if "content" in kwargs:
-                self.content = kwargs["content"]
-            return self
-        async def delete(self):
-            return None
-
-    class FakeTarget:
-        def __init__(self):
-            self.id = 1
-            self._sent = []
-        async def send(self, *args, **kwargs):
-            msg = FakeMessage()
-            if "content" in kwargs:
-                msg.content = kwargs["content"]
-            self._sent.append(msg)
-            return msg
-
     events = [
         AssistantMessage(
             content=[TextBlock(text="response text")],
@@ -136,7 +103,7 @@ async def test_footer_includes_context_segment_e2e():
         "rawMaxTokens": 200000,
         "model": "claude-sonnet-4-5",
     }
-    bridge = FakeBridge(events, ctx_response)
+    bridge = FakeBridge(events, get_context_usage_returns=ctx_response)
     await renderer.render_response(bridge, "hello")
 
     # Collect all message content
@@ -154,39 +121,6 @@ async def test_footer_omits_context_segment_on_get_context_usage_failure():
     from claude_agent_sdk.types import AssistantMessage, TextBlock, ResultMessage
     from clauded.discord_renderer import DiscordRenderer
 
-    class FailingBridge:
-        is_active = True
-        _client = MagicMock()
-        def __init__(self, events):
-            self._events = events
-        async def send_message(self, _text):
-            for ev in self._events:
-                yield ev
-        async def get_context_usage(self):
-            raise RuntimeError("synthetic CLI failure")
-
-    class FakeMessage:
-        def __init__(self):
-            self.content = ""
-            self.embeds = []
-        async def edit(self, **kwargs):
-            if "content" in kwargs:
-                self.content = kwargs["content"]
-            return self
-        async def delete(self):
-            return None
-
-    class FakeTarget:
-        id = 1
-        def __init__(self):
-            self._sent = []
-        async def send(self, *args, **kwargs):
-            msg = FakeMessage()
-            if "content" in kwargs:
-                msg.content = kwargs["content"]
-            self._sent.append(msg)
-            return msg
-
     events = [
         AssistantMessage(
             content=[TextBlock(text="result")],
@@ -201,7 +135,9 @@ async def test_footer_omits_context_segment_on_get_context_usage_failure():
     ]
     target = FakeTarget()
     renderer = DiscordRenderer(target)
-    bridge = FailingBridge(events)
+    bridge = FakeBridge(
+        events, get_context_usage_raises=RuntimeError("synthetic CLI failure")
+    )
     # MUST NOT raise
     await renderer.render_response(bridge, "hello")
     all_content = " ".join(m.content for m in target._sent if m.content)
@@ -223,39 +159,6 @@ async def test_footer_omits_context_when_get_context_usage_returns_none():
     from claude_agent_sdk.types import AssistantMessage, TextBlock, ResultMessage
     from clauded.discord_renderer import DiscordRenderer
 
-    class NoneBridge:
-        is_active = True
-        _client = MagicMock()
-        def __init__(self, events):
-            self._events = events
-        async def send_message(self, _text):
-            for ev in self._events:
-                yield ev
-        async def get_context_usage(self):
-            return None
-
-    class FakeMessage:
-        def __init__(self):
-            self.content = ""
-            self.embeds = []
-        async def edit(self, **kwargs):
-            if "content" in kwargs:
-                self.content = kwargs["content"]
-            return self
-        async def delete(self):
-            return None
-
-    class FakeTarget:
-        id = 1
-        def __init__(self):
-            self._sent = []
-        async def send(self, *args, **kwargs):
-            msg = FakeMessage()
-            if "content" in kwargs:
-                msg.content = kwargs["content"]
-            self._sent.append(msg)
-            return msg
-
     events = [
         AssistantMessage(
             content=[TextBlock(text="result")],
@@ -270,7 +173,8 @@ async def test_footer_omits_context_when_get_context_usage_returns_none():
     ]
     target = FakeTarget()
     renderer = DiscordRenderer(target)
-    bridge = NoneBridge(events)
+    # Default: get_context_usage_returns=None (matches the old NoneBridge)
+    bridge = FakeBridge(events)
     await renderer.render_response(bridge, "hi")
     all_content = " ".join(m.content for m in target._sent if m.content)
     assert "🧠" not in all_content

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -186,7 +186,9 @@ def test_touch_heartbeat_no_longer_creates_parent(
     If the cache dir doesn't exist, _touch_heartbeat silently no-ops via OSError."""
     from clauded import bot as bot_mod
     cache_dir = tmp_path / "caches"  # deliberately NOT created
-    monkeypatch.setattr(bot_mod, "_CACHE_DIR", cache_dir)
+    # NOTE: only `_HEARTBEAT_PATH` is read by `_touch_heartbeat`. After
+    # the stage-28 trim moved `_CACHE_DIR` to `_logging_setup`, patching
+    # `bot._CACHE_DIR` had no effect here — dropped per R1 engineer.
     monkeypatch.setattr(bot_mod, "_HEARTBEAT_PATH", cache_dir / "heartbeat")
     monkeypatch.setattr(bot_mod.sys, "platform", "darwin")
     bot_mod._touch_heartbeat()

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -39,6 +39,10 @@ def test_configure_logging_without_pytest_env_attaches_rotating_handler(
 
     v1.18: _configure_logging no longer mkdirs; _ensure_runtime_dirs owns that.
     The test must pre-create the dir to match the new contract.
+
+    v1.18 stage-28: _LOG_DIR + _configure_logging now live in
+    ``clauded._logging_setup``; monkeypatch the source module so the
+    function reads our temp path.
     """
     _reset_root_logger()
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
@@ -47,9 +51,9 @@ def test_configure_logging_without_pytest_env_attaches_rotating_handler(
     # directly rather than Path.home (which only affects new resolutions).
     log_dir = tmp_path / "Library" / "Logs" / "clauded"
     log_dir.mkdir(parents=True)  # contract: _ensure_runtime_dirs would do this at startup
-    from clauded import bot as bot_mod
-    monkeypatch.setattr(bot_mod, "_LOG_DIR", log_dir)
-    bot_mod._configure_logging()
+    from clauded import _logging_setup as logging_mod
+    monkeypatch.setattr(logging_mod, "_LOG_DIR", log_dir)
+    logging_mod._configure_logging()
     root = logging.getLogger()
     rotating = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
     assert len(rotating) == 1, "production mode should add RotatingFileHandler"
@@ -67,15 +71,18 @@ def test_configure_logging_fallback_on_oserror(
     and falls back to basicConfig when absent. Previously this branch was
     tested by raising OSError on mkdir; now it's tested by simply pointing
     at a path that doesn't exist.
+
+    v1.18 stage-28: monkeypatch ``_logging_setup._LOG_DIR`` (the source
+    of truth post-extraction).
     """
     _reset_root_logger()
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     monkeypatch.setattr(sys, "platform", "darwin")
-    from clauded import bot as bot_mod
+    from clauded import _logging_setup as logging_mod
     # Path doesn't exist; _ensure_runtime_dirs() not called. _configure_logging
     # must fall back to basicConfig instead of crashing.
-    monkeypatch.setattr(bot_mod, "_LOG_DIR", tmp_path / "nonexistent")
-    bot_mod._configure_logging()  # should not raise
+    monkeypatch.setattr(logging_mod, "_LOG_DIR", tmp_path / "nonexistent")
+    logging_mod._configure_logging()  # should not raise
     root = logging.getLogger()
     rotating = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
     assert len(rotating) == 0, "missing _LOG_DIR should NOT attach RotatingFileHandler"
@@ -142,13 +149,18 @@ def test_ensure_runtime_dirs_creates_both_on_darwin(
 ) -> None:
     """`_ensure_runtime_dirs` creates `_LOG_DIR` AND `_CACHE_DIR` once at startup
     so subsequent `_touch_heartbeat` and `_configure_logging` calls don't redo
-    the mkdir per tick (engineer R2 mkdir-on-every-tick nit)."""
+    the mkdir per tick (engineer R2 mkdir-on-every-tick nit).
+
+    v1.18 stage-28: function + dirs moved to ``_logging_setup``; the
+    bot ``_HEARTBEAT_PATH`` binding still lives in ``bot.py``.
+    """
     from clauded import bot as bot_mod
-    monkeypatch.setattr(bot_mod, "_LOG_DIR", tmp_path / "logs")
-    monkeypatch.setattr(bot_mod, "_CACHE_DIR", tmp_path / "caches")
+    from clauded import _logging_setup as logging_mod
+    monkeypatch.setattr(logging_mod, "_LOG_DIR", tmp_path / "logs")
+    monkeypatch.setattr(logging_mod, "_CACHE_DIR", tmp_path / "caches")
     monkeypatch.setattr(bot_mod, "_HEARTBEAT_PATH", tmp_path / "caches" / "heartbeat")
-    monkeypatch.setattr(bot_mod.sys, "platform", "darwin")
-    bot_mod._ensure_runtime_dirs()
+    monkeypatch.setattr(logging_mod.sys, "platform", "darwin")
+    logging_mod._ensure_runtime_dirs()
     assert (tmp_path / "logs").is_dir()
     assert (tmp_path / "caches").is_dir()
 
@@ -157,11 +169,11 @@ def test_ensure_runtime_dirs_noop_on_non_darwin(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Linux/Windows dev box → no `~/Library/` pollution."""
-    from clauded import bot as bot_mod
-    monkeypatch.setattr(bot_mod, "_LOG_DIR", tmp_path / "logs")
-    monkeypatch.setattr(bot_mod, "_CACHE_DIR", tmp_path / "caches")
-    monkeypatch.setattr(bot_mod.sys, "platform", "linux")
-    bot_mod._ensure_runtime_dirs()
+    from clauded import _logging_setup as logging_mod
+    monkeypatch.setattr(logging_mod, "_LOG_DIR", tmp_path / "logs")
+    monkeypatch.setattr(logging_mod, "_CACHE_DIR", tmp_path / "caches")
+    monkeypatch.setattr(logging_mod.sys, "platform", "linux")
+    logging_mod._ensure_runtime_dirs()
     assert not (tmp_path / "logs").exists()
     assert not (tmp_path / "caches").exists()
 

--- a/tests/test_subtask_complete_render.py
+++ b/tests/test_subtask_complete_render.py
@@ -24,25 +24,12 @@ class _FakeMessage(FakeMessage):
         return _FakeThread(name=name)
 
 
-class _FakeBridge(FakeBridge):
-    pass
-
-
 class _FakeTarget(FakeTarget):
-    """Override send() to use _FakeMessage (the create-thread-aware subclass)."""
-    async def send(self, *args, **kwargs):
-        self._next_id += 1
-        msg = _FakeMessage(msg_id=self._next_id)
-        if "content" in kwargs:
-            msg.content = kwargs["content"]
-        if "embed" in kwargs:
-            msg.embeds = [kwargs["embed"]]
-        if "view" in kwargs:
-            msg.attached_view = kwargs["view"]
-        if "file" in kwargs:
-            msg.attachments = [kwargs["file"]]
-        self._sent.append(msg)
-        return msg
+    """Override message factory to mint _FakeMessage (the create-thread-
+    aware subclass). Uses the conftest._make_message hook — no need to
+    duplicate the entire send() body."""
+    def _make_message(self, msg_id):
+        return _FakeMessage(msg_id=msg_id)
 
 
 # ---------------------------------------------------------------------------
@@ -253,20 +240,10 @@ async def test_subtask_complete_renders_clean_text_from_list_of_dicts():
         ),
     ]
 
-    target = _FakeTarget()
-    renderer = DiscordRenderer(target)
-    await renderer.render_response(_FakeBridge(events), "run task")
-
-    # Embeds may have been sent to either the main target OR the sub-thread.
-    # Collect from both.
-    all_embeds = list(target._sent)
-    # Find the sub-thread (was created on _FakeMessage.create_thread)
-    # by walking through anchor messages
-    # Actually FakeMessage.create_thread returns FakeThread instances; collect their sent too.
-    # Simpler: also scan FakeThread instances via the renderer/subagent_renderers
-    # (those are not exposed). For this test, embeds we care about end up on the
-    # sub-thread via subagent_renderers[tool_id]._safe_send.
-    # Hack: monkey-patch FakeMessage.create_thread to record threads globally
+    # The first render builds embeds we never inspect; we re-run below
+    # with a monkey-patched create_thread so we can capture the spawned
+    # sub-threads (renderer doesn't expose subagent_renderers). Skip the
+    # first pass entirely (R1 simplicity flagged it as dead async work).
     threads_created: list[_FakeThread] = []
     orig_create = _FakeMessage.create_thread
     async def _record_create(self, name, **kw):
@@ -274,12 +251,11 @@ async def test_subtask_complete_renders_clean_text_from_list_of_dicts():
         threads_created.append(t)
         return t
 
-    # Re-run with patched create_thread
     _FakeMessage.create_thread = _record_create  # type: ignore[method-assign]
     try:
         target2 = _FakeTarget()
         renderer2 = DiscordRenderer(target2)
-        await renderer2.render_response(_FakeBridge(events), "run task")
+        await renderer2.render_response(FakeBridge(events), "run task")
     finally:
         _FakeMessage.create_thread = orig_create  # type: ignore[method-assign]
 
@@ -359,7 +335,7 @@ async def test_subtask_complete_normal_path_still_works():
     try:
         target = _FakeTarget()
         renderer = DiscordRenderer(target)
-        await renderer.render_response(_FakeBridge(events), "run task")
+        await renderer.render_response(FakeBridge(events), "run task")
     finally:
         _FakeMessage.create_thread = orig  # type: ignore[method-assign]
 
@@ -432,7 +408,7 @@ async def test_subtask_failed_with_list_of_dicts_renders_clean_error():
     try:
         target = _FakeTarget()
         renderer = DiscordRenderer(target)
-        await renderer.render_response(_FakeBridge(events), "run task")
+        await renderer.render_response(FakeBridge(events), "run task")
     finally:
         _FakeMessage.create_thread = orig  # type: ignore[method-assign]
 

--- a/tests/test_subtask_complete_render.py
+++ b/tests/test_subtask_complete_render.py
@@ -6,7 +6,43 @@ Fixes:
 - C: _is_async_agent_dispatch + new "🚀 Sub-agent dispatched" embed title
 """
 import pytest
-from unittest.mock import MagicMock
+
+# v1.18 stage-28: subclass the shared fakes (cheap base inheritance keeps
+# the dedup win while still letting us mutate _FakeMessage.create_thread
+# at the class level without touching tests/conftest.py for other files).
+# _FakeThread stays as a separate inline class — one-off shape (random id
+# + tracked _sent) used only by this file's create_thread monkey-patching.
+from tests.conftest import FakeBridge, FakeMessage, FakeTarget
+
+
+class _FakeMessage(FakeMessage):
+    """Test-local subclass so monkey-patching create_thread on _FakeMessage
+    (the prod-failure regression path) doesn't bleed into other tests
+    that import the shared FakeMessage. Default create_thread returns a
+    real _FakeThread (the original behavior before stage-28 trim)."""
+    async def create_thread(self, name, auto_archive_duration=None, **kwargs):
+        return _FakeThread(name=name)
+
+
+class _FakeBridge(FakeBridge):
+    pass
+
+
+class _FakeTarget(FakeTarget):
+    """Override send() to use _FakeMessage (the create-thread-aware subclass)."""
+    async def send(self, *args, **kwargs):
+        self._next_id += 1
+        msg = _FakeMessage(msg_id=self._next_id)
+        if "content" in kwargs:
+            msg.content = kwargs["content"]
+        if "embed" in kwargs:
+            msg.embeds = [kwargs["embed"]]
+        if "view" in kwargs:
+            msg.attached_view = kwargs["view"]
+        if "file" in kwargs:
+            msg.attachments = [kwargs["file"]]
+        self._sent.append(msg)
+        return msg
 
 
 # ---------------------------------------------------------------------------
@@ -153,26 +189,14 @@ def test_dispatch_detection_rejects_unrelated_text():
 # ---------------------------------------------------------------------------
 
 
-class _FakeMessage:
-    def __init__(self, msg_id=1):
-        self.id = msg_id
-        self.content = ""
-        self.embeds = []
-    async def edit(self, **kwargs):
-        if "content" in kwargs:
-            self.content = kwargs["content"]
-        if "embed" in kwargs:
-            self.embeds = [kwargs["embed"]]
-        return self
-    async def delete(self):
-        return None
-    async def create_thread(self, name, auto_archive_duration=None, **kwargs):
-        # Return a fake thread that has the necessary fields
-        return _FakeThread(name=name)
-
-
 class _FakeThread:
-    """Minimal thread stub for the Task tool path."""
+    """Minimal thread stub for the Task tool path.
+
+    Kept inline (not in conftest) because it's only consumed here as the
+    return value of monkey-patched ``_FakeMessage.create_thread``. The
+    random-id + per-thread ``_sent`` shape is not used by any other test
+    file.
+    """
     def __init__(self, name):
         import random
         self.id = random.randint(10_000, 99_999)
@@ -188,36 +212,6 @@ class _FakeThread:
             msg.embeds = [kwargs["embed"]]
         self._sent.append(msg)
         return msg
-
-
-class _FakeTarget:
-    """Top-level channel/thread stub for Sub-agent dispatch path."""
-    def __init__(self):
-        self.id = 1
-        self.name = "main-thread"
-        self.mention = "<#1>"
-        self.parent = None
-        self._sent = []
-    async def send(self, *args, **kwargs):
-        msg = _FakeMessage(msg_id=len(self._sent) + 1)
-        if "content" in kwargs:
-            msg.content = kwargs["content"]
-        if "embed" in kwargs:
-            msg.embeds = [kwargs["embed"]]
-        self._sent.append(msg)
-        return msg
-
-
-class _FakeBridge:
-    is_active = True
-    _client = MagicMock()
-    def __init__(self, events):
-        self._events = events
-    async def send_message(self, _text):
-        for ev in self._events:
-            yield ev
-    async def get_context_usage(self):
-        return None
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_result_shorttier.py
+++ b/tests/test_tool_result_shorttier.py
@@ -14,6 +14,11 @@ from __future__ import annotations
 
 import pytest
 
+# v1.18 stage-28: pulled-in shared fakes. Five inline copies collapsed
+# into a single import. ``FailingAddViewBot`` stays inline (test-local
+# customization of bot.add_view).
+from tests.conftest import FakeBridge, FakeTarget
+
 
 def test_bonus_bug_websearch_pattern_match():
     """Regression pin: WebSearch's rolling-log line starts with '🔄 🔍 query'.
@@ -127,46 +132,10 @@ async def test_short_tier_integration_via_render_response():
     """
     import sys
     sys.path.insert(0, "src")
-    from unittest.mock import MagicMock, AsyncMock
     from claude_agent_sdk.types import (
         AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
     )
     from clauded.discord_renderer import DiscordRenderer
-
-    class FakeBridge:
-        def __init__(self, events):
-            self._events = events
-            self.is_active = True
-            self._client = MagicMock()
-        async def send_message(self, text):
-            for ev in self._events:
-                yield ev
-
-    class FakeMessage:
-        def __init__(self):
-            self.content = ""
-            self.embeds = []
-        async def edit(self, **kwargs):
-            if "content" in kwargs:
-                self.content = kwargs["content"]
-            if "embed" in kwargs:
-                self.embeds = [kwargs["embed"]]
-            return self
-        async def delete(self):
-            return None
-
-    class FakeTarget:
-        def __init__(self):
-            self.id = 1
-            self._sent = []
-        async def send(self, *args, **kwargs):
-            msg = FakeMessage()
-            if "content" in kwargs:
-                msg.content = kwargs["content"]
-            if "embed" in kwargs:
-                msg.embeds = [kwargs["embed"]]
-            self._sent.append(msg)
-            return msg
 
     events = [
         AssistantMessage(
@@ -301,51 +270,10 @@ async def test_medium_tier_integration_attaches_view_button():
     """
     import sys
     sys.path.insert(0, "src")
-    from unittest.mock import MagicMock
     from claude_agent_sdk.types import (
         AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
     )
     from clauded.discord_renderer import DiscordRenderer, ToolResultsView
-
-    class FakeBridge:
-        def __init__(self, events):
-            self._events = events
-            self.is_active = True
-            self._client = MagicMock()
-        async def send_message(self, _text):
-            for ev in self._events:
-                yield ev
-
-    class FakeMessage:
-        def __init__(self):
-            self.content = ""
-            self.embeds = []
-            self.attached_view = None
-        async def edit(self, **kwargs):
-            if "content" in kwargs:
-                self.content = kwargs["content"]
-            if "embed" in kwargs:
-                self.embeds = [kwargs["embed"]]
-            if "view" in kwargs:
-                self.attached_view = kwargs["view"]
-            return self
-        async def delete(self):
-            return None
-
-    class FakeTarget:
-        def __init__(self):
-            self.id = 1
-            self._sent = []
-        async def send(self, *args, **kwargs):
-            msg = FakeMessage()
-            if "content" in kwargs:
-                msg.content = kwargs["content"]
-            if "embed" in kwargs:
-                msg.embeds = [kwargs["embed"]]
-            if "view" in kwargs:
-                msg.attached_view = kwargs["view"]
-            self._sent.append(msg)
-            return msg
 
     medium_content = "\n".join(f"line {i}: some output text here" for i in range(30))
     assert 200 <= len(medium_content) < 8000
@@ -586,54 +514,10 @@ async def test_medium_tier_registers_view_via_bot_add_view():
     test pins that call so a regression can't drop it."""
     import sys
     sys.path.insert(0, "src")
-    from unittest.mock import MagicMock
     from claude_agent_sdk.types import (
         AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
     )
     from clauded.discord_renderer import DiscordRenderer, ToolResultsView
-
-    class FakeBridge:
-        def __init__(self, events):
-            self._events = events
-            self.is_active = True
-            self._client = MagicMock()
-        async def send_message(self, _text):
-            for ev in self._events:
-                yield ev
-
-    class FakeMessage:
-        def __init__(self, msg_id=12345):
-            self.id = msg_id
-            self.content = ""
-            self.embeds = []
-            self.attached_view = None
-        async def edit(self, **kwargs):
-            if "content" in kwargs:
-                self.content = kwargs["content"]
-            if "embed" in kwargs:
-                self.embeds = [kwargs["embed"]]
-            if "view" in kwargs:
-                self.attached_view = kwargs["view"]
-            return self
-        async def delete(self):
-            return None
-
-    class FakeTarget:
-        def __init__(self):
-            self.id = 1
-            self._sent = []
-            self._next_id = 99000
-        async def send(self, *args, **kwargs):
-            self._next_id += 1
-            msg = FakeMessage(msg_id=self._next_id)
-            if "content" in kwargs:
-                msg.content = kwargs["content"]
-            if "embed" in kwargs:
-                msg.embeds = [kwargs["embed"]]
-            if "view" in kwargs:
-                msg.attached_view = kwargs["view"]
-            self._sent.append(msg)
-            return msg
 
     class FakeBot:
         """Captures add_view calls."""
@@ -688,54 +572,10 @@ async def test_medium_tier_downgrades_log_when_add_view_raises():
     button."""
     import sys
     sys.path.insert(0, "src")
-    from unittest.mock import MagicMock
     from claude_agent_sdk.types import (
         AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
     )
     from clauded.discord_renderer import DiscordRenderer
-
-    class FakeBridge:
-        def __init__(self, events):
-            self._events = events
-            self.is_active = True
-            self._client = MagicMock()
-        async def send_message(self, _text):
-            for ev in self._events:
-                yield ev
-
-    class FakeMessage:
-        def __init__(self, msg_id=999):
-            self.id = msg_id
-            self.content = ""
-            self.embeds = []
-            self.attached_view = None
-        async def edit(self, **kwargs):
-            if "content" in kwargs:
-                self.content = kwargs["content"]
-            if "embed" in kwargs:
-                self.embeds = [kwargs["embed"]]
-            if "view" in kwargs:
-                self.attached_view = kwargs["view"]
-            return self
-        async def delete(self):
-            return None
-
-    class FakeTarget:
-        def __init__(self):
-            self.id = 1
-            self._sent = []
-            self._next_id = 90000
-        async def send(self, *args, **kwargs):
-            self._next_id += 1
-            msg = FakeMessage(msg_id=self._next_id)
-            if "content" in kwargs:
-                msg.content = kwargs["content"]
-            if "embed" in kwargs:
-                msg.embeds = [kwargs["embed"]]
-            if "view" in kwargs:
-                msg.attached_view = kwargs["view"]
-            self._sent.append(msg)
-            return msg
 
     class FailingAddViewBot:
         def add_view(self, view, *, message_id=None):
@@ -787,50 +627,10 @@ async def test_medium_tier_log_line_index_matches_button_index():
     guess which #N corresponds to which line."""
     import sys
     sys.path.insert(0, "src")
-    from unittest.mock import MagicMock
     from claude_agent_sdk.types import (
         AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
     )
     from clauded.discord_renderer import DiscordRenderer, ToolResultsView
-
-    class FakeBridge:
-        def __init__(self, events):
-            self._events = events
-            self.is_active = True
-            self._client = MagicMock()
-        async def send_message(self, _text):
-            for ev in self._events:
-                yield ev
-
-    class FakeMessage:
-        def __init__(self, msg_id=999):
-            self.id = msg_id
-            self.content = ""
-            self.embeds = []
-            self.attached_view = None
-        async def edit(self, **kwargs):
-            if "embed" in kwargs:
-                self.embeds = [kwargs["embed"]]
-            if "view" in kwargs:
-                self.attached_view = kwargs["view"]
-            return self
-        async def delete(self):
-            return None
-
-    class FakeTarget:
-        def __init__(self):
-            self.id = 1
-            self._sent = []
-            self._next_id = 90000
-        async def send(self, *args, **kwargs):
-            self._next_id += 1
-            msg = FakeMessage(msg_id=self._next_id)
-            if "embed" in kwargs:
-                msg.embeds = [kwargs["embed"]]
-            if "view" in kwargs:
-                msg.attached_view = kwargs["view"]
-            self._sent.append(msg)
-            return msg
 
     # 3 medium-tier tool calls: Bash, Read, Bash
     medium_content_a = "\n".join(f"a{i}: data data data" for i in range(30))


### PR DESCRIPTION
chore: stage-28 trim — extract `_logging_setup.py` + dedup test fakes via `tests/conftest.py`.

## Approved PRD
`docs/prd/v1.18-stage28-trim.md` — self-approved per taskmaster directive 2026-05-14.

## What changed

### S1 — `_logging_setup.py` extraction
- New `src/clauded/_logging_setup.py` housing `_LOG_DIR`, `_CACHE_DIR`, `_ensure_runtime_dirs`, `_configure_logging`
- `bot.py` imports them; lost `RotatingFileHandler` / `basicConfig` references in bot.py
- `_HEARTBEAT_PATH` stays in `bot.py` (composed from re-imported `_CACHE_DIR`)

### S2 — test fakes dedup
- New `tests/conftest.py` with shared `FakeBridge` / `FakeMessage` / `FakeTarget`
- 4 test files migrated; `test_tool_result_shorttier.py` collapsed 5 inline copies → 1 import (biggest single win, −200 LOC)
- `test_subtask_complete_render.py` uses thin subclasses to keep its `create_thread` monkey-patch isolated

## Files (8 changed)
- `src/clauded/_logging_setup.py` (+87 new)
- `src/clauded/bot.py` (−53 net)
- `tests/conftest.py` (+113 new)
- `tests/test_api_error_render.py` (−37)
- `tests/test_context_footer.py` (−102)
- `tests/test_logging_setup.py` (+14, patch-target updates)
- `tests/test_subtask_complete_render.py` (−38)
- `tests/test_tool_result_shorttier.py` (−200)

## pytest
**682 / 0** (unchanged — pure refactor)

## Repo LOC
**−177 net**

No production behavior change. Status: 🚧 Draft — pending R1 review.
