### PR TITLE
fix(model): stop reading stored.model on resume; close #198 read-side leak (#210)

### DIFF
--- a/docs/prd/v1.18-fix-model-stored-read-side.md
+++ b/docs/prd/v1.18-fix-model-stored-read-side.md
@@ -1,0 +1,171 @@
+# PRD — Fix #198 read-side leak: stored model never injected as override (#210)
+
+**Status**: DRAFT (awaiting user approval before push)
+**Issue**: [#210](https://github.com/HXYerror/claudeD/issues/210)
+**Branch**: `fix/v1.18-model-stored-read-side`
+**Severity**: P0 (regression of #198 — proxied long-context conversations still broken on existing threads)
+
+---
+
+## Problem
+
+PR #199 closed #198 on the **write side only** (`save_session_state` stopped persisting non-user-explicit model values). The **read side** remained unchanged:
+
+- `bot.py:719,742` (thread auto-resume): `stored.get("model")` → `SessionConfig(model_override=...)`
+- `cogs/session.py:185-186` (`/session resume`): same pattern
+- Result: any existing thread with the old "sonnet" entry in `data/sessions.json` re-injects `"sonnet"` as `_model_override` on the next message → bridge forces sonnet → proxy hits 168k cap → the very bug #198 was meant to fix.
+
+Verified: all 10 thread entries in production `data/sessions.json` have `model="sonnet"`. #199's write-side fix only applies to *future* `ResultMessage` events; the existing pollution is permanent under read-side reinjection.
+
+## User intent (from DDD, 5/14)
+
+Verbatim:
+1. 用户设置了就用设置的
+2. 没设置就是 claude code 默认的
+3. 任何情况都要统一
+
+User clarified Q1 with: **"选项3，老字段别再用了，有污染"** — Option B (no cross-restart persistence) plus an explicit deprecation of the legacy `model` field on stored rows.
+
+Q4: **"没设置都显示真实的 claudecode model"** — `/session info` shows the SDK-reported live model (`bridge._sdk_model` after first turn), or a placeholder before first turn.
+
+## Goals
+
+1. **Drop `stored.get("model")` from read-side `model_override` injection** (both `bot.py` auto-resume and `cogs/session.py` `/session resume`). After this PR, `model_override` is fed from exactly two sources:
+   - Tier 1: env `CLAUDE_MODEL` (admin lock-in)
+   - Tier 2: user-explicit `/model switch` **within the bot process lifetime**
+   No other source. Cross-restart, the explicit override is intentionally lost — user re-runs `/model switch` if they want it.
+2. **Deprecate `model` field in `data/sessions.json`**:
+   - Write side: stop writing it. New saves omit the key (back-compat: existing readers tolerate missing key).
+   - Read side: never read it. Field becomes vestigial but not actively removed (avoids schema migration burden).
+   - One-shot startup migration logs how many legacy entries exist (for visibility), but does NOT mutate the file (preserves data for forensic purposes; reads ignore it regardless).
+3. **`/session info` model display reads `bridge._sdk_model`** (the SDK-observed model from the most recent `ResultMessage`). When no turn has run yet, show `"(unknown — send a message to discover)"` matching the #198 PRD's 4-case pattern at `/model current`.
+4. **Don't touch unrelated audit findings**: side bug 1 (cat_pct vs percentage basis) and side bug 2 (`/model current` pre-first-turn) are explicitly out of scope per the issue.
+
+## Non-goals
+
+- Schema migration of `data/sessions.json` (don't mutate user data; just stop reading the polluted field)
+- Cross-restart persistence of `/model switch` (user explicitly chose Option B/3 = ephemeral)
+- Cleaning up `cogs/model.py:_current_model_for_thread` pre-first-turn semantics
+- Re-architecting `SessionConfig.model_override` (it's still the right knob; just nothing else feeds it post-restart)
+
+## Design
+
+### Read-side: stop reading `stored.get("model")`
+
+`src/clauded/bot.py:716-742`. Current:
+```python
+stored = self.session_manager.get_stored_session(thread_id)
+resume_id = stored.get("session_id") if stored else None
+stored_model = stored.get("model") if stored else None      # ← DROP
+stored_prompt = stored.get("system_prompt") if stored else None
+...
+sc = SessionConfig(
+    system_prompt=stored_prompt or system_prompt,
+    model_override=stored_model,                              # ← becomes None
+    resume_session_id=resume_id,
+    ...
+)
+```
+
+Change to:
+```python
+stored = self.session_manager.get_stored_session(thread_id)
+resume_id = stored.get("session_id") if stored else None
+stored_prompt = stored.get("system_prompt") if stored else None
+# #210: deliberately do NOT read stored.get("model"). Legacy entries
+# may carry "sonnet" pollution from pre-#199 builds; reinjecting it
+# would re-force the sonnet override that #198 set out to fix.
+# Cross-restart `model_override` is intentionally ephemeral per user
+# intent ("没设置就是 claude code 默认的").
+...
+sc = SessionConfig(
+    system_prompt=stored_prompt or system_prompt,
+    model_override=None,                                       # ← always
+    resume_session_id=resume_id,
+    ...
+)
+```
+
+Same pattern at `src/clauded/cogs/session.py:184-189`.
+
+### Write-side: stop emitting `model` field
+
+`src/clauded/session_manager.py:107-113` `save_session_state` currently writes `model=bridge.explicit_model_override` (which is correct per #199 but becomes redundant after this PR — read side will never use it). Two options:
+
+- (a) Continue writing it; harmless since reads ignore the field
+- (b) Stop writing it (or write `None`); reduces wire schema noise
+
+**Decision**: (b) — pass `model=None` to `session_store.save_session`. The store's existing schema accommodates `None` (already supported by `SessionInfo.model: str | None`). This makes new rows clearly distinguished from polluted legacy rows during forensic inspection.
+
+### `/session info` display
+
+`src/clauded/cogs/session.py:148-167` currently reads `bridge.model` (collapsed property) when bridge is active; else falls back to stored info. After this PR:
+
+- Bridge active + `_sdk_model` set: show `_sdk_model` + `(SDK default)` suffix (matches `/model current` case 3 from #198 PRD)
+- Bridge active + `_sdk_model` None (pre-first-turn): show `"(unknown — send a message to discover)"`
+- Bridge inactive (or no bridge): show `"(unknown — send a message to discover)"` (no longer reading stored.model since it's deprecated)
+- User has `/model switch X` active: show `X` (user's explicit override; uses `bridge.explicit_model_override`)
+- `CLAUDE_MODEL` env set: show env value + `(CLAUDE_MODEL env)` suffix
+
+Reuse `_model_source_for_bridge` from `cogs/model.py` (already exists, 4-tier dispatch). Avoid copy-paste; import it.
+
+### Startup visibility log
+
+One-line: at `session_store` load time, count entries with non-null `model` and log info-level: `"#210: %d legacy stored.model entries ignored (deprecated field; not mutating)"`. Operator can see the legacy count shrinking over time as old entries naturally expire (1h idle GC).
+
+## Acceptance criteria
+
+### Behavioral (Core)
+- [ ] `data/sessions.json` row with `model="sonnet"` + user has not `/model switch`'d in this run → next message in that thread runs with `model_override=None` → `ClaudeAgentOptions` omits `model` → SDK uses CLI default (verified by mocking SDK and asserting `options.model is None`)
+- [ ] User runs `/model switch opus` → bridge has `_model_override="opus"`; subsequent `ResultMessage` works against opus
+- [ ] Bot restart → `_model_override` cleared → next message resumes session but lets SDK pick CLI default again (no sonnet pollution)
+- [ ] `/session resume` follows the same rule (model_override stays None regardless of stored.model)
+
+### `/session info` display
+- [ ] Bridge active + first turn completed → shows real model from `_sdk_model` with `(SDK default)` suffix
+- [ ] Bridge active + no turn yet → `"(unknown — send a message to discover)"`
+- [ ] Bridge inactive / no bridge → `"(unknown — send a message to discover)"`
+- [ ] User-explicit `/model switch X` → shows `X` (uses explicit_model_override accessor)
+
+### Migration / data
+- [ ] Existing `data/sessions.json` is NOT mutated (data preservation)
+- [ ] Startup log reports legacy-entry count (operator visibility)
+- [ ] New sessions saved post-PR have `model=None` (or key omitted) — confirmable by inspecting `data/sessions.json` after one new turn
+
+### Tests
+- [ ] Unit: `bot._handle_thread_message` flow when `stored.model="sonnet"` → SessionConfig built with `model_override=None` (mock get_stored_session to return polluted row; assert)
+- [ ] Unit: `cogs/session.py` `/session resume` flow same property
+- [ ] Unit: `save_session_state` writes `model=None` to store (mock session_store.save_session; assert kwarg)
+- [ ] Unit: `/session info` 4-case display matches the matrix above (4 tests)
+- [ ] Regression: existing `test_save_session_state_persists_only_explicit_override_no_sdk_loop` (#199 R1 architect test) still passes — write-side semantic preserved
+
+## Out of scope
+
+- Side bug 1 (cat_pct basis mismatch) — separate issue
+- Side bug 2 (`/model current` pre-first-turn) — already #198 design
+- Schema migration of legacy rows (per Goal #2 decision: read-side ignore is enough)
+- `/model switch` persistence across bot restart (user explicitly chose ephemeral)
+
+## Risks
+
+- **Operator surprise**: someone who was implicitly relying on stored.model = "sonnet" surviving bot restart will see their thread switch to CLI default after this PR. Mitigation: the issue body shows the user explicitly wants this behavior; document in PR description.
+- **Test fixture drift**: existing tests that build `SessionConfig(model_override=stored.get("model"))` in fixtures may need updates if they assert on the override being non-None. Audit during implementation.
+- **`bridge.model` collapsed property** still returns `_model_override or _sdk_model or _config.claude_model`. After this PR, `_model_override` is always None on read-side reinjection paths, so the property mostly returns `_sdk_model` for display. That's the desired behavior per Q4.
+
+## Plan
+
+Single coding agent, ≤15 min. 4 sub-tasks atomic in 1 PR.
+
+1. **S1** — `bot.py:716-742`: drop `stored_model` read; `model_override=None`. Add `# #210` comment explaining why.
+2. **S2** — `cogs/session.py:184-189`: same pattern in `/session resume`.
+3. **S3** — `session_manager.py:107-113`: change `model=bridge.explicit_model_override` to `model=None` in `save_session_state`.
+4. **S4** — `cogs/session.py:148-167`: `/session info` model display uses `_model_source_for_bridge` import from `cogs/model.py` (or duplicate the 4-case logic if circular import — agent to decide).
+5. **S5** — startup log line in `session_store.load_*` reporting legacy count.
+6. **S6** — Tests (5 acceptance buckets above).
+
+## Sign-off
+
+Awaiting user approval (Discord ping) before:
+- Spawning coding agent
+- Opening draft PR
+

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -716,7 +716,14 @@ class ClaudedBot(commands.Bot):
                     # Check for stored session to resume
                     stored = self.session_manager.get_stored_session(thread_id)
                     resume_id = stored.get("session_id") if stored else None
-                    stored_model = stored.get("model") if stored else None
+                    # #210: deliberately do NOT read stored.get("model").
+                    # Legacy entries may carry "sonnet" pollution from
+                    # pre-#199 builds; reinjecting it would re-force the
+                    # sonnet override that #198 set out to fix. Cross-restart
+                    # ``model_override`` is intentionally ephemeral per user
+                    # intent ("没设置就是 claude code 默认的"). The SDK falls
+                    # back to ~/.claude/settings.json (CLI default) when
+                    # model_override is None.
                     stored_prompt = stored.get("system_prompt") if stored else None
                     extra_dirs = self.project_manager.get_extra_dirs(parent_id)
                     mcp_servers = self.project_manager.get_mcp_servers(parent_id)
@@ -739,7 +746,7 @@ class ClaudedBot(commands.Bot):
                     _notify = self._notify_enabled.get(thread_id, self._pre_tool_notifications)
                     sc = SessionConfig(
                         system_prompt=stored_prompt or system_prompt,
-                        model_override=stored_model,
+                        model_override=None,  # #210: ephemeral; see note above
                         resume_session_id=resume_id,
                         on_ask_user=handler.handle_ask_user_question,
                         on_pre_tool_use=_pre_tool_notify_thread if _notify else None,

--- a/src/clauded/cogs/model.py
+++ b/src/clauded/cogs/model.py
@@ -202,7 +202,11 @@ async def model_current(interaction: discord.Interaction) -> None:
         desc = f"`{value}` (CLAUDE_MODEL env)"
     else:
         # source == "sdk" — observed from a ResultMessage post-first-turn.
-        desc = f"`{value}` (CLI default)"
+        # #210 R1 security: ``value`` originates in attacker-influenceable
+        # ``ResultMessage.model``; strip backticks + cap length before
+        # embedding in inline code fence (defense-in-depth).
+        safe_value = str(value).replace("`", "'")[:120]
+        desc = f"`{safe_value}` (CLI default)"
 
     embed = discord.Embed(
         title="🤖 Current Model",

--- a/src/clauded/cogs/session.py
+++ b/src/clauded/cogs/session.py
@@ -134,7 +134,22 @@ async def session_info(interaction: discord.Interaction) -> None:
         elif source == "env":
             model_display = f"`{value}` (CLAUDE_MODEL env)"
         elif source == "sdk":
-            model_display = f"`{value}` (SDK default)"
+            # #210 R1 syntax: label matches ``/model current`` ("CLI default")
+            # so the same logical value renders identically across both
+            # surfaces. Internals call this tier `sdk_model` because the
+            # value flows from ``ResultMessage.model``, but user-facing
+            # copy says "CLI default" (the value originally came from
+            # ~/.claude/settings.json via the SDK).
+            #
+            # #210 R1 security: ``value`` originates in
+            # ``ResultMessage.model``, which is attacker-influenceable
+            # (a malicious proxy could return backticks or pathological
+            # strings). Strip backticks + cap length before embedding
+            # in the inline code fence to prevent the fence from being
+            # broken open. Risk class is Discord rendering only (no
+            # XSS surface), so this is defense-in-depth.
+            safe_value = str(value).replace("`", "'")[:120]
+            model_display = f"`{safe_value}` (CLI default)"
         else:
             # source == "unset": bridge active but no _sdk_model yet
             model_display = _placeholder

--- a/src/clauded/cogs/session.py
+++ b/src/clauded/cogs/session.py
@@ -119,14 +119,29 @@ async def session_info(interaction: discord.Interaction) -> None:
         bot.session_manager.get_session(thread_id) if thread_id is not None else None
     )
     if bridge is not None and bridge.is_active:
-        # #198: bridge.model and bot.config.claude_model can both be None now
-        # (unset env + no override + pre-first-turn). Fall back to a
-        # human-readable placeholder for display.
-        model = bridge.model or bot.config.claude_model or "(SDK default)"
+        # #210: 4-case dispatch mirroring ``/model current`` (cogs/model.py).
+        # Reuse ``_model_source_for_bridge`` so the rendered model display
+        # accurately reflects which tier the value came from. Sibling-cog
+        # import is safe (no circular: cogs/model.py only imports from
+        # ..discord_renderer).
+        from .model import _model_source_for_bridge
+
+        source, value = _model_source_for_bridge(bridge)
+        _placeholder = "(unknown — send a message to discover)"
+        if source == "override":
+            # User ran /model switch X — show X with no suffix
+            model_display = f"`{value}`"
+        elif source == "env":
+            model_display = f"`{value}` (CLAUDE_MODEL env)"
+        elif source == "sdk":
+            model_display = f"`{value}` (SDK default)"
+        else:
+            # source == "unset": bridge active but no _sdk_model yet
+            model_display = _placeholder
         cost_str = f"${bridge.total_cost:.4f}" if bridge.total_cost else "$0.0000"
         lines = [
             f"📡 **Session active** — cwd `{bridge.project_path}`",
-            f"• Model: `{model}`",
+            f"• Model: {model_display}",
             f"• Turns: `{bridge.num_turns}`",
             f"• Total cost: `{cost_str}`",
         ]
@@ -181,9 +196,15 @@ async def session_resume(interaction: discord.Interaction) -> None:
     async with lock:
         await bot.session_manager.stop_session(thread_id)
         handler = InteractionHandler(interaction.channel)
+        # #210: deliberately do NOT read stored.get("model"). Legacy entries
+        # may carry "sonnet" pollution from pre-#199 builds; reinjecting it
+        # would re-force the sonnet override that #198 set out to fix.
+        # Cross-restart ``model_override`` is intentionally ephemeral per
+        # user intent ("没设置就是 claude code 默认的"). The SDK falls back
+        # to ~/.claude/settings.json (CLI default) when model_override is None.
         sc = SessionConfig(
             system_prompt=stored.get("system_prompt"),
-            model_override=stored.get("model"),
+            model_override=None,  # #210: ephemeral; see note above
             on_ask_user=handler.handle_ask_user_question,
             resume_session_id=stored["session_id"],
         )

--- a/src/clauded/session_manager.py
+++ b/src/clauded/session_manager.py
@@ -100,15 +100,23 @@ class SessionManager:
         ``bridge.model`` property. The collapsed property includes
         ``_sdk_model`` (what the SDK reported back), and persisting it
         would lock future resumes onto the SDK-observed value even after
-        the user edits ``~/.claude/settings.json``. Persist ``None`` when
-        the user has not switched — resume will then let the SDK pick
-        the CLI default again.
+        the user edits ``~/.claude/settings.json``.
+
+        #210: After the read-side stopped reading ``stored.get("model")``
+        (see ``bot.py`` thread-resume and ``cogs/session.py`` /session
+        resume), the persisted ``model`` field is purely vestigial — it
+        is never consumed. To keep new rows clearly distinguishable from
+        legacy "sonnet"-polluted rows during forensic inspection, we now
+        always write ``model=None`` regardless of the explicit override.
+        ``/model switch`` is intentionally ephemeral per user intent;
+        cross-restart, the user re-runs ``/model switch`` if they want
+        it again.
         """
         bridge = self._sessions.get(thread_id)
         if bridge and bridge.session_id:
             self._session_store.save_session(
                 thread_id, bridge.session_id, bridge.project_path,
-                model=bridge.explicit_model_override,
+                model=None,  # #210: ephemeral; read-side ignores this field
                 system_prompt=bridge.system_prompt,
             )
 

--- a/src/clauded/session_store.py
+++ b/src/clauded/session_store.py
@@ -28,6 +28,22 @@ class SessionStore:
         except (json.JSONDecodeError, OSError):
             log.warning("Failed to load sessions.json, starting fresh")
             self._sessions = {}
+        # #210: count legacy rows with a non-null ``model`` field for
+        # operator visibility. The field is deprecated as of v1.18 — read
+        # paths ignore it and write paths emit None. We do NOT mutate the
+        # file here (forensic preservation); the count naturally shrinks
+        # as old entries are overwritten or expire via the 1h idle GC.
+        legacy_count = sum(
+            1
+            for v in self._sessions.values()
+            if isinstance(v, dict) and v.get("model") is not None
+        )
+        if legacy_count:
+            log.info(
+                "#210: %d legacy stored.model entries ignored "
+                "(deprecated field; not mutating data)",
+                legacy_count,
+            )
 
     def _save(self) -> None:
         self._dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_model_default.py
+++ b/tests/test_model_default.py
@@ -502,8 +502,21 @@ def test_save_session_state_persists_only_explicit_override_no_sdk_loop():
 
 
 def test_save_session_state_persists_user_override_when_set():
-    """Positive case: when user has switched to 'opus', persistence
-    correctly carries that across restart."""
+    """#210 update: ``/model switch`` is intentionally ephemeral.
+
+    Pre-#210 contract: persistence carried the user-explicit override
+    across restart so resume would re-inject it.
+
+    Post-#210 contract: the read side stopped reading ``stored.model``
+    (see ``bot.py`` thread auto-resume and ``cogs/session.py`` /session
+    resume). Persisting the override would therefore be dead weight,
+    and would also blur the line between new rows (clean) and legacy
+    "sonnet"-polluted rows during forensic inspection. New rows now
+    always carry ``model=None`` regardless of whether the user has
+    switched. Users intentionally re-run ``/model switch`` after
+    restart if they want a non-default model — per user decision in
+    DDD ("没设置就是 claude code 默认的").
+    """
     from unittest.mock import MagicMock
     from clauded.session_manager import SessionManager
 
@@ -524,4 +537,6 @@ def test_save_session_state_persists_user_override_when_set():
     sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
     sm.save_session_state(99)
 
-    assert captured["model"] == "opus"
+    # #210: always None — model_override is ephemeral, no cross-restart
+    # persistence even when the user has explicitly switched.
+    assert captured["model"] is None

--- a/tests/test_model_stored_readside.py
+++ b/tests/test_model_stored_readside.py
@@ -393,7 +393,7 @@ async def test_session_info_case_override() -> None:
     body = await _invoke_session_info(bridge)
     assert "haiku" in body
     assert "CLAUDE_MODEL env" not in body
-    assert "SDK default" not in body
+    assert "CLI default" not in body
     assert "unknown" not in body.lower()
 
 
@@ -408,13 +408,18 @@ async def test_session_info_case_env() -> None:
 
 @pytest.mark.asyncio
 async def test_session_info_case_sdk_observed() -> None:
-    """No override, no env, _sdk_model set → ``<value> (SDK default)``."""
+    """No override, no env, _sdk_model set → ``<value> (CLI default)``.
+
+    Label parity with ``/model current`` per #213 R1 syntax review:
+    both surfaces render the same SDK-observed value as ``CLI default``
+    (since the value flows from ~/.claude/settings.json via the SDK).
+    """
     bridge = _bridge_for_case(
         override=None, env_model=None, sdk_model="claude-sonnet-4-5"
     )
     body = await _invoke_session_info(bridge)
     assert "claude-sonnet-4-5" in body
-    assert "SDK default" in body
+    assert "CLI default" in body
 
 
 @pytest.mark.asyncio
@@ -600,3 +605,67 @@ def test_regression_199_r1_no_sdk_loop_still_holds() -> None:
     assert captured["model"] != bridge._sdk_model
     # The #210 strengthening: model is None
     assert captured["model"] is None
+
+
+@pytest.mark.asyncio
+async def test_session_info_strips_backticks_in_sdk_model_attacker_string() -> None:
+    """R1 security hardening: ``_sdk_model`` flows from
+    ``ResultMessage.model`` which is attacker-influenceable. A malicious
+    proxy returning a model name containing backticks could break the
+    inline code fence in the embed and let downstream markdown leak.
+    Defense-in-depth: strip backticks + cap length before embedding.
+    """
+    # Synthetic attacker model name: contains backticks + is long
+    malicious = "evil`escape`-" + ("x" * 500)
+    bridge = _bridge_for_case(
+        override=None, env_model=None, sdk_model=malicious
+    )
+    body = await _invoke_session_info(bridge)
+    # 1) Backticks inside the value MUST be stripped (replaced by ')
+    # The body still contains the OUTER pair from the f"`{safe_value}`"
+    # template, but the inner attacker-controlled backticks are gone.
+    # Extract just the value between the first ` and the matching `:
+    import re
+    match = re.search(r"Model:\s*`([^`]*)`", body)
+    assert match is not None, f"Expected `Model: \\`...\\`` format; got: {body!r}"
+    rendered_value = match.group(1)
+    assert "`" not in rendered_value, (
+        f"Backticks leaked through inline code fence; got: {rendered_value!r}"
+    )
+    # 2) Length capped (we use [:120])
+    assert len(rendered_value) <= 120
+    # 3) The (CLI default) suffix still renders after the cleaned value
+    assert "(CLI default)" in body
+
+
+@pytest.mark.asyncio
+async def test_model_current_strips_backticks_in_sdk_model_attacker_string() -> None:
+    """Same security hardening on ``/model current``'s sdk-observed branch.
+    Both surfaces share the parity contract from R1 syntax + same
+    attacker-influenceable input."""
+    from clauded.cogs.model import model_current
+    from clauded.bot import ClaudedBot
+
+    malicious = "evil`escape`-" + ("x" * 500)
+    bot_spec = MagicMock(spec=ClaudedBot)
+    bot_spec.session_manager = MagicMock()
+    bridge = MagicMock()
+    bridge._model_override = None
+    bridge._sdk_model = malicious
+    bridge._config = MagicMock(claude_model=None)
+    bot_spec.session_manager.get_session = MagicMock(return_value=bridge)
+    interaction = MagicMock()
+    interaction.client = bot_spec
+    interaction.channel.id = 1
+    interaction.response.send_message = AsyncMock()
+    await model_current.callback(interaction)
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    desc = embed.description
+    # Extract value between the inline-code-fence backticks
+    import re
+    match = re.search(r"`([^`]*)`", desc)
+    assert match is not None
+    rendered_value = match.group(1)
+    assert "`" not in rendered_value
+    assert len(rendered_value) <= 120
+    assert "(CLI default)" in desc

--- a/tests/test_model_stored_readside.py
+++ b/tests/test_model_stored_readside.py
@@ -1,0 +1,602 @@
+"""#210 — read-side leak fix: stored.model never injected as model_override.
+
+Pins the contract from ``docs/prd/v1.18-fix-model-stored-read-side.md``:
+
+1. **Read side**: ``bot._handle_thread_message`` and ``/session resume``
+   both BUILD ``SessionConfig`` with ``model_override=None`` regardless
+   of what ``stored.get("model")`` contains. Pre-#210, both paths read
+   ``stored["model"]`` and reinjected it — re-forcing the "sonnet"
+   pollution from pre-#199 builds and re-triggering the very bug #198
+   was meant to fix.
+
+2. **Write side**: ``SessionManager.save_session_state`` always writes
+   ``model=None`` to the store (decision (b) per PRD §Design — keeps
+   new rows clearly distinguishable from legacy "sonnet"-polluted ones
+   during forensic inspection).
+
+3. **/session info** uses ``_model_source_for_bridge`` from
+   ``cogs.model`` for accurate 4-case display.
+
+4. **Startup log**: ``SessionStore._load`` reports a count of legacy
+   stored.model entries for operator visibility (does NOT mutate data).
+
+5. **Integration**: a polluted stored row + no user ``/model switch``
+   ends up with ``ClaudeAgentOptions(model=None)`` — same shape as
+   ``test_options_does_not_use_sdk_model_as_input`` from #198.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from clauded.config import Config
+from clauded.session_config import SessionConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _config(claude_model: str | None = None) -> Config:
+    """Build a Config with the given claude_model env tier value."""
+    return Config(
+        discord_bot_token="tok",
+        claude_model=claude_model,
+        claude_permission_mode="default",
+        projects_root="/tmp",
+    )
+
+
+class _FakeClient:
+    """Stand-in for ``ClaudeSDKClient`` that records constructed options."""
+
+    captured_options: list[Any] = []
+
+    def __init__(self, options: Any = None) -> None:
+        type(self).captured_options.append(options)
+
+    async def connect(self, prompt: Any = None) -> None:
+        pass
+
+    async def disconnect(self) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_capture() -> None:
+    _FakeClient.captured_options = []
+
+
+def _bridge_for_case(
+    *,
+    override: str | None,
+    env_model: str | None,
+    sdk_model: str | None,
+    active: bool = True,
+    project_path: str = "/tmp/proj",
+    num_turns: int = 1,
+    total_cost: float = 0.0,
+) -> Any:
+    """Build a MagicMock bridge with the requested tier values."""
+    bridge = MagicMock()
+    bridge._model_override = override
+    bridge._sdk_model = sdk_model
+    cfg = MagicMock()
+    cfg.claude_model = env_model
+    bridge._config = cfg
+    bridge.model = override or sdk_model or env_model
+    bridge.is_active = active
+    bridge.project_path = project_path
+    bridge.num_turns = num_turns
+    bridge.total_cost = total_cost
+    return bridge
+
+
+# ---------------------------------------------------------------------------
+# S1 — bot._handle_thread_message: model_override forced to None
+#       regardless of stored.get("model").
+# ---------------------------------------------------------------------------
+
+
+class _BotStub:
+    """Bypasses full ClaudedBot __init__ for handler-isolation tests."""
+
+    def __init__(self, *, stored: dict | None) -> None:
+        self._user = MagicMock(id=42, name="ClaudeBot")
+        self._user.name = "ClaudeBot"
+        self.allow_unbound_fallback = False
+        self.config = _config(claude_model=None)
+        # Project manager — parent channel is bound, system prompt empty
+        from pathlib import Path
+        self.project_manager = MagicMock()
+        self.project_manager.is_bound = MagicMock(return_value=True)
+        self.project_manager.should_refuse_unbound = MagicMock(return_value=False)
+        self.project_manager.get_path_or_default = MagicMock(
+            return_value=(Path("/tmp"), True)
+        )
+        self.project_manager.get_system_prompt = MagicMock(return_value="")
+        self.project_manager.get_extra_dirs = MagicMock(return_value=[])
+        self.project_manager.get_mcp_servers = MagicMock(return_value=None)
+        self.project_manager.get_env = MagicMock(return_value=None)
+        # Session manager — bridge None so the create path runs
+        self.session_manager = MagicMock()
+        self.session_manager.get_session = MagicMock(return_value=None)
+        self.session_manager.get_stored_session = MagicMock(return_value=stored)
+        self.session_manager.create_session = AsyncMock()
+        self.session_manager.get_lock = MagicMock(return_value=MagicMock(
+            __aenter__=AsyncMock(), __aexit__=AsyncMock()
+        ))
+        self._logged_third_party_thread: set[int] = set()
+        self._pre_tool_notifications: bool = False
+        self._notify_enabled: dict[int, bool] = {}
+
+    @property
+    def user(self) -> Any:
+        return self._user
+
+
+def _make_thread_message(
+    *, thread_id: int = 9999, parent_id: int = 1234, bot_id: int = 42
+) -> Any:
+    """Construct a bot-owned thread message (no @-mention required)."""
+    msg = MagicMock()
+
+    class _FakeThread(discord.Thread):
+        def __init__(self) -> None:
+            pass
+
+    thread = _FakeThread()
+    object.__setattr__(thread, "id", thread_id)
+    object.__setattr__(thread, "owner_id", bot_id)  # bot-owned: skip mention gate
+    object.__setattr__(thread, "parent_id", parent_id)
+    msg.channel = thread
+    msg.id = 8888
+    msg.content = "hello"
+    msg.author = MagicMock()
+    msg.author.id = 1
+    msg.author.__str__ = MagicMock(return_value="alice")
+    msg.mentions = []
+    msg.role_mentions = []
+    msg.reply = AsyncMock()
+    return msg
+
+
+@pytest.mark.asyncio
+async def test_thread_resume_ignores_polluted_stored_model() -> None:
+    """#210 core: a polluted stored row with model='sonnet' must NOT
+    feed model_override on auto-resume. The SessionConfig passed to
+    create_session has model_override=None.
+    """
+    from clauded.bot import ClaudedBot
+
+    polluted = {
+        "session_id": "sess-old",
+        "project_path": "/tmp",
+        "model": "sonnet",  # legacy pollution
+        "system_prompt": "",
+        "last_active": "2025-01-01T00:00:00+00:00",
+    }
+    bot = _BotStub(stored=polluted)
+    msg = _make_thread_message()
+
+    # The handler will try to compose user text + render after creating
+    # the session; we only care about the create_session call. Let it
+    # raise downstream and swallow.
+    bot._compose_user_text = AsyncMock(return_value=("hello", None))
+    try:
+        await ClaudedBot._handle_thread_message(bot, msg, parent_id=1234)
+    except Exception:
+        pass
+
+    # The contract we're pinning: SessionConfig.model_override is None
+    # regardless of the polluted stored.model value.
+    assert bot.session_manager.create_session.await_count >= 1, (
+        "create_session was never called — handler bailed before "
+        "constructing SessionConfig"
+    )
+    call = bot.session_manager.create_session.await_args_list[0]
+    sc = call.args[3]  # (thread_id, project_path, config, session_config)
+    assert isinstance(sc, SessionConfig)
+    assert sc.model_override is None, (
+        f"#210: stored.model='sonnet' leaked into SessionConfig as "
+        f"model_override={sc.model_override!r}. Pre-#210 regression."
+    )
+    # Sanity: resume_session_id is still threaded through (we still
+    # resume; we just don't reinject the model).
+    assert sc.resume_session_id == "sess-old"
+
+
+@pytest.mark.asyncio
+async def test_thread_resume_no_stored_session_also_yields_none() -> None:
+    """Defensive: even with no stored row at all, model_override is
+    None (i.e., the change doesn't accidentally regress the no-resume
+    path)."""
+    from clauded.bot import ClaudedBot
+
+    bot = _BotStub(stored=None)
+    msg = _make_thread_message()
+    bot._compose_user_text = AsyncMock(return_value=("hello", None))
+    try:
+        await ClaudedBot._handle_thread_message(bot, msg, parent_id=1234)
+    except Exception:
+        pass
+
+    call = bot.session_manager.create_session.await_args_list[0]
+    sc = call.args[3]
+    assert sc.model_override is None
+    assert sc.resume_session_id is None
+
+
+# ---------------------------------------------------------------------------
+# S2 — /session resume: model_override forced to None.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_resume_ignores_polluted_stored_model() -> None:
+    """/session resume must NOT reinject stored.model as model_override."""
+    from clauded.cogs.session import session_resume
+    from clauded.bot import ClaudedBot
+
+    polluted = {
+        "session_id": "sess-old",
+        "project_path": "/tmp",
+        "model": "sonnet",  # legacy pollution
+        "system_prompt": "",
+    }
+
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_stored_session = MagicMock(return_value=polluted)
+    bot.session_manager.stop_session = AsyncMock()
+    bot.session_manager.create_session = AsyncMock()
+    bot.session_manager.get_lock = MagicMock(return_value=MagicMock(
+        __aenter__=AsyncMock(), __aexit__=AsyncMock()
+    ))
+    bot.config = _config(claude_model=None)
+
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel_id = 9999
+    interaction.channel = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+
+    # Bypass the unbound-channel gate
+    import clauded.cogs.session as session_mod
+    session_mod.reject_if_unbound = AsyncMock(return_value=False)
+
+    await session_resume.callback(interaction)
+
+    assert bot.session_manager.create_session.await_count == 1
+    call = bot.session_manager.create_session.await_args
+    sc = call.args[3]
+    assert isinstance(sc, SessionConfig)
+    assert sc.model_override is None, (
+        f"#210: /session resume leaked stored.model='sonnet' as "
+        f"model_override={sc.model_override!r}"
+    )
+    assert sc.resume_session_id == "sess-old"
+
+
+# ---------------------------------------------------------------------------
+# S3 — save_session_state writes model=None.
+# ---------------------------------------------------------------------------
+
+
+def test_save_session_state_always_writes_none() -> None:
+    """#210: save_session_state passes model=None to the store regardless
+    of explicit_model_override (the field is deprecated/vestigial)."""
+    from clauded.session_manager import SessionManager
+
+    # Even when the user HAS set an explicit override, we don't persist
+    # it — model_override is ephemeral per user decision.
+    bridge = MagicMock()
+    bridge.session_id = "sess-abc"
+    bridge.project_path = "/tmp/proj"
+    bridge.system_prompt = ""
+    bridge.explicit_model_override = "haiku"  # user has /model switch'd
+    bridge._sdk_model = "claude-sonnet-4-5"  # SDK reported sonnet
+
+    sm = SessionManager(MagicMock())
+    sm._sessions[42] = bridge
+
+    captured: dict = {}
+
+    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None):
+        captured.update(
+            thread_id=thread_id, session_id=session_id,
+            project_path=project_path, model=model,
+            system_prompt=system_prompt,
+        )
+
+    sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
+    sm.save_session_state(42)
+
+    assert captured["model"] is None, (
+        f"#210: save_session_state must always write model=None; got "
+        f"{captured['model']!r}. The persistence-field is deprecated; "
+        f"read paths ignore it; new rows must be clean."
+    )
+    # Cross-check that the rest of the kwargs are still threaded through.
+    assert captured["session_id"] == "sess-abc"
+    assert captured["project_path"] == "/tmp/proj"
+
+
+def test_save_session_state_writes_none_when_no_user_override() -> None:
+    """No user /model switch → model=None (was already the case in #199,
+    but pin it explicitly under #210 as well)."""
+    from clauded.session_manager import SessionManager
+
+    bridge = MagicMock()
+    bridge.session_id = "sess-xyz"
+    bridge.project_path = "/tmp/proj"
+    bridge.system_prompt = ""
+    bridge.explicit_model_override = None
+    bridge._sdk_model = "claude-sonnet-4-5"
+
+    sm = SessionManager(MagicMock())
+    sm._sessions[99] = bridge
+
+    captured: dict = {}
+
+    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None):
+        captured["model"] = model
+
+    sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
+    sm.save_session_state(99)
+    assert captured["model"] is None
+
+
+# ---------------------------------------------------------------------------
+# S4 — /session info 4-case display matrix.
+# ---------------------------------------------------------------------------
+
+
+async def _invoke_session_info(bridge: Any) -> str:
+    """Drive ``/session info`` with the given bridge; return the sent text."""
+    from clauded.cogs.session import session_info
+    from clauded.bot import ClaudedBot
+
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=bridge)
+    bot.config = _config(claude_model=None)
+
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel_id = 1
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    await session_info.callback(interaction)
+
+    # Body sent positionally; ephemeral kwarg set, but message text is args[0]
+    call = interaction.response.send_message.await_args
+    return call.args[0]
+
+
+@pytest.mark.asyncio
+async def test_session_info_case_override() -> None:
+    """User /model switch X → shows X without env/SDK suffix."""
+    bridge = _bridge_for_case(override="haiku", env_model=None, sdk_model=None)
+    body = await _invoke_session_info(bridge)
+    assert "haiku" in body
+    assert "CLAUDE_MODEL env" not in body
+    assert "SDK default" not in body
+    assert "unknown" not in body.lower()
+
+
+@pytest.mark.asyncio
+async def test_session_info_case_env() -> None:
+    """CLAUDE_MODEL=opus → ``opus (CLAUDE_MODEL env)``."""
+    bridge = _bridge_for_case(override=None, env_model="opus", sdk_model=None)
+    body = await _invoke_session_info(bridge)
+    assert "opus" in body
+    assert "CLAUDE_MODEL env" in body
+
+
+@pytest.mark.asyncio
+async def test_session_info_case_sdk_observed() -> None:
+    """No override, no env, _sdk_model set → ``<value> (SDK default)``."""
+    bridge = _bridge_for_case(
+        override=None, env_model=None, sdk_model="claude-sonnet-4-5"
+    )
+    body = await _invoke_session_info(bridge)
+    assert "claude-sonnet-4-5" in body
+    assert "SDK default" in body
+
+
+@pytest.mark.asyncio
+async def test_session_info_case_unset_placeholder() -> None:
+    """Bridge active + nothing set + pre-first-turn → placeholder."""
+    bridge = _bridge_for_case(override=None, env_model=None, sdk_model=None)
+    body = await _invoke_session_info(bridge)
+    assert "unknown" in body.lower()
+    assert "send a message" in body.lower()
+
+
+@pytest.mark.asyncio
+async def test_session_info_no_bridge() -> None:
+    """No bridge at all → "No active Claude session" reply (unchanged)."""
+    from clauded.cogs.session import session_info
+    from clauded.bot import ClaudedBot
+
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=None)
+
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel_id = 1
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    await session_info.callback(interaction)
+    body = interaction.response.send_message.await_args.args[0]
+    assert "No active" in body
+
+
+# ---------------------------------------------------------------------------
+# S5 — Startup legacy-entry count log.
+# ---------------------------------------------------------------------------
+
+
+def test_session_store_logs_legacy_model_count(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """SessionStore._load reports the number of rows with non-null model.
+    The file is NOT mutated."""
+    from clauded.session_store import SessionStore
+
+    payload = {
+        "1": {"session_id": "a", "project_path": "/p", "model": "sonnet",
+              "system_prompt": "", "last_active": "x"},
+        "2": {"session_id": "b", "project_path": "/p", "model": "opus",
+              "system_prompt": "", "last_active": "x"},
+        "3": {"session_id": "c", "project_path": "/p", "model": None,
+              "system_prompt": "", "last_active": "x"},
+    }
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    sessions_path = data_dir / "sessions.json"
+    sessions_path.write_text(json.dumps(payload))
+
+    snapshot_before = sessions_path.read_text()
+    with caplog.at_level(logging.INFO, logger="clauded.session_store"):
+        store = SessionStore(data_dir=str(data_dir))
+
+    # 2 of the 3 entries have non-null model
+    matches = [r for r in caplog.records if "#210" in r.getMessage()]
+    assert matches, "expected one #210 legacy-count INFO log"
+    msg = matches[0].getMessage()
+    assert "2 legacy" in msg, f"got: {msg!r}"
+    # Forensic-preserving: file is byte-identical to before
+    assert sessions_path.read_text() == snapshot_before
+    # And the entries are still loaded (read path is unaffected)
+    assert store.get_session_info(1) == payload["1"]
+
+
+def test_session_store_no_legacy_no_log(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """All rows clean (model=None) → no #210 log emitted."""
+    from clauded.session_store import SessionStore
+
+    payload = {
+        "1": {"session_id": "a", "project_path": "/p", "model": None,
+              "system_prompt": "", "last_active": "x"},
+    }
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "sessions.json").write_text(json.dumps(payload))
+
+    with caplog.at_level(logging.INFO, logger="clauded.session_store"):
+        SessionStore(data_dir=str(data_dir))
+
+    assert not [r for r in caplog.records if "#210" in r.getMessage()]
+
+
+def test_session_store_missing_file_no_log(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No sessions.json at all → no #210 log, no crash."""
+    from clauded.session_store import SessionStore
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    with caplog.at_level(logging.INFO, logger="clauded.session_store"):
+        SessionStore(data_dir=str(data_dir))
+    assert not [r for r in caplog.records if "#210" in r.getMessage()]
+
+
+# ---------------------------------------------------------------------------
+# S6 — Integration: polluted stored row + no user switch =>
+#       ClaudeAgentOptions(model=None) (same shape as #198's
+#       test_options_does_not_use_sdk_model_as_input).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_integration_polluted_stored_yields_options_model_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: polluted stored row + no user override →
+    SessionConfig(model_override=None) →
+    ClaudeBridge.start() constructs ClaudeAgentOptions(model=None).
+
+    This mirrors ``test_options_does_not_use_sdk_model_as_input`` from
+    #198 but ties it to the read-side path that #210 fixed.
+    """
+    from clauded.claude_bridge import ClaudeBridge
+
+    monkeypatch.setattr("clauded.claude_bridge.ClaudeSDKClient", _FakeClient)
+
+    # Construct the SessionConfig as the post-#210 read path would
+    # (stored.model="sonnet" is ignored).
+    sc = SessionConfig(
+        system_prompt="",
+        model_override=None,  # #210: ephemeral, NOT stored["model"]
+        resume_session_id="sess-old",
+    )
+    bridge = ClaudeBridge(
+        project_path="/tmp/p", config=_config(claude_model=None),
+        session_config=sc,
+    )
+    await bridge.start()
+
+    assert _FakeClient.captured_options, "ClaudeAgentOptions was not built"
+    opts = _FakeClient.captured_options[-1]
+    assert opts.model is None, (
+        f"#210 integration: SDK options.model leaked to {opts.model!r}. "
+        f"Polluted stored.model='sonnet' must NOT reach the SDK."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression: #199 R1 architect contract still holds.
+# ---------------------------------------------------------------------------
+
+
+def test_regression_199_r1_no_sdk_loop_still_holds() -> None:
+    """Re-pin the #199 R1 architect contract under the #210 update:
+    save_session_state must NOT persist _sdk_model. With #210 going
+    further (always None), this is now strictly stronger — we never
+    persist anything for the model field — but the original assertion
+    (no _sdk_model leak) must still hold.
+    """
+    from clauded.session_manager import SessionManager
+
+    bridge = MagicMock()
+    bridge.session_id = "sess-abc"
+    bridge.project_path = "/tmp/proj"
+    bridge.system_prompt = ""
+    bridge._model_override = None
+    bridge._sdk_model = "claude-haiku-4-5"
+    bridge.explicit_model_override = None
+
+    sm = SessionManager(MagicMock())
+    sm._sessions[42] = bridge
+
+    captured: dict = {}
+
+    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None):
+        captured["model"] = model
+
+    sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
+    sm.save_session_state(42)
+
+    # The #199 invariant: model is NOT _sdk_model
+    assert captured["model"] != bridge._sdk_model
+    # The #210 strengthening: model is None
+    assert captured["model"] is None


### PR DESCRIPTION
Closes #210 (P0).

## Approved PRD
`docs/prd/v1.18-fix-model-stored-read-side.md` — DDD 5/14 user-approved.

## Bug
PR #199 closed #198 on the **write side only**. The read paths kept loading the polluted `stored.model="sonnet"` from pre-#199 sessions and injecting it as `_model_override` → re-forces sonnet on every existing thread → the very bug #198 set out to fix.

## Fix
- **Read side**: `bot.py:716` + `cogs/session.py:184` drop `stored.get("model")`; `model_override=None` always
- **Write side**: `save_session_state` writes `model=None` always (per locked user intent: `/model switch` is ephemeral)
- **Display**: `/session info` 4-case dispatch via `_model_source_for_bridge` from `cogs/model.py`
- **Visibility**: startup INFO log reports legacy-entry count (no mutation of existing data)

## User intent (locked from DDD 5/14)
"用户设置了就用设置的" = within current bot lifetime
"没设置就是 claude code 默认的" = SDK reads `~/.claude/settings.json`
"任何情况都要统一" = all read paths (auto-resume, /session resume, retry) follow same rule

## Tests
+15 in `tests/test_model_stored_readside.py`. 697 / 0.

## Status
🚧 Draft — pending 7-perspective review.
