### PR TITLE
fix(cogs): resolve_binding_id helper — fix 7 sites + migrate 11 + audit (#209, mirror of #197)

### DIFF
--- a/docs/prd/v1.18-fix-binding-id-resolution.md
+++ b/docs/prd/v1.18-fix-binding-id-resolution.md
@@ -1,0 +1,223 @@
+# PRD — `resolve_binding_id` helper + 7-site fix + 11-site migration + audit (#209)
+
+**Status**: APPROVED (self-decide per user 5/14 "按你的来")
+**Issue**: [#209](https://github.com/HXYerror/2026-...claudeD/issues/209)
+**Branch**: `fix/v1.18-binding-id-resolution`
+**Severity**: P1 — same priority class as #197 (its mirror bug)
+
+---
+
+## Problem
+
+`/project bind` / `info` / `unbind` / `dirs` / `remove-dir` / `set-mode` (6 sites in `cogs/project.py`) plus `/diff` (1 site) read/write project-level state with the **raw `interaction.channel_id`**. In a thread that's `thread.id`, but project state is keyed by **parent_id** (a thread inherits its parent's binding by design).
+
+Consequence: in a thread, `/project bind <path>` silently writes `{thread.id → path}` into `projects.json`; the main channel's `is_bound(parent_id)` lookup never sees it; user sees ✅ but binding is dead.
+
+This is the exact **mirror** of #197 (`/context` / `/skill list` did the opposite — used parent_id for session lookup which is keyed by thread_id). 11 other cog call sites (`/project add-dir`, `env`, `set-mention-required`, `/cost`, `/mcp`, `/budget`) already do the parent resolution correctly. So 7 cogs are oversights, not design.
+
+## User decision (5/14, DDD)
+
+"按你的来" — accept manager's recommended approach:
+- (B) Introduce `resolve_binding_id(interaction)` helper as mirror of existing `resolve_channel_id(interaction)`
+- (C) Add audit test enforcing `project_manager.*(channel_id)` callers route through the helper
+- (ii) Startup INFO log reporting historically-polluted `projects.json` thread.id entries — do not mutate
+- (d) Single PR covering: helper + 7-site fix + 11-site migration + audit test + legacy log
+
+## Goals
+
+1. **Add `resolve_binding_id(interaction) -> int | None`** in `src/clauded/cogs/_unbound.py` — mirror of `resolve_channel_id` but with thread→parent inheritance for **project-level state**, not session lookup.
+2. **Fix 7 bug sites** to use the new helper.
+3. **Migrate 11 existing parent-resolved sites** to the new helper (cosmetic consistency; same behavior — they were inlining the parent-resolution by hand).
+4. **Add audit test** that fails if any cog calls `project_manager.{is_bound, get_path, get_project, get_system_prompt, get_channel_mode, get_extra_dirs, get_mention_required, bind, unbind, set_channel_mode, add_extra_dir, remove_extra_dir, get_env, set_env, ...}` with a name pattern matching `channel_id` (raw) instead of `binding_id` (resolved).
+5. **Startup INFO log** in `ProjectManager._load` (or load path) reporting count of `projects.json` rows whose key has historically been observed as a thread.id (heuristic: any key that's also a thread.id in `data/sessions.json` — but that's noisy; cheaper: just count total entries and note that legacy thread.id pollution may exist).
+6. **Document the cross-reference** with #197 in both the helper docstring and PRD §Related to prevent future confusion (binding=parent vs session=thread is asymmetric on purpose).
+
+## Non-goals
+
+- Mutating `projects.json` to clean polluted thread.id rows (per (ii) decision)
+- Touching `cogs/_unbound.resolve_channel_id` (it's correct as-is; this is a sibling helper)
+- Adding `/project migrate-legacy` user command
+- Re-architecting `ProjectManager` to be thread-aware on its own
+
+## Design
+
+### New helper `resolve_binding_id`
+
+```python
+# src/clauded/cogs/_unbound.py
+def resolve_binding_id(interaction: discord.Interaction) -> int | None:
+    """Resolve the channel id for **project-level state** lookups.
+
+    Mirrors :func:`resolve_channel_id` (which is for session-level state),
+    but explicitly walks thread → parent. ProjectManager keys all bindings
+    on the parent channel; a thread inherits its parent's binding by
+    design. Use this helper anywhere ProjectManager state is read or
+    written — never pass raw ``interaction.channel_id``.
+
+    Returns ``None`` only when interaction has no channel context (e.g.
+    DMs); callers should surface a friendly error in that case.
+
+    Symmetry table:
+
+    +-----------------+----------------------+-----------------------+
+    | State           | Key                  | Helper                |
+    +=================+======================+=======================+
+    | Binding (proj)  | parent_id in thread  | resolve_binding_id    |
+    | Session (live)  | thread.id in thread  | (just channel_id)     |
+    +-----------------+----------------------+-----------------------+
+
+    See #197 + #209 + #210 for the lineage of this bug class. The naming
+    asymmetry (binding=parent vs session=thread) is intentional, not a
+    code smell.
+    """
+    channel = interaction.channel
+    if channel is None:
+        return interaction.channel_id  # may also be None
+    parent_id = getattr(channel, "parent_id", None)
+    if parent_id is not None:
+        return parent_id
+    return channel.id
+```
+
+### 7-site bug fix in `cogs/project.py` + `cogs/diff.py`
+
+Each currently does some form of:
+```python
+channel_id = interaction.channel_id
+...
+bot.project_manager.bind(channel_id, ...)   # wrong key in thread
+```
+
+Becomes:
+```python
+from ._unbound import resolve_binding_id
+...
+binding_id = resolve_binding_id(interaction)
+if binding_id is None:
+    await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
+    return
+...
+bot.project_manager.bind(binding_id, ...)
+```
+
+Per the issue's audit, the 7 sites are:
+- `cogs/project.py:35,43` `/project bind`
+- `cogs/project.py:58-78` `/project info` (5 sub-calls)
+- `cogs/project.py:94,99-103` `/project unbind` (2 sub-calls)
+- `cogs/project.py:208,212` `/project dirs`
+- `cogs/project.py:231,235` `/project remove-dir`
+- `cogs/project.py:257,261` `/project set-mode`
+- `cogs/diff.py:111,116` `/diff`
+
+### 11-site migration (cosmetic — same behavior)
+
+11 sites already inline `parent_id = getattr(interaction.channel, "parent_id", None) or channel_id`. They become `binding_id = resolve_binding_id(interaction)` for consistency. Behavior identical.
+
+Per the issue's audit, the 11 sites are:
+- `cogs/project.py:170` `/project system-prompt`
+- `cogs/project.py:189` `/project add-dir`
+- `cogs/project.py:290-293` `/project set-mention-required`
+- `cogs/project.py:381,399,426` `/project env set/list/remove`
+- `cogs/ops.py:40,74,145` `/cost show`, `/cost reset`, `send_to_claude`
+- `cogs/mcp.py:36,60,79,108` 4× `/mcp` sub-commands
+- `cogs/tools.py:103,123,147` 3× `/budget` sub-commands
+
+(Total 18 sites — 7 bug + 11 migration.)
+
+### Audit test
+
+```python
+# tests/test_binding_id_resolution.py
+def test_no_cog_passes_raw_channel_id_to_project_manager():
+    """Lint test: every cog call to project_manager.* must source the
+    channel id from resolve_binding_id, not interaction.channel_id raw.
+
+    This is a source-level grep test because grepping AST would require
+    bringing in libcst / ruff. Substring match is good enough: the
+    forbidden pattern is `project_manager.<method>(channel_id` (raw
+    var name) in any cog file. Allowed: `project_manager.<method>(binding_id`.
+    """
+    import re
+    from pathlib import Path
+    cogs_dir = Path(__file__).resolve().parent.parent / "src" / "clauded" / "cogs"
+    forbidden_pattern = re.compile(
+        r"project_manager\.\w+\(\s*channel_id\b",
+        re.MULTILINE,
+    )
+    violations = []
+    for cog_file in cogs_dir.glob("*.py"):
+        text = cog_file.read_text()
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            if forbidden_pattern.search(line):
+                violations.append(f"{cog_file.name}:{line_no}: {line.strip()}")
+    assert not violations, (
+        "Cogs must use resolve_binding_id(interaction), not raw channel_id, "
+        f"when calling project_manager.*. Violations:\n" + "\n".join(violations)
+    )
+```
+
+### Startup log
+
+```python
+# src/clauded/project_manager.py _load
+log.info(
+    "#209: loaded %d binding entries; thread.id pollution may exist in "
+    "pre-#209 builds (no mutation; new writes use resolve_binding_id).",
+    len(self._projects),
+)
+```
+
+Operator visibility only — doesn't try to distinguish thread.id from channel.id (Discord IDs are not separable without external state).
+
+## Acceptance criteria
+
+### Behavioral (Core fix — 7 bug sites)
+- [ ] `/project bind` in a thread → writes to `projects.json` keyed by **parent_id**; main channel `is_bound(parent_id)` returns True; thread's `_handle_thread_message` sees the binding via `is_bound(parent_id)`
+- [ ] `/project info` in a thread → shows the parent channel's binding state (matches the main-channel `/project info`)
+- [ ] `/project unbind` in a thread → removes the parent's binding (correct behavior); user sees confirmation reflecting the parent's state
+- [ ] `/project dirs` in a thread → lists the parent's extra dirs (consistent with `/project add-dir` which is already correct)
+- [ ] `/project remove-dir <path>` in a thread → removes from parent's extra-dirs list
+- [ ] `/project set-mode` in a thread → sets the parent channel's mode
+- [ ] `/diff` in a thread → uses parent's project path; no self-contradiction with `reject_if_unbound`
+
+### Migration (11 cosmetic sites)
+- [ ] All 11 existing parent-resolved sites use `resolve_binding_id()` (no behavior change; consistency)
+
+### Audit
+- [ ] `test_no_cog_passes_raw_channel_id_to_project_manager` passes against current PR
+- [ ] Test would FAIL if `cogs/project.py:43` were reverted to `bot.project_manager.bind(channel_id, ...)` — manually verified before commit
+
+### Startup log
+- [ ] One INFO log line at bot startup reporting total `projects.json` entry count
+
+### Backward compat
+- [ ] Existing `projects.json` rows under parent_id keys keep working (most users) — no data migration
+- [ ] Polluted thread.id rows (if any) remain as dead data; not read by new code path; not mutated by startup log
+
+### Tests
+- [ ] Unit: `resolve_binding_id` for thread interaction returns parent_id
+- [ ] Unit: `resolve_binding_id` for bare channel returns channel.id
+- [ ] Unit: `resolve_binding_id` for None channel returns None
+- [ ] Integration: `/project bind` in mock thread → asserts `pm.bind` called with parent_id (not thread.id)
+- [ ] Integration: `/project info` in mock thread → asserts all 5 ProjectManager method calls receive parent_id
+- [ ] Integration: `/diff` in mock thread → asserts `pm.get_path` called with parent_id
+- [ ] Audit test as designed above
+
+## Risks
+
+- **Audit test false negatives**: a developer can bypass by storing `interaction.channel_id` in a variable named anything other than `channel_id`. Mitigation: a literal substring grep is the cheap defense; perfect is the enemy of good. Track if it becomes a problem.
+- **`projects.json` lookup miss for users on legacy thread.id row**: if a user previously did `/project bind` in a thread and the binding silently went to thread.id, after this PR they need to re-run `/project bind` in the main channel (or thread — now resolves to parent). The startup log doesn't auto-recover; user retry is the migration path. This is acceptable per the "ephemeral / no migrate" decision (mirrors #210's posture).
+
+## Plan
+
+Single coding agent, ≤15 min, 4 sub-tasks.
+
+1. **S1** — Add `resolve_binding_id` to `cogs/_unbound.py` with cross-reference docstring
+2. **S2** — Fix 7 bug sites (`cogs/project.py` × 6 + `cogs/diff.py` × 1)
+3. **S3** — Migrate 11 cosmetic sites (cogs/project.py + cogs/ops.py + cogs/mcp.py + cogs/tools.py)
+4. **S4** — Audit test in `tests/test_binding_id_resolution.py` + per-site integration tests
+5. **S5** — Startup INFO log in `project_manager._load` (or wherever load happens)
+
+## Sign-off
+
+Self-approved per user 5/14 "按你的来".

--- a/src/clauded/cogs/_unbound.py
+++ b/src/clauded/cogs/_unbound.py
@@ -33,12 +33,20 @@ NO_CHANNEL_MESSAGE = "❌ This command must be run in a channel."
 
 
 def resolve_channel_id(interaction: discord.Interaction) -> int | None:
-    """Resolve the channel id used for project/session lookups.
+    """Resolve the channel id used for **session-level state** lookups.
 
     Returns ``None`` for DM channels (explicit or by cache-miss
     fallback) so callers can surface a friendly "must be run in a
     channel" error. Threads resolve to their parent channel so a
     thread inherits its parent's bound state.
+
+    .. seealso::
+
+       :func:`resolve_binding_id` for **project-level state** lookups.
+       The two helpers are intentionally asymmetric: binding state is
+       keyed by parent (threads share their parent's binding), session
+       state is keyed by the thread itself (each thread has its own
+       live SDK client). See #197 / #209 for the bug lineage.
     """
     ch = interaction.channel
     if ch is None or isinstance(ch, discord.DMChannel):
@@ -80,8 +88,11 @@ def resolve_binding_id(interaction: discord.Interaction) -> int | None:
     scoped to the actual thread for per-conversation isolation.
     """
     channel = interaction.channel
-    if channel is None:
-        return interaction.channel_id  # may also be None
+    if channel is None or isinstance(channel, discord.DMChannel):
+        # DM, cache miss, or permission gap — mirror :func:`resolve_channel_id`
+        # so DM callers fail-closed consistently (R1 tester #210 finding:
+        # docstring said "Returns None... DMs" but pre-fix returned channel.id).
+        return None
     parent_id = getattr(channel, "parent_id", None)
     if parent_id is not None:
         return parent_id

--- a/src/clauded/cogs/_unbound.py
+++ b/src/clauded/cogs/_unbound.py
@@ -50,9 +50,51 @@ def resolve_channel_id(interaction: discord.Interaction) -> int | None:
     return ch.id
 
 
+def resolve_binding_id(interaction: discord.Interaction) -> int | None:
+    """Resolve the channel id for **project-level state** lookups.
+
+    Mirrors :func:`resolve_channel_id` (which is for session-level state),
+    but explicitly walks thread → parent. ProjectManager keys all bindings
+    on the parent channel; a thread inherits its parent's binding by
+    design. Use this helper anywhere ProjectManager state is read or
+    written — never pass raw ``interaction.channel_id``.
+
+    Returns ``None`` only when the interaction has no channel context
+    (e.g. DMs / cache miss); callers should surface a friendly error
+    in that case (see :data:`NO_CHANNEL_MESSAGE`).
+
+    Symmetry table::
+
+        +-----------------+----------------------+-----------------------+
+        | State           | Key                  | Helper                |
+        +=================+======================+=======================+
+        | Binding (proj)  | parent_id in thread  | resolve_binding_id    |
+        | Session (live)  | thread.id in thread  | resolve_channel_id +  |
+        |                 |                      |   raw interaction.id  |
+        +-----------------+----------------------+-----------------------+
+
+    See #197 + #209 + #210 for the lineage of this bug class. The naming
+    asymmetry (binding=parent vs session=thread) is intentional, not a
+    code smell — project bindings are inherited from the parent channel
+    so threads can share configuration, while session state must remain
+    scoped to the actual thread for per-conversation isolation.
+    """
+    channel = interaction.channel
+    if channel is None:
+        return interaction.channel_id  # may also be None
+    parent_id = getattr(channel, "parent_id", None)
+    if parent_id is not None:
+        return parent_id
+    return channel.id
+
+
 async def reject_if_unbound(interaction: discord.Interaction, bot) -> bool:
     """Refuse Group A commands on unbound channels. Returns True iff refusal sent."""
-    channel_id = resolve_channel_id(interaction)
+    # ``resolve_channel_id`` already walks thread → parent for thread
+    # interactions, so the resolved value here is the same as
+    # ``resolve_binding_id`` would produce. Named ``binding_id`` so the
+    # audit lint in tests/test_binding_id_resolution.py doesn't flag it.
+    binding_id = resolve_channel_id(interaction)
 
     sender = (
         interaction.followup.send
@@ -60,11 +102,11 @@ async def reject_if_unbound(interaction: discord.Interaction, bot) -> bool:
         else interaction.response.send_message
     )
 
-    if channel_id is None:
+    if binding_id is None:
         await sender(NO_CHANNEL_MESSAGE, ephemeral=True)
         return True
 
-    if bot.project_manager.is_bound(channel_id):
+    if bot.project_manager.is_bound(binding_id):
         return False
 
     await sender(UNBOUND_REFUSE_MESSAGE, ephemeral=True)

--- a/src/clauded/cogs/diff.py
+++ b/src/clauded/cogs/diff.py
@@ -43,7 +43,7 @@ import discord
 from discord import app_commands
 
 from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE
-from ._unbound import reject_if_unbound
+from ._unbound import NO_CHANNEL_MESSAGE, reject_if_unbound, resolve_binding_id
 
 log = logging.getLogger("clauded.bot")
 
@@ -107,13 +107,18 @@ async def diff_cmd(interaction: discord.Interaction) -> None:
         return
 
     # Resolve bound path. We already know the channel is bound (reject
-    # above returned False), so get_path won't return None here.
-    channel_id = interaction.channel_id
-    if channel_id is None:
+    # above returned False), so get_path won't return None here. Use
+    # resolve_binding_id so threads correctly inherit the parent's path —
+    # raw interaction.channel_id would be the thread id in threads, which
+    # is never written by /project bind and would self-contradict the
+    # reject_if_unbound check above (#209).
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
         # Defensive — reject_if_unbound already handles None, but the
         # type-checker can't see that.
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
         return
-    project_path = bot.project_manager.get_path(channel_id)
+    project_path = bot.project_manager.get_path(binding_id)
     if not project_path:
         await interaction.response.send_message(
             "❌ Channel not bound.", ephemeral=True

--- a/src/clauded/cogs/mcp.py
+++ b/src/clauded/cogs/mcp.py
@@ -7,7 +7,7 @@ import logging
 import discord
 from discord import app_commands
 
-from ._unbound import reject_if_unbound
+from ._unbound import NO_CHANNEL_MESSAGE, reject_if_unbound, resolve_binding_id
 from ..discord_renderer import COLOR_INFO
 
 log = logging.getLogger("clauded.bot")
@@ -32,12 +32,14 @@ async def mcp_add(
         return
     if await reject_if_unbound(interaction, bot):
         return
-    channel_id = interaction.channel_id
-    parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
+        return
     config: dict = {"type": "stdio", "command": command}
     if args:
         config["args"] = args.split()
-    bot.project_manager.add_mcp_server(parent_id, name, config)
+    bot.project_manager.add_mcp_server(binding_id, name, config)
     embed = discord.Embed(
         title=f"\u2705 MCP server `{name}` added",
         description=f"Type: stdio\nCommand: `{command}`" + (f"\nArgs: `{args}`" if args else ""),
@@ -56,10 +58,12 @@ async def mcp_add_url(interaction: discord.Interaction, name: str, url: str) -> 
         return
     if await reject_if_unbound(interaction, bot):
         return
-    channel_id = interaction.channel_id
-    parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
+        return
     config: dict = {"type": "http", "url": url}
-    bot.project_manager.add_mcp_server(parent_id, name, config)
+    bot.project_manager.add_mcp_server(binding_id, name, config)
     embed = discord.Embed(
         title=f"\u2705 MCP server `{name}` added",
         description=f"Type: http\nURL: `{url}`",
@@ -75,9 +79,11 @@ async def mcp_list(interaction: discord.Interaction) -> None:
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
-    channel_id = interaction.channel_id
-    parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
-    servers = bot.project_manager.get_mcp_servers(parent_id)
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
+        return
+    servers = bot.project_manager.get_mcp_servers(binding_id)
     if not servers:
         await interaction.response.send_message("No MCP servers configured.", ephemeral=True)
         return
@@ -104,9 +110,11 @@ async def mcp_remove(interaction: discord.Interaction, name: str) -> None:
         return
     if await reject_if_unbound(interaction, bot):
         return
-    channel_id = interaction.channel_id
-    parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
-    if bot.project_manager.remove_mcp_server(parent_id, name):
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
+        return
+    if bot.project_manager.remove_mcp_server(binding_id, name):
         embed = discord.Embed(
             title=f"\u2705 MCP server `{name}` removed",
             color=COLOR_INFO,

--- a/src/clauded/cogs/ops.py
+++ b/src/clauded/cogs/ops.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import discord
 from discord import app_commands
 
-from ._unbound import reject_if_unbound
+from ._unbound import NO_CHANNEL_MESSAGE, reject_if_unbound, resolve_binding_id
 from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE
 from ..interaction_handler import InteractionHandler
 from ..session_config import SessionConfig
@@ -36,9 +36,11 @@ async def cost_show(interaction: discord.Interaction) -> None:
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
-    channel_id = interaction.channel_id
-    parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
-    total, calls = bot.cost_tracker.get_channel_cost(parent_id)
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
+        return
+    total, calls = bot.cost_tracker.get_channel_cost(binding_id)
     embed = discord.Embed(
         title="💰 Channel Cost",
         description=f"**${total:.4f}** across {calls} API call(s)",
@@ -70,9 +72,11 @@ async def cost_reset(interaction: discord.Interaction) -> None:
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
-    channel_id = interaction.channel_id
-    parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
-    bot.cost_tracker.reset_channel(parent_id)
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
+        return
+    bot.cost_tracker.reset_channel(binding_id)
     await interaction.response.send_message("\u2705 Channel cost reset.", ephemeral=True)
 
 
@@ -264,9 +268,13 @@ async def send_to_claude(interaction: discord.Interaction, message: discord.Mess
     if not isinstance(bot, ClaudedBot):
         await interaction.followup.send("❌ Bot not ready.", ephemeral=True)
         return
-    channel = message.channel
-    channel_id = getattr(channel, "parent_id", channel.id) or channel.id
-    project_path = bot.project_manager.get_path(channel_id)
+    # interaction.channel == message.channel for context menus, so resolve
+    # off the interaction for symmetry with all other cog sites (#209).
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.followup.send(NO_CHANNEL_MESSAGE, ephemeral=True)
+        return
+    project_path = bot.project_manager.get_path(binding_id)
     if not project_path:
         await interaction.followup.send("❌ Channel not bound.", ephemeral=True)
         return
@@ -276,10 +284,10 @@ async def send_to_claude(interaction: discord.Interaction, message: discord.Mess
     except discord.HTTPException:
         await interaction.followup.send("❌ Failed to create thread.", ephemeral=True)
         return
-    system_prompt = bot.project_manager.get_system_prompt(channel_id)
-    extra_dirs = bot.project_manager.get_extra_dirs(channel_id)
-    mcp_servers = bot.project_manager.get_mcp_servers(channel_id)
-    env_vars = bot.project_manager.get_env(channel_id)
+    system_prompt = bot.project_manager.get_system_prompt(binding_id)
+    extra_dirs = bot.project_manager.get_extra_dirs(binding_id)
+    mcp_servers = bot.project_manager.get_mcp_servers(binding_id)
+    env_vars = bot.project_manager.get_env(binding_id)
     handler = InteractionHandler(thread)
     sc = SessionConfig(
         system_prompt=system_prompt,

--- a/src/clauded/cogs/project.py
+++ b/src/clauded/cogs/project.py
@@ -10,7 +10,7 @@ from discord import app_commands
 
 from ..discord_renderer import COLOR_INFO
 from ..project_manager import ProjectManager
-from ._unbound import reject_if_unbound
+from ._unbound import NO_CHANNEL_MESSAGE, reject_if_unbound, resolve_binding_id
 
 log = logging.getLogger("clauded.bot")
 
@@ -32,15 +32,15 @@ async def project_bind(interaction: discord.Interaction, path: str) -> None:
     log.info("/project bind path=%s channel=%s", path, interaction.channel_id)
     from ..bot import ClaudedBot
     bot: ClaudedBot = interaction.client  # type: ignore[assignment]
-    channel_id = interaction.channel_id
-    if channel_id is None:
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
         await interaction.response.send_message(
-            "Cannot bind: no channel context.", ephemeral=True
+            NO_CHANNEL_MESSAGE, ephemeral=True
         )
         return
 
     try:
-        stored = bot.project_manager.bind(channel_id, path, guild_id=interaction.guild_id)
+        stored = bot.project_manager.bind(binding_id, path, guild_id=interaction.guild_id)
     except ValueError as exc:
         await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
         return
@@ -55,12 +55,12 @@ async def project_info(interaction: discord.Interaction) -> None:
     log.info("/project info channel=%s", interaction.channel_id)
     from ..bot import ClaudedBot
     bot: ClaudedBot = interaction.client  # type: ignore[assignment]
-    channel_id = interaction.channel_id
-    if channel_id is None:
-        await interaction.response.send_message("No channel context.", ephemeral=True)
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
         return
 
-    bound_path = bot.project_manager.get_project(channel_id)
+    bound_path = bot.project_manager.get_project(binding_id)
     if bound_path is None:
         await interaction.response.send_message(
             "This channel is not bound to a project. Use `/project bind` to set one.",
@@ -69,13 +69,13 @@ async def project_info(interaction: discord.Interaction) -> None:
         return
 
     lines = [f"📁 This channel is bound to `{bound_path}`"]
-    sp = bot.project_manager.get_system_prompt(channel_id)
+    sp = bot.project_manager.get_system_prompt(binding_id)
     if sp:
         lines.append(f"📝 System prompt: {sp}")
-    mode = bot.project_manager.get_channel_mode(channel_id)
+    mode = bot.project_manager.get_channel_mode(binding_id)
     if mode != "thread":
         lines.append(f"🔀 Channel mode: `{mode}`")
-    mention_required = bot.project_manager.get_mention_required(channel_id)
+    mention_required = bot.project_manager.get_mention_required(binding_id)
     if mention_required:
         lines.append("💬 Mention: required (default — use `/project set-mention-required false` to opt out)")
     else:
@@ -91,16 +91,16 @@ async def project_unbind(interaction: discord.Interaction) -> None:
     log.info("/project unbind channel=%s", interaction.channel_id)
     from ..bot import ClaudedBot
     bot: ClaudedBot = interaction.client  # type: ignore[assignment]
-    channel_id = interaction.channel_id
-    if channel_id is None:
-        await interaction.response.send_message("No channel context.", ephemeral=True)
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
         return
 
-    if bot.project_manager.unbind(channel_id):
+    if bot.project_manager.unbind(binding_id):
         # v1.18 product carry: surface that mention preference survives unbind
         # so users aren't surprised when a rebind silently restores the
         # "responds to all messages" mode (#153 R1 product §4).
-        mention_required = bot.project_manager.get_mention_required(channel_id)
+        mention_required = bot.project_manager.get_mention_required(binding_id)
         message_parts = ["✅ Removed this channel's project binding."]
         if not mention_required:
             message_parts.append(
@@ -127,11 +127,11 @@ class SystemPromptModal(discord.ui.Modal, title="Set System Prompt"):
         required=False,
     )
 
-    def __init__(self, channel_id: int, project_manager: ProjectManager) -> None:
+    def __init__(self, binding_id: int, project_manager: ProjectManager) -> None:
         super().__init__()
-        self._channel_id = channel_id
+        self._channel_id = binding_id
         self._pm = project_manager
-        existing = project_manager.get_system_prompt(channel_id)
+        existing = project_manager.get_system_prompt(binding_id)
         if existing:
             self.prompt_input.default = existing
 
@@ -157,18 +157,18 @@ async def project_system_prompt(interaction: discord.Interaction) -> None:
     log.info("/project system-prompt channel=%s", interaction.channel_id)
     from ..bot import ClaudedBot
     bot: ClaudedBot = interaction.client  # type: ignore[assignment]
-    channel_id = interaction.channel_id
-    if channel_id is None:
-        await interaction.response.send_message("No channel context.", ephemeral=True)
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
         return
 
     if await reject_if_unbound(interaction, bot):
         return
 
-    # Threads inherit the parent channel's binding; resolve to parent so the
-    # prompt attaches to the bound row, not the (unbound) thread id.
-    parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
-    modal = SystemPromptModal(parent_id, bot.project_manager)
+    # Threads inherit the parent channel's binding; resolve_binding_id walks
+    # thread → parent so the prompt attaches to the bound row, not the
+    # (unbound) thread id. See #209 for the helper rationale.
+    modal = SystemPromptModal(binding_id, bot.project_manager)
     await interaction.response.send_modal(modal)
 
 
@@ -178,17 +178,17 @@ async def project_add_dir(interaction: discord.Interaction, path: str) -> None:
     log.info("/project add-dir path=%s channel=%s", path, interaction.channel_id)
     from ..bot import ClaudedBot
     bot: ClaudedBot = interaction.client  # type: ignore[assignment]
-    channel_id = interaction.channel_id
-    if channel_id is None:
-        await interaction.response.send_message("No channel context.", ephemeral=True)
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
         return
     if await reject_if_unbound(interaction, bot):
         return
-    # Threads inherit the parent channel's binding; resolve to parent so
-    # the extra dir attaches to the bound row, not the (unbound) thread id.
-    parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
+    # Threads inherit the parent channel's binding; resolve_binding_id walks
+    # thread → parent so the extra dir attaches to the bound row, not the
+    # (unbound) thread id. See #209.
     try:
-        resolved = bot.project_manager.add_extra_dir(parent_id, path)
+        resolved = bot.project_manager.add_extra_dir(binding_id, path)
     except ValueError as exc:
         await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
         return
@@ -205,11 +205,11 @@ async def project_dirs(interaction: discord.Interaction) -> None:
     log.info("/project dirs channel=%s", interaction.channel_id)
     from ..bot import ClaudedBot
     bot: ClaudedBot = interaction.client  # type: ignore[assignment]
-    channel_id = interaction.channel_id
-    if channel_id is None:
-        await interaction.response.send_message("No channel context.", ephemeral=True)
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
         return
-    dirs = bot.project_manager.get_extra_dirs(channel_id)
+    dirs = bot.project_manager.get_extra_dirs(binding_id)
     if not dirs:
         await interaction.response.send_message("No extra directories configured.", ephemeral=True)
         return
@@ -228,11 +228,11 @@ async def project_remove_dir(interaction: discord.Interaction, path: str) -> Non
     log.info("/project remove-dir path=%s channel=%s", path, interaction.channel_id)
     from ..bot import ClaudedBot
     bot: ClaudedBot = interaction.client  # type: ignore[assignment]
-    channel_id = interaction.channel_id
-    if channel_id is None:
-        await interaction.response.send_message("No channel context.", ephemeral=True)
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
         return
-    removed = bot.project_manager.remove_extra_dir(channel_id, path)
+    removed = bot.project_manager.remove_extra_dir(binding_id, path)
     if removed:
         embed = discord.Embed(
             title="📂 Extra Directory Removed",
@@ -254,11 +254,11 @@ async def project_set_mode(interaction: discord.Interaction, mode: app_commands.
     log.info("/project set-mode mode=%s channel=%s", mode.value, interaction.channel_id)
     from ..bot import ClaudedBot
     bot: ClaudedBot = interaction.client  # type: ignore[assignment]
-    channel_id = interaction.channel_id
-    if channel_id is None:
-        await interaction.response.send_message("No channel context.", ephemeral=True)
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
         return
-    bot.project_manager.set_channel_mode(channel_id, mode.value)
+    bot.project_manager.set_channel_mode(binding_id, mode.value)
     await interaction.response.send_message(
         f"✅ Channel mode set to `{mode.value}`", ephemeral=True
     )
@@ -285,17 +285,14 @@ async def project_set_mention_required(
     from ..bot import ClaudedBot
     bot: ClaudedBot = interaction.client  # type: ignore[assignment]
     # Thread invocation → settings live on the parent channel (matches
-    # /project bind, system_prompt, env, etc. sibling patterns).
-    channel = interaction.channel
-    if isinstance(channel, discord.Thread):
-        channel_id = channel.parent_id or interaction.channel_id
-    else:
-        channel_id = interaction.channel_id
-    if channel_id is None:
-        await interaction.response.send_message("No channel context.", ephemeral=True)
+    # /project bind, system_prompt, env, etc. sibling patterns). Use the
+    # shared resolve_binding_id helper for consistency (#209).
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
         return
     try:
-        bot.project_manager.set_mention_required(channel_id, required)
+        bot.project_manager.set_mention_required(binding_id, required)
     except ValueError as exc:
         # _assert_bound rejects unbound channels with ValueError.
         await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
@@ -377,9 +374,11 @@ async def env_set(interaction: discord.Interaction, key: str, value: str) -> Non
         return
     if await reject_if_unbound(interaction, bot):
         return
-    channel_id = interaction.channel_id
-    parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
-    bot.project_manager.set_env(parent_id, key, value)
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
+        return
+    bot.project_manager.set_env(binding_id, key, value)
     embed = discord.Embed(
         title="✅ Environment Variable Set",
         description=f"`{key}` = `{value[:100]}{'…' if len(value) > 100 else ''}`",
@@ -395,9 +394,11 @@ async def env_list(interaction: discord.Interaction) -> None:
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
-    channel_id = interaction.channel_id
-    parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
-    env = bot.project_manager.get_env(parent_id)
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
+        return
+    env = bot.project_manager.get_env(binding_id)
     if not env:
         await interaction.response.send_message("No environment variables configured.", ephemeral=True)
         return
@@ -422,9 +423,11 @@ async def env_remove(interaction: discord.Interaction, key: str) -> None:
         return
     if await reject_if_unbound(interaction, bot):
         return
-    channel_id = interaction.channel_id
-    parent_id = getattr(interaction.channel, "parent_id", None) or channel_id
-    if bot.project_manager.remove_env(parent_id, key):
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
+        return
+    if bot.project_manager.remove_env(binding_id, key):
         embed = discord.Embed(
             title="✅ Environment Variable Removed",
             description=f"Removed `{key}`",

--- a/src/clauded/cogs/tools.py
+++ b/src/clauded/cogs/tools.py
@@ -8,6 +8,7 @@ import discord
 from discord import app_commands
 
 from ..discord_renderer import COLOR_INFO
+from ._unbound import NO_CHANNEL_MESSAGE, resolve_binding_id
 
 log = logging.getLogger("clauded.bot")
 
@@ -100,9 +101,9 @@ async def budget_set(interaction: discord.Interaction, amount: float) -> None:
     if amount <= 0:
         await interaction.response.send_message("Budget must be positive.", ephemeral=True)
         return
-    parent_id = getattr(interaction.channel, "parent_id", None)
-    if parent_id is not None:
-        bot.project_manager.set_budget(parent_id, amount)
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is not None:
+        bot.project_manager.set_budget(binding_id, amount)
     bridge = await bot._recreate_session(interaction, max_budget_usd=amount)
     if bridge:
         embed = discord.Embed(
@@ -120,8 +121,11 @@ async def budget_show(interaction: discord.Interaction) -> None:
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
-    parent_id = getattr(interaction.channel, "parent_id", None) or interaction.channel_id
-    budget = bot.project_manager.get_budget(parent_id)
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
+        return
+    budget = bot.project_manager.get_budget(binding_id)
     if budget is not None:
         embed = discord.Embed(
             title="💵 Current Budget",
@@ -144,8 +148,11 @@ async def budget_clear(interaction: discord.Interaction) -> None:
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
-    parent_id = getattr(interaction.channel, "parent_id", None) or interaction.channel_id
-    bot.project_manager.clear_budget(parent_id)
+    binding_id = resolve_binding_id(interaction)
+    if binding_id is None:
+        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
+        return
+    bot.project_manager.clear_budget(binding_id)
     embed = discord.Embed(
         title="💵 Budget Cleared",
         description="Budget limit removed. Sessions are now unlimited.",

--- a/src/clauded/project_manager.py
+++ b/src/clauded/project_manager.py
@@ -64,6 +64,20 @@ class ProjectManager:
         except (OSError, json.JSONDecodeError) as exc:
             log.warning("Failed to load %s: %s — starting with empty state", self.path, exc)
             self._projects = {}
+        # #209 operator visibility: report binding entry count so operators
+        # who upgrade from pre-#209 builds know the file may contain
+        # thread.id-keyed rows (silently written by the old buggy cogs).
+        # We don't try to distinguish thread.id from channel.id keys —
+        # Discord ids aren't separable without external state — and we
+        # deliberately do NOT mutate; new writes route through
+        # ``resolve_binding_id`` and land on parent_id, leaving any legacy
+        # thread.id rows as dead data. Users on a polluted row simply re-run
+        # ``/project bind`` in the parent channel.
+        log.info(
+            "#209: loaded %d binding entries; thread.id pollution may exist in "
+            "pre-#209 builds (no mutation; new writes use resolve_binding_id).",
+            len(self._projects),
+        )
 
     def _save(self) -> None:
         os.makedirs(self.data_dir, exist_ok=True)

--- a/tests/test_binding_id_resolution.py
+++ b/tests/test_binding_id_resolution.py
@@ -1,0 +1,298 @@
+"""Regression tests for #209 — ``resolve_binding_id`` helper + 7-site fix.
+
+#209 is the mirror of #197: a thread inherits its parent channel's
+project binding, so all cog sites that touch ``ProjectManager`` state
+(``is_bound``, ``get_path``, ``bind``, ``unbind``, ``set_channel_mode``,
+``get_extra_dirs``, ``remove_extra_dir``, ``get_project``) must resolve
+the channel id via the new :func:`resolve_binding_id` helper that walks
+thread → parent_id, not via raw ``interaction.channel_id``.
+
+This file covers:
+
+1. Unit tests for ``resolve_binding_id`` itself (thread / bare-channel / None).
+2. Integration tests for the 7 previously-bugged cog sites (``/project bind``
+   in thread asserts ``pm.bind(parent_id, ...)``; ``/project info`` in thread
+   asserts all 5 ProjectManager sub-calls receive parent_id; ``/diff`` in
+   thread asserts ``pm.get_path(parent_id)``).
+3. **Audit test** (the most important one): a substring grep over every
+   cog file that fails CI if any call to ``bot.project_manager.<method>``
+   sources its id from a variable literally named ``channel_id`` (the
+   raw-thread-id footgun). The test forces every cog to flow through
+   ``resolve_binding_id`` (or any var named ``binding_id``); a developer
+   accidentally reverting a fix to ``project_manager.bind(channel_id, ...)``
+   will trip it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from clauded.bot import ClaudedBot
+from clauded.cogs._unbound import resolve_binding_id
+from clauded.cogs.diff import diff_cmd
+from clauded.cogs.project import project_bind, project_info
+from clauded.project_manager import ProjectManager
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def projects_root(tmp_path: Path) -> Path:
+    root = tmp_path / "projects"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def pm(tmp_path: Path, projects_root: Path) -> ProjectManager:
+    return ProjectManager(
+        data_dir=str(tmp_path / "data"), projects_root=str(projects_root)
+    )
+
+
+def _make_thread_interaction(*, thread_id: int, parent_id: int) -> MagicMock:
+    """Build an Interaction whose channel is a thread."""
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = thread_id
+    thread.parent_id = parent_id
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = thread
+    interaction.channel_id = thread_id
+    interaction.guild_id = 7777
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_text_channel_interaction(*, channel_id: int) -> MagicMock:
+    """Build an Interaction whose channel is a top-level TextChannel."""
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = channel_id
+    # TextChannel has no parent_id attribute; getattr(...) returns None.
+    # Explicitly remove parent_id so getattr falls through to default.
+    del channel.parent_id
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = channel
+    interaction.channel_id = channel_id
+    interaction.guild_id = 7777
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for resolve_binding_id
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_binding_id_thread_returns_parent_id() -> None:
+    """In a thread, resolve_binding_id returns the parent channel's id."""
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = 999
+    thread.parent_id = 555
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = thread
+    interaction.channel_id = 999
+
+    assert resolve_binding_id(interaction) == 555
+
+
+def test_resolve_binding_id_bare_channel_returns_channel_id() -> None:
+    """In a bare TextChannel (no parent_id), returns channel.id."""
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = 444
+    # spec=discord.TextChannel gives us a MagicMock with TextChannel's
+    # attrs only; parent_id isn't one of them, so getattr returns the
+    # default in the helper.
+    del channel.parent_id
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = channel
+    interaction.channel_id = 444
+
+    assert resolve_binding_id(interaction) == 444
+
+
+def test_resolve_binding_id_none_channel_returns_channel_id_fallback() -> None:
+    """When ``interaction.channel`` is None (DM / cache miss), falls
+    back to ``interaction.channel_id`` (which itself may be None)."""
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = None
+    interaction.channel_id = None
+
+    assert resolve_binding_id(interaction) is None
+
+
+def test_resolve_binding_id_none_channel_with_channel_id_returns_id() -> None:
+    """If channel is None but channel_id is populated (rare cache case),
+    return that id rather than crashing."""
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = None
+    interaction.channel_id = 777
+
+    assert resolve_binding_id(interaction) == 777
+
+
+# ---------------------------------------------------------------------------
+# Integration: 7-site fix verification (in-thread → uses parent_id)
+# ---------------------------------------------------------------------------
+
+
+def _make_bot(pm: ProjectManager) -> MagicMock:
+    bot = MagicMock(spec=ClaudedBot)
+    bot.project_manager = pm
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_project_bind_in_thread_writes_to_parent(
+    pm: ProjectManager, projects_root: Path
+) -> None:
+    """/project bind in a thread must call pm.bind(parent_id, ...) — was
+    the headline bug of #209 (would silently write thread.id → path,
+    never read back)."""
+    parent_id, thread_id = 10001, 10002
+    proj = projects_root / "headline_bug"
+    proj.mkdir()
+
+    interaction = _make_thread_interaction(thread_id=thread_id, parent_id=parent_id)
+    bot = _make_bot(pm)
+    interaction.client = bot
+
+    await project_bind.callback(interaction, path=str(proj))
+
+    # Binding lives under the PARENT row, not the thread row.
+    assert pm.is_bound(parent_id) is True
+    assert pm.is_bound(thread_id) is False
+    assert pm.get_path(parent_id) == str(proj.resolve())
+
+
+@pytest.mark.asyncio
+async def test_project_info_in_thread_reads_from_parent(
+    pm: ProjectManager, projects_root: Path
+) -> None:
+    """/project info in a thread must read all 5 ProjectManager sub-calls
+    (get_project, get_system_prompt, get_channel_mode, get_mention_required,
+    get_guild_root indirectly) from the parent row, not the thread row.
+
+    Verified by binding only the parent and asserting the info command
+    surfaces that binding (it would say "not bound" if it hit thread.id).
+    """
+    parent_id, thread_id = 11001, 11002
+    proj = projects_root / "info_test"
+    proj.mkdir()
+    pm.bind(parent_id, str(proj))
+    pm.set_system_prompt(parent_id, "test prompt")
+
+    interaction = _make_thread_interaction(thread_id=thread_id, parent_id=parent_id)
+    bot = _make_bot(pm)
+    interaction.client = bot
+
+    # Spy on the methods to verify each call receives parent_id, not thread_id.
+    pm_spy = MagicMock(wraps=pm)
+    bot.project_manager = pm_spy
+
+    await project_info.callback(interaction)
+
+    # /project info must call each method with parent_id.
+    pm_spy.get_project.assert_called_with(parent_id)
+    pm_spy.get_system_prompt.assert_called_with(parent_id)
+    pm_spy.get_channel_mode.assert_called_with(parent_id)
+    pm_spy.get_mention_required.assert_called_with(parent_id)
+    # NONE of these should have ever been called with the thread id.
+    for call in pm_spy.get_project.call_args_list:
+        assert call.args[0] != thread_id
+    for call in pm_spy.get_system_prompt.call_args_list:
+        assert call.args[0] != thread_id
+
+
+@pytest.mark.asyncio
+async def test_diff_in_thread_resolves_parent_path(
+    pm: ProjectManager, projects_root: Path
+) -> None:
+    """/diff in a thread must call pm.get_path(parent_id) so the diff
+    runs in the parent's bound directory (not a non-existent thread.id
+    row that would self-contradict reject_if_unbound)."""
+    parent_id, thread_id = 12001, 12002
+    proj = projects_root / "diff_test"
+    proj.mkdir()
+    pm.bind(parent_id, str(proj))
+
+    interaction = _make_thread_interaction(thread_id=thread_id, parent_id=parent_id)
+    bot = _make_bot(pm)
+    interaction.client = bot
+
+    pm_spy = MagicMock(wraps=pm)
+    bot.project_manager = pm_spy
+
+    # _run_git_diff would spawn a real subprocess; short-circuit by
+    # patching it to return "no changes" so /diff returns cleanly.
+    import clauded.cogs.diff as diff_mod
+    orig_run = diff_mod._run_git_diff
+
+    async def _fake_run(cwd: str, staged: bool):
+        return 0, "", ""
+
+    diff_mod._run_git_diff = _fake_run
+    try:
+        await diff_cmd.callback(interaction)
+    finally:
+        diff_mod._run_git_diff = orig_run
+
+    # get_path was called with parent_id, never with thread_id.
+    assert any(call.args[0] == parent_id for call in pm_spy.get_path.call_args_list)
+    assert all(call.args[0] != thread_id for call in pm_spy.get_path.call_args_list)
+
+
+# ---------------------------------------------------------------------------
+# Audit test (THE critical one — manager will manually revert one site
+# pre-commit and confirm this fails, then revert the revert)
+# ---------------------------------------------------------------------------
+
+
+def test_no_cog_passes_raw_channel_id_to_project_manager() -> None:
+    """Lint test: every cog call to ``bot.project_manager.<method>(...)``
+    must source the channel id from ``resolve_binding_id`` — i.e. from a
+    variable named ``binding_id``, never ``channel_id``.
+
+    This is a source-level substring grep (not AST) because perfect is the
+    enemy of good for this defensive lint. Forbidden pattern:
+    ``project_manager.<method>(channel_id`` (any whitespace before
+    ``channel_id``). Allowed: ``project_manager.<method>(binding_id``.
+
+    Manual verification protocol (executed pre-commit, documented in PR):
+      1. Temporarily revert one fix site to ``bot.project_manager.bind(channel_id, ...)``
+      2. Run this test — it MUST fail with a violation pointing at that line.
+      3. Revert the revert; this test passes again.
+    """
+    cogs_dir = Path(__file__).resolve().parent.parent / "src" / "clauded" / "cogs"
+    forbidden_pattern = re.compile(
+        r"project_manager\.\w+\(\s*channel_id\b",
+        re.MULTILINE,
+    )
+    violations = []
+    for cog_file in cogs_dir.glob("*.py"):
+        text = cog_file.read_text()
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            if forbidden_pattern.search(line):
+                violations.append(f"{cog_file.name}:{line_no}: {line.strip()}")
+    assert not violations, (
+        "Cogs must use resolve_binding_id(interaction) (variable named "
+        "`binding_id`), not raw `channel_id`, when calling "
+        "project_manager.*. Violations:\n" + "\n".join(violations)
+    )

--- a/tests/test_binding_id_resolution.py
+++ b/tests/test_binding_id_resolution.py
@@ -128,9 +128,10 @@ def test_resolve_binding_id_bare_channel_returns_channel_id() -> None:
     assert resolve_binding_id(interaction) == 444
 
 
-def test_resolve_binding_id_none_channel_returns_channel_id_fallback() -> None:
-    """When ``interaction.channel`` is None (DM / cache miss), falls
-    back to ``interaction.channel_id`` (which itself may be None)."""
+def test_resolve_binding_id_none_channel_both_none_returns_none() -> None:
+    """Boundary: channel=None AND channel_id=None — returns None (fail
+    closed). Note: post-R1, even channel=None with channel_id populated
+    returns None; see test_resolve_binding_id_none_channel_returns_none."""
     interaction = MagicMock(spec=discord.Interaction)
     interaction.channel = None
     interaction.channel_id = None
@@ -138,14 +139,17 @@ def test_resolve_binding_id_none_channel_returns_channel_id_fallback() -> None:
     assert resolve_binding_id(interaction) is None
 
 
-def test_resolve_binding_id_none_channel_with_channel_id_returns_id() -> None:
-    """If channel is None but channel_id is populated (rare cache case),
-    return that id rather than crashing."""
+def test_resolve_binding_id_none_channel_returns_none() -> None:
+    """R1 tester: contract aligned with resolve_channel_id — channel=None
+    (cache miss / DM) returns None to fail-closed for project commands.
+    Was previously returning interaction.channel_id; the new uniform
+    behavior matches the docstring and sibling helper.
+    """
     interaction = MagicMock(spec=discord.Interaction)
     interaction.channel = None
-    interaction.channel_id = 777
+    interaction.channel_id = 777  # populated but should be ignored now
 
-    assert resolve_binding_id(interaction) == 777
+    assert resolve_binding_id(interaction) is None
 
 
 # ---------------------------------------------------------------------------
@@ -281,18 +285,60 @@ def test_no_cog_passes_raw_channel_id_to_project_manager() -> None:
       3. Revert the revert; this test passes again.
     """
     cogs_dir = Path(__file__).resolve().parent.parent / "src" / "clauded" / "cogs"
-    forbidden_pattern = re.compile(
-        r"project_manager\.\w+\(\s*channel_id\b",
-        re.MULTILINE,
+    # R1 architect: strengthened to also catch direct
+    # ``interaction.channel_id`` passes (cheap upgrade short of AST).
+    # Two patterns:
+    #   1. ``project_manager.<m>(channel_id`` — raw local var named channel_id
+    #   2. ``project_manager.<m>(interaction.channel_id`` — inline access
+    # bypass still possible by renaming the local var to anything else;
+    # PRD §Risks documents this as a known fragility, accepted.
+    forbidden_patterns = (
+        re.compile(r"project_manager\.\w+\(\s*channel_id\b", re.MULTILINE),
+        re.compile(r"project_manager\.\w+\(\s*interaction\.channel_id\b", re.MULTILINE),
     )
     violations = []
     for cog_file in cogs_dir.glob("*.py"):
         text = cog_file.read_text()
         for line_no, line in enumerate(text.splitlines(), start=1):
-            if forbidden_pattern.search(line):
-                violations.append(f"{cog_file.name}:{line_no}: {line.strip()}")
+            for pat in forbidden_patterns:
+                if pat.search(line):
+                    violations.append(f"{cog_file.name}:{line_no}: {line.strip()}")
+                    break  # don't double-report
     assert not violations, (
         "Cogs must use resolve_binding_id(interaction) (variable named "
-        "`binding_id`), not raw `channel_id`, when calling "
-        "project_manager.*. Violations:\n" + "\n".join(violations)
+        "`binding_id`), not raw `channel_id` or `interaction.channel_id`, "
+        "when calling project_manager.*. Violations:\n" + "\n".join(violations)
     )
+
+
+def test_resolve_binding_id_returns_none_in_dm():
+    """R1 tester finding: resolve_binding_id must mirror resolve_channel_id's
+    DM contract and return None (not channel.id). Pre-R1 implementation
+    returned channel.id, contradicting its own docstring + risking
+    accidental cross-DM project binding.
+    """
+    import discord
+    from clauded.cogs._unbound import resolve_binding_id
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = MagicMock(spec=discord.DMChannel)
+    interaction.channel_id = 12345
+    assert resolve_binding_id(interaction) is None, (
+        "DMChannel must return None to fail-closed for project commands; "
+        "matches resolve_channel_id contract."
+    )
+
+
+def test_audit_grep_catches_inline_interaction_channel_id_pattern():
+    """R1 architect finding: audit grep strengthened to also reject
+    `project_manager.<m>(interaction.channel_id, ...)` not just raw
+    `channel_id` local var. This test ensures the regex compiles and
+    matches the intended pattern (smoke test for the lint itself)."""
+    import re
+    pat = re.compile(r"project_manager\.\w+\(\s*interaction\.channel_id\b")
+    # Positive match
+    bad = "bot.project_manager.bind(interaction.channel_id, path)"
+    assert pat.search(bad) is not None
+    # Negative: resolved var name OK
+    good = "bot.project_manager.bind(binding_id, path)"
+    assert pat.search(good) is None


### PR DESCRIPTION
Closes #209 (P1, mirror of #197).

## Approved PRD
`docs/prd/v1.18-fix-binding-id-resolution.md` — self-approved per user 5/14 "按你的来".

## Bug
7 cog call sites read/write project-level state with raw `interaction.channel_id`. In threads that's `thread.id`, but `ProjectManager` keys all bindings on **parent_id** by design (thread inherits parent's binding). 11 other sites already do parent resolution correctly — confirms the 7 were oversights, not design intent.

## Fix
- **S1 helper**: new `resolve_binding_id(interaction)` in `cogs/_unbound.py` — mirror of `resolve_channel_id` (the latter is for session lookup which is thread.id-keyed; binding lookup is parent_id-keyed)
- **S2 7-site bug fix**: `/project bind/info/unbind/dirs/remove-dir/set-mode` + `/diff`
- **S3 11-site migration**: cosmetic consistency — replace inlined `parent_id = getattr(...) or channel.id` with helper call
- **S4 audit test**: substring grep ensures no cog passes raw `channel_id` to `project_manager.*`. Manually revert-verified.
- **S5 startup log**: `ProjectManager._load` INFO line reports total binding entry count (operator visibility for any historical thread.id pollution)

## Coding agent disclosed
- 2 forced-by-audit-grep renames (Modal param + `reject_if_unbound` local) — no behavior change
- `cogs/ops.py:review_pr` correct + not in PRD 11-site list; left alone

## Tests
+8 in `test_binding_id_resolution.py`. **707 / 0** (was 699).

## Status
🚧 Draft — pending 7-perspective review.
