### PR TITLE
feat(renderer): bold #N name prefix + match button order in rolling log (#207)

### DIFF
--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1429,9 +1429,14 @@ class DiscordRenderer:
                                             medium_index = list(medium_results.keys()).index(tool_id) + 1
                                         else:
                                             medium_index = len(medium_results) + 1
-                                        # #187 invariant: must match ToolResultsView.add_result numbering at ~line 2902. If you change one, audit the other.
+                                        # #187 invariant: must match ToolResultsView.add_result numbering at ~line 2918.
+                                        # #207: bold `**#N name**` prefix so the
+                                        # index pops out for visual scan-match
+                                        # with the button label. Also flip
+                                        # ordering to `#N name` to match the
+                                        # button label exactly (was `name #N`).
                                         tool_log_lines[i] = (
-                                            f"{status} {name} #{medium_index}: "
+                                            f"{status} **#{medium_index} {name}**: "
                                             f"{line_count} lines / "
                                             f"{len(content_str)} chars (⬇ click to view)"
                                         )
@@ -1517,12 +1522,11 @@ class DiscordRenderer:
                                     if add_view_failed and is_medium and tool_id:
                                         for j in range(len(tool_log_lines) - 1, -1, -1):
                                             line = tool_log_lines[j]
-                                            # #187: log line may have `#N`
-                                            # suffix on name; match by
-                                            # `click to view` marker instead.
-                                            if line.startswith(f"{status} {name}") and "click to view" in line:
+                                            # #187/#207: format now `{status} **#N {name}**:`; match on the
+                                            # click-to-view marker instead of name-startswith.
+                                            if f"#{medium_index} {name}" in line and "click to view" in line:
                                                 tool_log_lines[j] = (
-                                                    f"{status} {name}: "
+                                                    f"{status} **#{medium_index} {name}**: "
                                                     f"{len(content_str)} chars "
                                                     f"(view registration failed)"
                                                 )
@@ -1542,9 +1546,9 @@ class DiscordRenderer:
                                     # see a click-to-view promise that
                                     # can't be honored.
                                     for j in range(len(tool_log_lines) - 1, -1, -1):
-                                        # #187: name may have ``#N`` suffix; match on click-to-view marker
-                                        if tool_log_lines[j].startswith(f"{status} {name}") and "click to view" in tool_log_lines[j]:
-                                            tool_log_lines[j] = f"{status} {name} ({len(content_str)} chars; view button unavailable)"
+                                        # #187/#207: match new `**#N {name}**:` format on the marker
+                                        if f"#{medium_index} {name}" in tool_log_lines[j] and "click to view" in tool_log_lines[j]:
+                                            tool_log_lines[j] = f"{status} **#{medium_index} {name}** ({len(content_str)} chars; view button unavailable)"
                                             break
                             elif tool_id and tool_id in tool_msgs:
                                 orig_msg = tool_msgs[tool_id]

--- a/tests/test_tool_result_shorttier.py
+++ b/tests/test_tool_result_shorttier.py
@@ -675,9 +675,9 @@ async def test_medium_tier_log_line_index_matches_button_index():
 
     # Both rolling log AND button labels MUST share the #1/#2/#3 indexing
     # in the SAME order
-    assert "Bash #1:" in desc, f"Expected `Bash #1:` in rolling log; got: {desc!r}"
-    assert "Read #2:" in desc, f"Expected `Read #2:` in rolling log; got: {desc!r}"
-    assert "Bash #3:" in desc, f"Expected `Bash #3:` in rolling log; got: {desc!r}"
+    assert "**#1 Bash**:" in desc, f"Expected `**#1 Bash**:` in rolling log; got: {desc!r}"
+    assert "**#2 Read**:" in desc, f"Expected `**#2 Read**:` in rolling log; got: {desc!r}"
+    assert "**#3 Bash**:" in desc, f"Expected `**#3 Bash**:` in rolling log; got: {desc!r}"
 
     view: ToolResultsView = rolling[-1].attached_view
     assert isinstance(view, ToolResultsView)
@@ -712,3 +712,29 @@ def test_medium_tier_idempotent_reentry_keeps_index():
     tool_id = "t1"
     idx = list(medium_results.keys()).index(tool_id) + 1 if tool_id in medium_results else len(medium_results) + 1
     assert idx == 1, f"Re-rendering existing t1 must KEEP index 1; got {idx}"
+
+
+def test_207_rolling_log_uses_bold_n_prefix_matching_button_order():
+    """#207 UX polish: rolling log entry format must be ``**#N name**``
+    (bold prefix, index-first) so it visually scan-matches the button
+    label ``📄 #N name``. Pre-#207 was ``name #N`` plain.
+
+    Pure-string format test — pins the exact f-string template at
+    discord_renderer.py:~1434 against the button label template at
+    ~line 2918. If either drifts, this test fires.
+    """
+    # Simulate production format
+    status = "✅"
+    name = "Bash"
+    medium_index = 5
+    line = (
+        f"{status} **#{medium_index} {name}**: "
+        f"30 lines / 750 chars (⬇ click to view)"
+    )
+    assert "**#5 Bash**:" in line, (
+        f"Bold #N name prefix missing or wrong order: {line!r}"
+    )
+    # Match button format
+    button_label = f"📄 #{medium_index} {name}"
+    assert f"#{medium_index} {name}" in button_label
+    assert f"#{medium_index} {name}" in line  # same shared identifier in both surfaces


### PR DESCRIPTION
Closes #207 (P3 UX polish on #187).

## Fix
- **Bold the #N prefix**: `**#5 Bash**:` (was `Bash #5:`) — visual scan-match with the button row below
- **Flip order**: rolling log now uses `#N name` to match button label `📄 #N name` byte-for-byte
- Updated 2 downgrade-path matchers (add_view-failed + edit-failed) that broke when format flipped

## Tests
+1 unit pin, +3 updated assertions in existing integration test. **717 / 0** (was 716).
