### PR TITLE
feat(mode): /mode group + footer + persistence (#211)

### DIFF
--- a/docs/prd/v1.18-permission-mode-cmd.md
+++ b/docs/prd/v1.18-permission-mode-cmd.md
@@ -1,0 +1,182 @@
+# PRD — `/mode` slash command group + footer display + persistence (#211)
+
+**Status**: APPROVED (DDD locked 5/16 via hxy)
+**Issue**: [#211](https://github.com/HXYerror/2026-...claudeD/issues/211)
+**Branch**: `feat/v1.18-permission-mode-cmd`
+**Severity**: enhancement (CLI parity)
+
+---
+
+## Problem
+
+Claude CLI's terminal UI shows the current permission mode (e.g. `bypass permissions on`, `plan mode on`) and supports `shift+tab` to cycle through them. claudeD has no equivalent — users can't see what mode they're in or switch it mid-session. SDK supports runtime switching via `ClaudeSDKClient.set_permission_mode(...)`.
+
+## User decisions (DDD 5/16, locked)
+
+| # | Decision |
+|---|---|
+| 1 | Use candidate 3: `/mode` group with `set` / `cycle` / `current` subcommands (parallel to `/model`) |
+| 2 | Footer: single new line (not appended to the cost row) |
+| 3 | `/mode set` and `/mode cycle` reply with ephemeral confirmation embed |
+| 4 | **Persistent**: user-explicit mode survives bot restart (saved to `data/sessions.json`). Unset → use `CLAUDED_PERMISSION_MODE` env / `"default"` fallback |
+| 5 | Only expose 4 modes the CLI uses: `default`, `acceptEdits`, `plan`, `bypassPermissions`. `dontAsk` / `auto` not surfaced |
+| 6 | Cycle order: `default → acceptEdits → plan → bypassPermissions → default` |
+
+⚠️ **Decision #4 contrast with #210**: #210 made `model_override` *ephemeral* because `stored.model` was already polluted with forced-sonnet values from pre-#199 builds, so we couldn't trust the stored value. `permission_mode` has no such legacy pollution — fresh schema field, no prior writes. User's underlying intent ("设置了就用设置了") therefore applies directly without the cleanup safeguard.
+
+## Goals
+
+1. **`/mode` group** with 3 subcommands:
+   - `/mode set <mode>` — explicit set, autocomplete to 4-mode set
+   - `/mode cycle` — advance one step in fixed order
+   - `/mode current` — show current mode + source (override / env / default)
+2. **Bridge runtime switch** — call SDK's `set_permission_mode()`; track in `bridge._permission_mode_override` (new field).
+3. **Footer line** — when current effective mode != `"default"`, append a separate line below the cost row showing the mode (e.g., `🔒 plan` / `⚡ bypassPermissions`). When default, no extra line.
+4. **Persistence** — `data/sessions.json` row gains `permission_mode_override: str | None` field. Written via `save_session_state` when user has explicitly set it. Read on auto-resume / `/session resume` and re-injected as `SessionConfig.permission_mode_override` for the next bridge init.
+5. **`/health` + `/session info`** — include the current permission mode in their existing displays.
+
+## Non-goals
+
+- Surfacing `dontAsk` or `auto` SDK modes (per decision #5)
+- Cross-channel "global" mode setting
+- Hooking SDK's hook system for fine-grained per-tool decisions
+- Re-implementing `CLAUDED_PERMISSION_MODE` env semantics — keep as-is
+
+## Design
+
+### Tier resolution (mirror of `/model`'s 4-tier from #198 PRD)
+
+| Tier | Source | Lifetime | Footer label |
+|---|---|---|---|
+| 1 | `/mode set <X>` → `_permission_mode_override` | persisted across restart | `{X}` (no suffix) |
+| 2 | `CLAUDED_PERMISSION_MODE` env | persistent (env-set) | `{X} (env)` |
+| 3 | unset → SDK / config default `"default"` | implicit | (no footer line) |
+
+Cycle reads the **current effective mode** (override or env or default) and advances. Persists the new value as override.
+
+### Footer
+
+`discord_renderer.py` cost-footer builder. After the existing line:
+```
+-# 💰 $0.0042 │ 📥 1.2k │ 📤 800 │ ⏱️ 3.4s │ 🧠 12%
+```
+add a conditional second line **only when effective mode != "default"**:
+```
+-# 🔒 plan
+```
+or
+```
+-# ⚡ bypassPermissions
+```
+
+Emoji mapping (centralized):
+- `default` → (no footer line shown)
+- `acceptEdits` → `✏️ acceptEdits`
+- `plan` → `🔒 plan`
+- `bypassPermissions` → `⚡ bypassPermissions`
+
+### SDK runtime switch
+
+`claude_bridge.py`:
+```python
+async def set_permission_mode(self, mode: str) -> None:
+    """Runtime switch via SDK control-plane. Persists to _permission_mode_override
+    so subsequent reads via .effective_permission_mode reflect the new value."""
+    if self._client is None or not self._active:
+        raise RuntimeError("bridge not active")
+    await self._client.set_permission_mode(mode)
+    self._permission_mode_override = mode
+```
+
+### Persistence schema
+
+`data/sessions.json` per-thread row:
+```json
+{
+  "session_id": "...",
+  "project_path": "...",
+  "system_prompt": "...",
+  "model": null,
+  "permission_mode_override": "plan",   // ← NEW; null when unset
+  "last_active": "..."
+}
+```
+
+`SessionStore.save_session(thread_id, session_id, project_path, *, model=None, system_prompt=None, permission_mode_override=None)` gains the new kwarg. `SessionManager.save_session_state` writes `bridge.permission_mode_override` (new accessor — parallel to `bridge.explicit_model_override` from #199).
+
+Read path: `bot.py:_handle_thread_message` resume block reads `stored.get("permission_mode_override")` and feeds it into `SessionConfig(permission_mode_override=...)`. New bridge instances honor it at `start()`.
+
+### Cycle command
+
+Pure helper:
+```python
+_CYCLE_ORDER = ["default", "acceptEdits", "plan", "bypassPermissions"]
+
+def _next_mode(current: str) -> str:
+    try:
+        idx = _CYCLE_ORDER.index(current)
+    except ValueError:
+        return "default"  # unknown / dontAsk / auto → snap to start
+    return _CYCLE_ORDER[(idx + 1) % len(_CYCLE_ORDER)]
+```
+
+## Acceptance criteria
+
+### Behavioral
+- [ ] `/mode set plan` in active session → SDK actually switches; next tool-use respects plan mode; embed reply confirms; footer shows `🔒 plan` on next turn
+- [ ] `/mode cycle` advances through 4 modes in order; loops back to default
+- [ ] `/mode current` shows current mode + source tag (override / env / default)
+- [ ] Bot restart → resumes with persisted `permission_mode_override`; user not forced back to default
+- [ ] `CLAUDED_PERMISSION_MODE=plan` env, no `/mode set` → `/mode current` shows `plan (env)`
+- [ ] Default mode → footer second line omitted
+- [ ] Non-default mode → footer second line present
+
+### Persistence
+- [ ] `save_session_state` writes `permission_mode_override` when user has set one
+- [ ] `save_session_state` writes `null` when user has not set one (parallel to #210 `model=None` pattern)
+- [ ] Auto-resume reads field and threads to `SessionConfig`
+
+### `/health` + `/session info`
+- [ ] Both show the current effective permission mode + source
+
+### Migration
+- [ ] Pre-#211 rows in `sessions.json` lack the field → read returns `None` → resume falls through to env / default. No crash.
+- [ ] New rows post-#211 always include the field (may be `null`).
+- [ ] No startup migration needed (schema additive).
+
+### Tests
+- [ ] Unit: `_next_mode` cycle order + invalid-current fallback
+- [ ] Unit: effective_permission_mode resolution tier (override > env > "default")
+- [ ] Integration: `/mode set plan` triggers `bridge.set_permission_mode("plan")` + persists override
+- [ ] Integration: `/mode cycle` runs 5 times → cycles all 4 + back to default
+- [ ] Integration: `/mode current` 3 source cases (override / env / default)
+- [ ] Integration: bot restart simulation — write `permission_mode_override="bypassPermissions"` to stored, resume → `SessionConfig` carries it
+- [ ] Integration: footer renders `🔒 plan` when mode=plan, omits when default
+- [ ] Audit: `MODE_EMOJI` mapping has exactly 3 entries (acceptEdits, plan, bypassPermissions); default excluded
+
+## Out of scope
+
+- Surfacing `dontAsk` / `auto` SDK modes
+- Per-channel global mode policy
+- Hook-based fine-grained tool permission decisions
+- Migration of legacy fields in `sessions.json`
+
+## Risks
+
+- **SDK type drift**: `PermissionMode` is a `Literal` — if SDK renames a mode, our hardcoded `_CYCLE_ORDER` + `MODE_EMOJI` keys silently miss. Mitigation: a contract pin test like #193's (`from claude_agent_sdk.types import PermissionMode` + assert keys are subset of Literal values).
+- **Default-mode resume edge case**: user explicitly does `/mode set default`. Is that "they want default explicitly" or "unset"? Per decision #4 + #210 lesson: explicit-default is still an explicit override (persisted as `"default"`, not `None`). Footer still omits (default = no footer line). Distinguishable by `/mode current` showing source = override.
+
+## Plan
+
+Single coding agent ~15 min. 5 sub-tasks:
+
+1. **S1** — `cogs/mode.py` new module with `/mode set/cycle/current` group + `_CYCLE_ORDER` + `MODE_EMOJI` + `_next_mode` helper. Register in `bot.py setup_hook` alongside other groups.
+2. **S2** — `claude_bridge.py`: `_permission_mode_override` field, `permission_mode_override` accessor, `set_permission_mode()` async method, `effective_permission_mode` property.
+3. **S3** — `session_store.py` schema + `session_manager.py.save_session_state` + `bot.py:_handle_thread_message` auto-resume + `cogs/session.py` /session resume — thread the new field through.
+4. **S4** — `discord_renderer.py`: footer second line for non-default mode.
+5. **S5** — `/health` + `/session info` display updates.
+6. **S6** — Tests per acceptance criteria.
+
+## Sign-off
+
+DDD-approved per hxy 5/16 message in test guild.

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -223,6 +223,7 @@ class ClaudedBot(commands.Bot):
         from .cogs.project import project_group, env_group
         from .cogs.session import session_group
         from .cogs.model import model_group, set_effort, max_turns_cmd, fallback_model_cmd, toggle_bare
+        from .cogs.mode import mode_group
         from .cogs.tools import tools_group, budget_group
         from .cogs.agent import agent_group
         from .cogs.mcp import mcp_group
@@ -239,6 +240,7 @@ class ClaudedBot(commands.Bot):
         self.tree.add_command(session_group)
         self.tree.add_command(cost_group)
         self.tree.add_command(model_group)
+        self.tree.add_command(mode_group)
         self.tree.add_command(set_effort)
         self.tree.add_command(tools_group)
         self.tree.add_command(budget_group)
@@ -725,6 +727,14 @@ class ClaudedBot(commands.Bot):
                     # back to ~/.claude/settings.json (CLI default) when
                     # model_override is None.
                     stored_prompt = stored.get("system_prompt") if stored else None
+                    # #211: read the user-explicit permission-mode override
+                    # from the stored row so a bot restart preserves the
+                    # user's last ``/mode set`` / cycle choice (PRD user
+                    # decision #4). Missing field on legacy rows → None →
+                    # bridge falls back to env / "default".
+                    stored_perm_mode = (
+                        stored.get("permission_mode_override") if stored else None
+                    )
                     extra_dirs = self.project_manager.get_extra_dirs(parent_id)
                     mcp_servers = self.project_manager.get_mcp_servers(parent_id)
                     _thread_target = message.channel
@@ -747,6 +757,7 @@ class ClaudedBot(commands.Bot):
                     sc = SessionConfig(
                         system_prompt=stored_prompt or system_prompt,
                         model_override=None,  # #210: ephemeral; see note above
+                        permission_mode_override=stored_perm_mode,  # #211: persistent
                         resume_session_id=resume_id,
                         on_ask_user=handler.handle_ask_user_question,
                         on_pre_tool_use=_pre_tool_notify_thread if _notify else None,
@@ -998,6 +1009,7 @@ class ClaudedBot(commands.Bot):
                             retry_sc = SessionConfig(
                                 system_prompt=_retry_sc.system_prompt,
                                 model_override=_retry_sc.model_override,
+                                permission_mode_override=_retry_sc.permission_mode_override,
                                 effort=_retry_sc.effort,
                                 allowed_tools=list(_retry_sc.allowed_tools) if _retry_sc.allowed_tools else [],
                                 disallowed_tools=list(_retry_sc.disallowed_tools) if _retry_sc.disallowed_tools else [],

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -95,6 +95,12 @@ class ClaudeBridge:
         self._last_activity = time.time()
         self._start_time = time.time()
         self._model_override = sc.model_override
+        # #211: per-session override for ``permission_mode``. Initialized
+        # from the SessionConfig (which auto-resume / /session resume read
+        # from ``data/sessions.json`` so the user's choice survives a bot
+        # restart). When None, the SDK call uses ``config.claude_permission_mode``
+        # (CLAUDE_PERMISSION_MODE env or ``"default"``).
+        self._permission_mode_override: str | None = sc.permission_mode_override
         self._resume_session_id = sc.resume_session_id
         self._effort = sc.effort
         self._allowed_tools = list(sc.allowed_tools) if sc.allowed_tools else []
@@ -177,6 +183,61 @@ class ClaudeBridge:
         not switched and the SDK's CLI-default should govern.
         """
         return self._model_override
+
+    @property
+    def permission_mode_override(self) -> str | None:
+        """The user-explicit ``/mode set`` (or ``/mode cycle``) value, or ``None``.
+
+        #211: read-only accessor used by
+        :meth:`SessionManager.save_session_state` so we persist ONLY what
+        the user explicitly set — not the env or default fallback. Mirror
+        of :attr:`explicit_model_override` but for permission mode.
+
+        Returns ``None`` when the user has never run ``/mode set`` / cycle
+        on this thread (or on a previous-restart thread we haven't re-seen
+        since); callers fall back to env (``CLAUDE_PERMISSION_MODE``) or
+        ``"default"`` via :attr:`effective_permission_mode`.
+        """
+        return self._permission_mode_override
+
+    @property
+    def effective_permission_mode(self) -> str:
+        """Return the active permission mode: override > config > ``"default"``.
+
+        #211: collapsed accessor used by the footer renderer and ``/mode
+        current`` display. Always returns a non-empty string (the SDK's
+        ``PermissionMode`` literal contract), so callers can compare
+        ``!= "default"`` without a None check.
+
+        Tier order:
+        1. ``_permission_mode_override`` — user ran ``/mode set`` or ``cycle``
+        2. ``_config.claude_permission_mode`` — ``CLAUDE_PERMISSION_MODE`` env,
+           or its ``"default"`` fallback (set by ``load_config``)
+        """
+        return (
+            self._permission_mode_override
+            or self._config.claude_permission_mode
+            or "default"
+        )
+
+    async def set_permission_mode(self, mode: str) -> None:
+        """Runtime switch via the SDK's control-plane.
+
+        #211: surfaces ``ClaudeSDKClient.set_permission_mode`` so user-
+        facing ``/mode set`` / ``/mode cycle`` can flip the mode mid-
+        session without recreating the bridge (which would lose context).
+        Caller is responsible for passing a valid SDK ``PermissionMode``
+        literal — the SDK will raise if it doesn't recognize the value.
+
+        Persists the new value to ``_permission_mode_override`` so
+        :attr:`effective_permission_mode` and the footer reflect the
+        change. The SDK call happens FIRST so a rejection from the
+        underlying CLI leaves our override unchanged (no lying display).
+        """
+        if self._client is None or not self._active:
+            raise RuntimeError("bridge not active")
+        await self._client.set_permission_mode(mode)
+        self._permission_mode_override = mode
 
     @property
     def is_active(self) -> bool:
@@ -357,7 +418,12 @@ class ClaudeBridge:
         options = ClaudeAgentOptions(
             cwd=self.project_path,
             env=self._env or {},
-            permission_mode=self._config.claude_permission_mode,
+            # #211: per-session override > config (env / default). Use the
+            # same accessor the runtime ``set_permission_mode()`` updates so
+            # an auto-resumed session with a persisted override re-enters the
+            # bridge with the right mode on the very first turn (not just
+            # after the user re-runs ``/mode set``).
+            permission_mode=self.effective_permission_mode,
             model=chosen_model,
             resume=self._resume_session_id,
             # R3 (#116): system_prompt preset dict replaces append_system_prompt

--- a/src/clauded/cogs/mode.py
+++ b/src/clauded/cogs/mode.py
@@ -21,7 +21,12 @@ import logging
 import discord
 from discord import app_commands
 
-from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE, COLOR_TOOL_SUCCESS
+from ..discord_renderer import (
+    COLOR_INFO,
+    COLOR_TOOL_FAILURE,
+    COLOR_TOOL_SUCCESS,
+    MODE_EMOJI,
+)
 
 log = logging.getLogger("clauded.bot")
 
@@ -37,15 +42,10 @@ _CYCLE_ORDER: list[str] = [
 
 
 # Emoji mapping for the footer + display surfaces. ``default`` is
-# deliberately absent — when the effective mode is ``default`` the
-# footer second line is omitted entirely (PRD §Design "Footer"). Keep
-# this dict centralized so the renderer + /health + /session info all
-# share the same source of truth.
-MODE_EMOJI: dict[str, str] = {
-    "acceptEdits": "✏️",
-    "plan": "🔒",
-    "bypassPermissions": "⚡",
-}
+# MODE_EMOJI is imported from `..discord_renderer` (#211 R1 architect:
+# relocated there to break a cyclic import — the renderer's cost-footer
+# code is the primary consumer; this cog imports it back for
+# /mode current + /health + /session info displays).
 
 
 def _next_mode(current: str) -> str:
@@ -88,26 +88,61 @@ def _mode_source_for_bridge(bridge) -> tuple[str, str]:
 
 
 def _format_mode_display(mode: str, source: str) -> str:
-    """Render ``{emoji} {mode} (source: ...)`` for embed bodies.
+    """Render ``{emoji} {mode} (source: ...) — persisted/...`` for embed bodies.
 
     Used by ``/mode current``, ``/health``, and ``/session info`` so
     every surface labels the active mode identically. ``default`` shows
     no emoji prefix; the other three modes get their ``MODE_EMOJI``
     glyph.
+
+    Source → lifetime label (#211 R1 architect):
+      - ``override`` → “persisted” (survives bot restart, PRD §Decision #4)
+      - ``env``      → “env-pinned” (CLAUDED_PERMISSION_MODE env)
+      - ``default``  → “CLI default”
+    Surfacing the lifetime is the user-visible fix for the
+    /mode-persistent vs /model-ephemeral dichotomy.
     """
     emoji = MODE_EMOJI.get(mode, "")
     label = f"{emoji} `{mode}`".strip() if emoji else f"`{mode}`"
-    return f"{label} (source: {source})"
+    lifetime = {
+        "override": "persisted",
+        "env": "env-pinned",
+        "default": "CLI default",
+    }.get(source, source)
+    return f"{label} (source: {source} — {lifetime})"
 
 
 mode_group = app_commands.Group(
     name="mode",
     description="View / switch Claude permission mode for this thread",
+    # #211 R1 security HIGH (PR #221): /mode set bypassPermissions auto-
+    # approves all SDK tool calls + persists across restart. Gate write
+    # subcommands to admin-default; `/mode current` is read-only and
+    # stays open. Defense-in-depth re-check at each callback (Discord
+    # default_permissions is admin-reassignable in the server UI; the
+    # callback check defends against role overrides). Pattern matches
+    # `ops.unbound_fallback_toggle` (the closest precedent).
 )
+
+
+def _require_admin(interaction: discord.Interaction) -> bool:
+    """Defense-in-depth admin check for write-side /mode subcommands.
+
+    Returns True if caller is administrator; otherwise emits an
+    ephemeral refusal and returns False (caller should return early).
+    Mirror of the per-callback re-check in ``ops.unbound_fallback_toggle``
+    (#211 R1 security #1).
+    """
+    perms = getattr(interaction.user, "guild_permissions", None)
+    if perms is not None and perms.administrator:
+        return True
+    return False
 
 
 @mode_group.command(name="set", description="Set Claude permission mode for this thread")
 @app_commands.describe(mode="Mode: default / acceptEdits / plan / bypassPermissions")
+@app_commands.default_permissions(administrator=True)
+@app_commands.guild_only()
 @app_commands.choices(mode=[
     app_commands.Choice(name="default", value="default"),
     app_commands.Choice(name="acceptEdits ✏️", value="acceptEdits"),
@@ -123,6 +158,16 @@ async def mode_set(
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
+    # #211 R1 security HIGH: defense-in-depth admin re-check (Discord
+    # default_permissions can be UI-overridden per role; the callback
+    # check guarantees a privilege-elevating action requires admin
+    # regardless of UI policy).
+    if not _require_admin(interaction):
+        await interaction.response.send_message(
+            "❌ Administrator permission required to change permission mode.",
+            ephemeral=True,
+        )
+        return
     thread_id = getattr(interaction.channel, "id", None)
     bridge = (
         bot.session_manager.get_session(thread_id) if thread_id is not None else None
@@ -135,6 +180,13 @@ async def mode_set(
         )
         return
 
+    # #211 R1 security HIGH: privilege-elevation audit trail.
+    # Every permission_mode write is forensic-worthy; log WARNING with
+    # WHO/WHERE/WHAT-CHANGED so operators can reconstruct who relaxed
+    # tool permissions when. Matches `ops.unbound_fallback_toggle`
+    # precedent.
+    member = interaction.user
+    previous_mode = getattr(bridge, "effective_permission_mode", "default")
     try:
         await bridge.set_permission_mode(mode.value)
     except Exception as exc:
@@ -148,6 +200,12 @@ async def mode_set(
             ephemeral=True,
         )
         return
+    log.warning(
+        "SECURITY: /mode set permission_mode %s -> %s by user=%s(id=%s) guild=%s channel=%s thread=%s",
+        previous_mode, mode.value,
+        getattr(member, "name", "?"), getattr(member, "id", "?"),
+        interaction.guild_id, interaction.channel_id, thread_id,
+    )
 
     # Persist immediately so a bot restart between this turn and the
     # next one preserves the user's choice (PRD user decision #4).
@@ -160,7 +218,11 @@ async def mode_set(
     title = f"{emoji} Permission mode: `{mode.value}`".strip()
     embed = discord.Embed(
         title=title,
-        description=f"Mode set to **{mode.value}**. The next tool call will respect it.",
+        description=(
+            f"Mode set to **{mode.value}**. The next tool call will respect it.\n\n"
+            "-# 💾 **Persisted** — survives bot restart. (Contrast with "
+            "`/model switch` which is per-session.) Use `/mode set default` to clear."
+        ),
         color=COLOR_INFO,
     )
     await interaction.response.send_message(embed=embed, ephemeral=True)
@@ -170,12 +232,21 @@ async def mode_set(
     name="cycle",
     description="Advance to the next permission mode in the fixed cycle order",
 )
+@app_commands.default_permissions(administrator=True)
+@app_commands.guild_only()
 async def mode_cycle(interaction: discord.Interaction) -> None:
     from ..bot import ClaudedBot
 
     bot = interaction.client
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    # #211 R1 security HIGH: defense-in-depth admin re-check.
+    if not _require_admin(interaction):
+        await interaction.response.send_message(
+            "❌ Administrator permission required to cycle permission mode.",
+            ephemeral=True,
+        )
         return
     thread_id = getattr(interaction.channel, "id", None)
     bridge = (
@@ -194,6 +265,7 @@ async def mode_cycle(interaction: discord.Interaction) -> None:
     # back to ``acceptEdits`` (the would-be successor of ``default``).
     current = getattr(bridge, "effective_permission_mode", "default") or "default"
     new_mode = _next_mode(current)
+    member = interaction.user
     try:
         await bridge.set_permission_mode(new_mode)
     except Exception as exc:
@@ -207,6 +279,12 @@ async def mode_cycle(interaction: discord.Interaction) -> None:
             ephemeral=True,
         )
         return
+    log.warning(
+        "SECURITY: /mode cycle permission_mode %s -> %s by user=%s(id=%s) guild=%s channel=%s thread=%s",
+        current, new_mode,
+        getattr(member, "name", "?"), getattr(member, "id", "?"),
+        interaction.guild_id, interaction.channel_id, thread_id,
+    )
 
     try:
         bot.session_manager.save_session_state(thread_id)
@@ -217,7 +295,10 @@ async def mode_cycle(interaction: discord.Interaction) -> None:
     title = f"{emoji} Permission mode: `{new_mode}`".strip()
     embed = discord.Embed(
         title=title,
-        description=f"Cycled `{current}` → **{new_mode}**.",
+        description=(
+            f"Cycled `{current}` → **{new_mode}**.\n\n"
+            "-# 💾 **Persisted** — survives bot restart."
+        ),
         color=COLOR_INFO,
     )
     await interaction.response.send_message(embed=embed, ephemeral=True)

--- a/src/clauded/cogs/mode.py
+++ b/src/clauded/cogs/mode.py
@@ -1,0 +1,267 @@
+"""#211 — `/mode` slash command group for Claude permission mode.
+
+Surfaces the SDK's existing ``ClaudeSDKClient.set_permission_mode()``
+control-plane runtime switch as user-facing slash commands so a Discord
+user can see / change / cycle the active permission mode without having
+to recreate the session. Mirrors the Claude CLI's terminal UI which
+displays the mode below the cost row and supports ``shift+tab`` to
+cycle. See ``docs/prd/v1.18-permission-mode-cmd.md``.
+
+Per PRD user decision #5 only 4 of the SDK's 6 ``PermissionMode``
+literals are exposed (``dontAsk`` / ``auto`` are deliberately hidden).
+``test_permission_mode_literals_match_sdk_contract`` pins this list as
+a subset of the SDK's ``PermissionMode`` so a future SDK rename of any
+of our 4 modes fails loudly rather than silently.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord import app_commands
+
+from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE, COLOR_TOOL_SUCCESS
+
+log = logging.getLogger("clauded.bot")
+
+
+# Cycle order surfaced by ``/mode cycle`` (per PRD user decision #6).
+# Order is fixed: default → acceptEdits → plan → bypassPermissions → default.
+_CYCLE_ORDER: list[str] = [
+    "default",
+    "acceptEdits",
+    "plan",
+    "bypassPermissions",
+]
+
+
+# Emoji mapping for the footer + display surfaces. ``default`` is
+# deliberately absent — when the effective mode is ``default`` the
+# footer second line is omitted entirely (PRD §Design "Footer"). Keep
+# this dict centralized so the renderer + /health + /session info all
+# share the same source of truth.
+MODE_EMOJI: dict[str, str] = {
+    "acceptEdits": "✏️",
+    "plan": "🔒",
+    "bypassPermissions": "⚡",
+}
+
+
+def _next_mode(current: str) -> str:
+    """Return the next mode in ``_CYCLE_ORDER`` after ``current``.
+
+    Loops back to the first element after the last. If ``current`` is
+    not in the cycle list (e.g., it's ``dontAsk`` / ``auto`` / some
+    future SDK literal we don't surface), snap to the first element so
+    the user can recover into the known cycle.
+    """
+    try:
+        idx = _CYCLE_ORDER.index(current)
+    except ValueError:
+        return _CYCLE_ORDER[0]
+    return _CYCLE_ORDER[(idx + 1) % len(_CYCLE_ORDER)]
+
+
+def _mode_source_for_bridge(bridge) -> tuple[str, str]:
+    """Return ``(source, value)`` describing where the bridge's mode came from.
+
+    Mirror of ``cogs/model.py:_model_source_for_bridge`` but with only 3
+    tiers (no SDK-observed tier — the SDK doesn't report ``permission_mode``
+    on ``ResultMessage``, so the override / env / default split is the
+    full picture).
+
+    Returns one of:
+    - ``("override", "<mode>")``  — user ran ``/mode set`` or ``/mode cycle``
+    - ``("env", "<mode>")``       — ``CLAUDE_PERMISSION_MODE`` env var set
+    - ``("default", "default")``  — fallback (env unset → ``"default"``)
+    """
+    override = getattr(bridge, "_permission_mode_override", None)
+    if override:
+        return ("override", override)
+    config = getattr(bridge, "_config", None)
+    env_mode = getattr(config, "claude_permission_mode", None) if config else None
+    if env_mode and env_mode != "default":
+        # env explicitly pinned to something non-default
+        return ("env", env_mode)
+    return ("default", "default")
+
+
+def _format_mode_display(mode: str, source: str) -> str:
+    """Render ``{emoji} {mode} (source: ...)`` for embed bodies.
+
+    Used by ``/mode current``, ``/health``, and ``/session info`` so
+    every surface labels the active mode identically. ``default`` shows
+    no emoji prefix; the other three modes get their ``MODE_EMOJI``
+    glyph.
+    """
+    emoji = MODE_EMOJI.get(mode, "")
+    label = f"{emoji} `{mode}`".strip() if emoji else f"`{mode}`"
+    return f"{label} (source: {source})"
+
+
+mode_group = app_commands.Group(
+    name="mode",
+    description="View / switch Claude permission mode for this thread",
+)
+
+
+@mode_group.command(name="set", description="Set Claude permission mode for this thread")
+@app_commands.describe(mode="Mode: default / acceptEdits / plan / bypassPermissions")
+@app_commands.choices(mode=[
+    app_commands.Choice(name="default", value="default"),
+    app_commands.Choice(name="acceptEdits ✏️", value="acceptEdits"),
+    app_commands.Choice(name="plan 🔒", value="plan"),
+    app_commands.Choice(name="bypassPermissions ⚡", value="bypassPermissions"),
+])
+async def mode_set(
+    interaction: discord.Interaction, mode: app_commands.Choice[str]
+) -> None:
+    from ..bot import ClaudedBot
+
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    thread_id = getattr(interaction.channel, "id", None)
+    bridge = (
+        bot.session_manager.get_session(thread_id) if thread_id is not None else None
+    )
+    if bridge is None or not bridge.is_active:
+        await interaction.response.send_message(
+            "ℹ️ No active session in this channel. Send a message to start one, "
+            "then `/mode set` will take effect on the next turn.",
+            ephemeral=True,
+        )
+        return
+
+    try:
+        await bridge.set_permission_mode(mode.value)
+    except Exception as exc:
+        log.exception("/mode set failed: %s", exc)
+        await interaction.response.send_message(
+            embed=discord.Embed(
+                title="❌ Failed to set mode",
+                description=f"```\n{str(exc)[:500]}\n```",
+                color=COLOR_TOOL_FAILURE,
+            ),
+            ephemeral=True,
+        )
+        return
+
+    # Persist immediately so a bot restart between this turn and the
+    # next one preserves the user's choice (PRD user decision #4).
+    try:
+        bot.session_manager.save_session_state(thread_id)
+    except Exception:  # pragma: no cover - persistence is best-effort
+        log.exception("/mode set: failed to persist session state")
+
+    emoji = MODE_EMOJI.get(mode.value, "")
+    title = f"{emoji} Permission mode: `{mode.value}`".strip()
+    embed = discord.Embed(
+        title=title,
+        description=f"Mode set to **{mode.value}**. The next tool call will respect it.",
+        color=COLOR_INFO,
+    )
+    await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+@mode_group.command(
+    name="cycle",
+    description="Advance to the next permission mode in the fixed cycle order",
+)
+async def mode_cycle(interaction: discord.Interaction) -> None:
+    from ..bot import ClaudedBot
+
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    thread_id = getattr(interaction.channel, "id", None)
+    bridge = (
+        bot.session_manager.get_session(thread_id) if thread_id is not None else None
+    )
+    if bridge is None or not bridge.is_active:
+        await interaction.response.send_message(
+            "ℹ️ No active session in this channel. Send a message to start one.",
+            ephemeral=True,
+        )
+        return
+
+    # Cycle reads the EFFECTIVE mode (override > env > default), not just
+    # the override field. That way the first cycle from an env-pinned
+    # ``plan`` advances to ``bypassPermissions`` rather than snapping
+    # back to ``acceptEdits`` (the would-be successor of ``default``).
+    current = getattr(bridge, "effective_permission_mode", "default") or "default"
+    new_mode = _next_mode(current)
+    try:
+        await bridge.set_permission_mode(new_mode)
+    except Exception as exc:
+        log.exception("/mode cycle failed: %s", exc)
+        await interaction.response.send_message(
+            embed=discord.Embed(
+                title="❌ Failed to cycle mode",
+                description=f"```\n{str(exc)[:500]}\n```",
+                color=COLOR_TOOL_FAILURE,
+            ),
+            ephemeral=True,
+        )
+        return
+
+    try:
+        bot.session_manager.save_session_state(thread_id)
+    except Exception:  # pragma: no cover - persistence is best-effort
+        log.exception("/mode cycle: failed to persist session state")
+
+    emoji = MODE_EMOJI.get(new_mode, "")
+    title = f"{emoji} Permission mode: `{new_mode}`".strip()
+    embed = discord.Embed(
+        title=title,
+        description=f"Cycled `{current}` → **{new_mode}**.",
+        color=COLOR_INFO,
+    )
+    await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+@mode_group.command(
+    name="current",
+    description="Show the current permission mode + which tier it came from",
+)
+async def mode_current(interaction: discord.Interaction) -> None:
+    from ..bot import ClaudedBot
+
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    thread_id = getattr(interaction.channel, "id", None)
+    bridge = (
+        bot.session_manager.get_session(thread_id) if thread_id is not None else None
+    )
+    if bridge is None:
+        await interaction.response.send_message(
+            "ℹ️ No active session in this channel. Send a message to start one.",
+            ephemeral=True,
+        )
+        return
+
+    source, value = _mode_source_for_bridge(bridge)
+    embed = discord.Embed(
+        title="🛡️ Current Permission Mode",
+        description=_format_mode_display(value, source),
+        color=COLOR_TOOL_SUCCESS,
+    )
+    await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+__all__ = [
+    "mode_group",
+    "mode_set",
+    "mode_cycle",
+    "mode_current",
+    "_CYCLE_ORDER",
+    "MODE_EMOJI",
+    "_next_mode",
+    "_mode_source_for_bridge",
+    "_format_mode_display",
+]

--- a/src/clauded/cogs/model.py
+++ b/src/clauded/cogs/model.py
@@ -100,7 +100,11 @@ async def model_switch(interaction: discord.Interaction, name: str) -> None:
         await interaction.followup.send(
             embed=discord.Embed(
                 title=f"🔄 Switched to `{name}`",
-                description="⚠️ Previous conversation context was reset.",
+                description=(
+                    "⚠️ Previous conversation context was reset.\n\n"
+                    "-# ⏱️ **Per-session** — bot restart returns to your CLI "
+                    "default. (Contrast with `/mode set` which persists.)"
+                ),
                 color=COLOR_INFO,
             )
         )

--- a/src/clauded/cogs/ops.py
+++ b/src/clauded/cogs/ops.py
@@ -109,6 +109,25 @@ async def health_check(interaction: discord.Interaction) -> None:
     embed.add_field(name="Claude CLI", value=claude_version, inline=True)
     embed.add_field(name="Python", value=sys.version.split()[0], inline=True)
 
+    # #211: surface the current channel's permission mode if a session
+    # exists. ``/health`` is callable outside threads too (no session
+    # in scope), in which case we silently skip the field. Centralized
+    # ``_format_mode_display`` keeps the label format in sync with
+    # ``/mode current`` + ``/session info``.
+    thread_id = getattr(interaction.channel, "id", None)
+    bridge = (
+        bot.session_manager.get_session(thread_id) if thread_id is not None else None
+    )
+    if bridge is not None:
+        from .mode import _mode_source_for_bridge, _format_mode_display
+
+        source, value = _mode_source_for_bridge(bridge)
+        embed.add_field(
+            name="Permission mode",
+            value=_format_mode_display(value, source),
+            inline=False,
+        )
+
     await interaction.response.send_message(embed=embed, ephemeral=True)
 
 

--- a/src/clauded/cogs/session.py
+++ b/src/clauded/cogs/session.py
@@ -154,9 +154,17 @@ async def session_info(interaction: discord.Interaction) -> None:
             # source == "unset": bridge active but no _sdk_model yet
             model_display = _placeholder
         cost_str = f"${bridge.total_cost:.4f}" if bridge.total_cost else "$0.0000"
+        # #211: surface the current permission mode + source-tier (parity
+        # with ``/mode current`` and ``/health``). Centralized formatter
+        # lives in cogs.mode so all three surfaces share one label format.
+        from .mode import _mode_source_for_bridge, _format_mode_display
+
+        mode_source, mode_value = _mode_source_for_bridge(bridge)
+        mode_line = _format_mode_display(mode_value, mode_source)
         lines = [
             f"📡 **Session active** — cwd `{bridge.project_path}`",
             f"• Model: {model_display}",
+            f"• Mode: {mode_line}",
             f"• Turns: `{bridge.num_turns}`",
             f"• Total cost: `{cost_str}`",
         ]
@@ -220,6 +228,11 @@ async def session_resume(interaction: discord.Interaction) -> None:
         sc = SessionConfig(
             system_prompt=stored.get("system_prompt"),
             model_override=None,  # #210: ephemeral; see note above
+            # #211: opposite of model_override — permission_mode_override
+            # IS persistent (PRD user decision #4 contrast with #210). Read
+            # the stored value if present; legacy rows without the field
+            # safely return None and fall through to env / "default".
+            permission_mode_override=stored.get("permission_mode_override"),
             on_ask_user=handler.handle_ask_user_question,
             resume_session_id=stored["session_id"],
         )

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1634,6 +1634,28 @@ class DiscordRenderer:
                 if _last_stop_reason and _last_stop_reason != "end_turn":
                     footer_text += f" │ ⚠️ {_last_stop_reason}"
 
+                # #211: append a second footer line showing the current
+                # effective permission mode — but ONLY when it's not the
+                # implicit ``"default"`` (PRD §Design "Footer"). Pulling
+                # ``bridge.effective_permission_mode`` here collapses
+                # override / env / default into one string we just compare.
+                # Imported lazily to keep the module-level dependency graph
+                # symmetric (renderer ↔ cogs.mode would otherwise import
+                # each other transitively through bot.py).
+                try:
+                    from .cogs.mode import MODE_EMOJI
+                    effective_mode = getattr(
+                        bridge, "effective_permission_mode", "default"
+                    )
+                    if effective_mode and effective_mode != "default":
+                        mode_emoji = MODE_EMOJI.get(effective_mode, "")
+                        # Discord ``-#`` small-text marker repeats per
+                        # line: emoji on its own row keeps the mode
+                        # visually separated from the cost stats above.
+                        footer_text += f"\n-# {mode_emoji} {effective_mode}".rstrip()
+                except Exception:  # pragma: no cover - never break the cost footer
+                    log.debug("Mode footer append failed; continuing", exc_info=True)
+
                 if self._last_msg is not None:
                     # Try to append to the last user-visible message.
                     current = self._last_msg_text.rstrip(CURSOR)

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -179,6 +179,17 @@ COLOR_THINKING = 0x6B7280      # Gray — thinking
 # we can append a cursor or close-and-reopen a code fence safely.
 DISCORD_MAX_LEN = 1900
 
+# #211 R1 architect: relocated from cogs/mode.py to break a real cyclic
+# import (cogs/mode.py imports COLOR_INFO from this module; the renderer
+# previously did a lazy ``from .cogs.mode import MODE_EMOJI`` to paper
+# over the cycle). MODE_EMOJI is a rendering concern — it lives here.
+# cogs/mode.py imports it back for /mode current + /health + /session info.
+MODE_EMOJI: dict[str, str] = {
+    "acceptEdits": "✏️",
+    "plan": "🔒",
+    "bypassPermissions": "⚡",
+}
+
 # Single-character cursor appended to the in-flight typewriter message.
 CURSOR = "▌"
 
@@ -1639,11 +1650,10 @@ class DiscordRenderer:
                 # implicit ``"default"`` (PRD §Design "Footer"). Pulling
                 # ``bridge.effective_permission_mode`` here collapses
                 # override / env / default into one string we just compare.
-                # Imported lazily to keep the module-level dependency graph
-                # symmetric (renderer ↔ cogs.mode would otherwise import
-                # each other transitively through bot.py).
+                # MODE_EMOJI lives at module scope of this file (#211 R1
+                # architect relocation — breaks the previous lazy import
+                # cycle with cogs/mode.py).
                 try:
-                    from .cogs.mode import MODE_EMOJI
                     effective_mode = getattr(
                         bridge, "effective_permission_mode", "default"
                     )

--- a/src/clauded/session_config.py
+++ b/src/clauded/session_config.py
@@ -11,6 +11,7 @@ class SessionConfig:
 
     system_prompt: str | None = None
     model_override: str | None = None
+    permission_mode_override: str | None = None
     resume_session_id: str | None = None
     effort: str | None = None
     allowed_tools: list[str] = field(default_factory=list)

--- a/src/clauded/session_manager.py
+++ b/src/clauded/session_manager.py
@@ -118,6 +118,13 @@ class SessionManager:
                 thread_id, bridge.session_id, bridge.project_path,
                 model=None,  # #210: ephemeral; read-side ignores this field
                 system_prompt=bridge.system_prompt,
+                # #211: persist the user-explicit override (None when
+                # they've never run /mode set on this thread; the
+                # SessionStore happily round-trips None for legacy rows
+                # / unset cases).
+                permission_mode_override=getattr(
+                    bridge, "permission_mode_override", None
+                ),
             )
 
     def get_stored_session(self, thread_id: int) -> dict | None:

--- a/src/clauded/session_store.py
+++ b/src/clauded/session_store.py
@@ -55,12 +55,19 @@ class SessionStore:
         os.replace(tmp, self._path)
 
     def save_session(self, thread_id: int, session_id: str, project_path: str,
-                     model: str | None = None, system_prompt: str | None = None) -> None:
+                     model: str | None = None, system_prompt: str | None = None,
+                     permission_mode_override: str | None = None) -> None:
         self._sessions[str(thread_id)] = {
             "session_id": session_id,
             "project_path": project_path,
             "model": model,
             "system_prompt": system_prompt,
+            # #211: persist the user's explicit ``/mode set`` / cycle choice
+            # so it survives bot restart (per PRD user decision #4). Unlike
+            # ``model`` (which #210 made vestigial because of legacy
+            # pollution), ``permission_mode_override`` is a fresh schema
+            # field with no prior writes — read-side honors it unmodified.
+            "permission_mode_override": permission_mode_override,
             "last_active": datetime.now(timezone.utc).isoformat(),
         }
         self._save()

--- a/tests/test_model_default.py
+++ b/tests/test_model_default.py
@@ -481,7 +481,7 @@ def test_save_session_state_persists_only_explicit_override_no_sdk_loop():
     # Capture what gets passed to the store
     captured: dict = {}
 
-    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None):
+    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None, **kwargs):
         captured.update(
             thread_id=thread_id, session_id=session_id, project_path=project_path,
             model=model, system_prompt=system_prompt,
@@ -531,7 +531,7 @@ def test_save_session_state_persists_user_override_when_set():
 
     captured: dict = {}
 
-    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None):
+    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None, **kwargs):
         captured["model"] = model
 
     sm._session_store.save_session = _fake_save  # type: ignore[method-assign]

--- a/tests/test_model_stored_readside.py
+++ b/tests/test_model_stored_readside.py
@@ -313,7 +313,7 @@ def test_save_session_state_always_writes_none() -> None:
 
     captured: dict = {}
 
-    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None):
+    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None, **kwargs):
         captured.update(
             thread_id=thread_id, session_id=session_id,
             project_path=project_path, model=model,
@@ -350,7 +350,7 @@ def test_save_session_state_writes_none_when_no_user_override() -> None:
 
     captured: dict = {}
 
-    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None):
+    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None, **kwargs):
         captured["model"] = model
 
     sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
@@ -595,7 +595,7 @@ def test_regression_199_r1_no_sdk_loop_still_holds() -> None:
 
     captured: dict = {}
 
-    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None):
+    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None, **kwargs):
         captured["model"] = model
 
     sm._session_store.save_session = _fake_save  # type: ignore[method-assign]

--- a/tests/test_permission_mode.py
+++ b/tests/test_permission_mode.py
@@ -1,0 +1,890 @@
+"""#211 — `/mode` group + bridge runtime switch + persistence + footer.
+
+Pins the contract from ``docs/prd/v1.18-permission-mode-cmd.md``:
+
+- ``_CYCLE_ORDER`` + ``MODE_EMOJI`` shape (decisions #5, #6).
+- ``_next_mode`` cycle correctness + invalid-current fallback.
+- ``effective_permission_mode`` 3-tier resolution (override > env > default).
+- ``/mode set`` calls ``bridge.set_permission_mode`` + persists.
+- ``/mode cycle`` 5-step walk back to ``default``.
+- ``/mode current`` source-tag matrix.
+- Persistence end-to-end (write + auto-resume read + /session resume read).
+- Footer second-line presence/absence by mode.
+- ``/health`` + ``/session info`` show the mode.
+- SDK contract pin: cycle modes ⊂ SDK ``PermissionMode`` Literal.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from clauded.config import Config
+from clauded.session_config import SessionConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _config(perm_mode: str = "default") -> Config:
+    return Config(
+        discord_bot_token="tok",
+        claude_model=None,
+        claude_permission_mode=perm_mode,
+        projects_root="/tmp",
+    )
+
+
+def _bridge(
+    *, override: str | None = None, env_mode: str = "default", active: bool = True
+) -> Any:
+    """Build a MagicMock bridge with the requested tier state."""
+    bridge = MagicMock()
+    bridge._permission_mode_override = override
+    cfg = MagicMock()
+    cfg.claude_permission_mode = env_mode
+    bridge._config = cfg
+    bridge.is_active = active
+    bridge.project_path = "/tmp/proj"
+    bridge.num_turns = 1
+    bridge.total_cost = 0.0
+    # Mirror the real bridge property semantics:
+    bridge.permission_mode_override = override
+    bridge.effective_permission_mode = override or env_mode or "default"
+    bridge.set_permission_mode = AsyncMock()
+    return bridge
+
+
+# ---------------------------------------------------------------------------
+# S1 — _CYCLE_ORDER + MODE_EMOJI shape pins.
+# ---------------------------------------------------------------------------
+
+
+def test_cycle_order_has_exactly_four_modes() -> None:
+    """Decision #5: 4 surfaced modes only. ``dontAsk`` / ``auto`` not in list."""
+    from clauded.cogs.mode import _CYCLE_ORDER
+
+    assert _CYCLE_ORDER == [
+        "default", "acceptEdits", "plan", "bypassPermissions",
+    ], f"_CYCLE_ORDER drifted: {_CYCLE_ORDER}"
+
+
+def test_mode_emoji_has_exactly_three_non_default_entries() -> None:
+    """Decision #2: ``default`` has NO emoji entry (footer skips when default)."""
+    from clauded.cogs.mode import MODE_EMOJI
+
+    assert set(MODE_EMOJI.keys()) == {"acceptEdits", "plan", "bypassPermissions"}, (
+        f"MODE_EMOJI keys drifted: {set(MODE_EMOJI.keys())}"
+    )
+    assert "default" not in MODE_EMOJI
+
+
+def test_permission_mode_literals_match_sdk_contract() -> None:
+    """Mirror of #193's literal-pin pattern: the modes we surface must be a
+    subset of the SDK's PermissionMode Literal so a future SDK rename breaks
+    loudly here rather than silently mis-routing tool calls."""
+    from clauded.cogs.mode import _CYCLE_ORDER, MODE_EMOJI
+    from claude_agent_sdk.types import PermissionMode
+    import typing
+
+    sdk_modes = set(typing.get_args(PermissionMode))
+    cycle_modes = set(_CYCLE_ORDER)
+    assert cycle_modes.issubset(sdk_modes), (
+        f"_CYCLE_ORDER has modes not in SDK PermissionMode Literal: "
+        f"{cycle_modes - sdk_modes}"
+    )
+    emoji_modes = set(MODE_EMOJI.keys())
+    assert emoji_modes.issubset(sdk_modes), (
+        f"MODE_EMOJI has keys not in SDK PermissionMode Literal: "
+        f"{emoji_modes - sdk_modes}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# S1 — _next_mode pure-function tests.
+# ---------------------------------------------------------------------------
+
+
+def test_next_mode_walks_cycle_order() -> None:
+    from clauded.cogs.mode import _next_mode
+
+    assert _next_mode("default") == "acceptEdits"
+    assert _next_mode("acceptEdits") == "plan"
+    assert _next_mode("plan") == "bypassPermissions"
+    assert _next_mode("bypassPermissions") == "default"
+
+
+def test_next_mode_unknown_input_snaps_to_default() -> None:
+    """``dontAsk``/``auto``/typos → snap to first element of cycle."""
+    from clauded.cogs.mode import _next_mode
+
+    assert _next_mode("dontAsk") == "default"
+    assert _next_mode("auto") == "default"
+    assert _next_mode("") == "default"
+    assert _next_mode("garbage") == "default"
+
+
+# ---------------------------------------------------------------------------
+# S1 — _mode_source_for_bridge tier dispatch.
+# ---------------------------------------------------------------------------
+
+
+def test_mode_source_override_wins() -> None:
+    from clauded.cogs.mode import _mode_source_for_bridge
+
+    bridge = _bridge(override="plan", env_mode="acceptEdits")
+    src, val = _mode_source_for_bridge(bridge)
+    assert src == "override"
+    assert val == "plan"
+
+
+def test_mode_source_env_when_no_override() -> None:
+    from clauded.cogs.mode import _mode_source_for_bridge
+
+    bridge = _bridge(override=None, env_mode="acceptEdits")
+    src, val = _mode_source_for_bridge(bridge)
+    assert src == "env"
+    assert val == "acceptEdits"
+
+
+def test_mode_source_default_when_env_is_default() -> None:
+    """``CLAUDE_PERMISSION_MODE`` unset → config has ``"default"`` →
+    source is ``default``, not ``env``."""
+    from clauded.cogs.mode import _mode_source_for_bridge
+
+    bridge = _bridge(override=None, env_mode="default")
+    src, val = _mode_source_for_bridge(bridge)
+    assert src == "default"
+    assert val == "default"
+
+
+# ---------------------------------------------------------------------------
+# S2 — bridge.effective_permission_mode + set_permission_mode + accessors.
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_effective_permission_mode_resolution() -> None:
+    """Real ClaudeBridge tier semantics: override > config > 'default'."""
+    from clauded.claude_bridge import ClaudeBridge
+
+    # Case 1: override set — wins regardless of config
+    sc = SessionConfig(permission_mode_override="plan")
+    bridge = ClaudeBridge(
+        project_path="/tmp", config=_config(perm_mode="default"), session_config=sc,
+    )
+    assert bridge.effective_permission_mode == "plan"
+
+    # Case 2: no override, env-set config
+    sc = SessionConfig()
+    bridge = ClaudeBridge(
+        project_path="/tmp", config=_config(perm_mode="acceptEdits"),
+        session_config=sc,
+    )
+    assert bridge.effective_permission_mode == "acceptEdits"
+
+    # Case 3: nothing set anywhere → "default"
+    sc = SessionConfig()
+    bridge = ClaudeBridge(
+        project_path="/tmp", config=_config(perm_mode="default"),
+        session_config=sc,
+    )
+    assert bridge.effective_permission_mode == "default"
+
+
+def test_bridge_permission_mode_override_accessor_returns_explicit_only() -> None:
+    """Public accessor must return ONLY the explicit override (None when
+    user hasn't set one), parallel to ``explicit_model_override``. This is
+    what ``save_session_state`` reads for persistence."""
+    from clauded.claude_bridge import ClaudeBridge
+
+    sc = SessionConfig()
+    bridge = ClaudeBridge(
+        project_path="/tmp", config=_config(perm_mode="plan"), session_config=sc,
+    )
+    # Env says "plan" but user hasn't run /mode set → accessor returns None
+    assert bridge.permission_mode_override is None
+    # But effective is still "plan" (env tier)
+    assert bridge.effective_permission_mode == "plan"
+
+
+@pytest.mark.asyncio
+async def test_bridge_set_permission_mode_calls_sdk_and_persists() -> None:
+    from clauded.claude_bridge import ClaudeBridge
+
+    sc = SessionConfig()
+    bridge = ClaudeBridge(
+        project_path="/tmp", config=_config(), session_config=sc,
+    )
+    fake_client = MagicMock()
+    fake_client.set_permission_mode = AsyncMock()
+    bridge._client = fake_client
+    bridge._active = True
+
+    await bridge.set_permission_mode("plan")
+
+    fake_client.set_permission_mode.assert_awaited_once_with("plan")
+    # Persisted to override field
+    assert bridge._permission_mode_override == "plan"
+    assert bridge.permission_mode_override == "plan"
+    assert bridge.effective_permission_mode == "plan"
+
+
+@pytest.mark.asyncio
+async def test_bridge_set_permission_mode_rejected_when_inactive() -> None:
+    """SDK rejection must not silently lie about the active mode."""
+    from clauded.claude_bridge import ClaudeBridge
+
+    bridge = ClaudeBridge(
+        project_path="/tmp", config=_config(), session_config=SessionConfig(),
+    )
+    # No _client → not active
+    bridge._client = None
+    bridge._active = False
+    with pytest.raises(RuntimeError):
+        await bridge.set_permission_mode("plan")
+    # Override untouched
+    assert bridge._permission_mode_override is None
+
+
+@pytest.mark.asyncio
+async def test_bridge_set_permission_mode_sdk_error_keeps_old_override() -> None:
+    """If the SDK call raises, the override field must NOT advance — otherwise
+    the footer would lie about the active mode."""
+    from clauded.claude_bridge import ClaudeBridge
+
+    sc = SessionConfig(permission_mode_override="acceptEdits")
+    bridge = ClaudeBridge(
+        project_path="/tmp", config=_config(), session_config=sc,
+    )
+    fake_client = MagicMock()
+    fake_client.set_permission_mode = AsyncMock(side_effect=ValueError("nope"))
+    bridge._client = fake_client
+    bridge._active = True
+
+    with pytest.raises(ValueError):
+        await bridge.set_permission_mode("plan")
+    # Override stays at the previous value
+    assert bridge._permission_mode_override == "acceptEdits"
+
+
+# ---------------------------------------------------------------------------
+# S2 — bridge.start() passes effective mode to SDK.
+# ---------------------------------------------------------------------------
+
+
+class _FakeSDKClient:
+    captured_options: list[Any] = []
+
+    def __init__(self, options: Any = None) -> None:
+        type(self).captured_options.append(options)
+
+    async def connect(self, prompt: Any = None) -> None:
+        pass
+
+    async def disconnect(self) -> None:
+        pass
+
+
+@pytest.fixture
+def _reset_sdk_capture() -> None:
+    _FakeSDKClient.captured_options = []
+
+
+@pytest.mark.asyncio
+async def test_bridge_start_passes_override_to_sdk(
+    monkeypatch: pytest.MonkeyPatch, _reset_sdk_capture: None
+) -> None:
+    """Persisted override → ClaudeAgentOptions(permission_mode=<override>)."""
+    from clauded.claude_bridge import ClaudeBridge
+
+    monkeypatch.setattr("clauded.claude_bridge.ClaudeSDKClient", _FakeSDKClient)
+    sc = SessionConfig(permission_mode_override="plan")
+    bridge = ClaudeBridge(
+        project_path="/tmp", config=_config(perm_mode="default"), session_config=sc,
+    )
+    await bridge.start()
+    assert _FakeSDKClient.captured_options
+    assert _FakeSDKClient.captured_options[-1].permission_mode == "plan"
+
+
+@pytest.mark.asyncio
+async def test_bridge_start_falls_back_to_config_when_no_override(
+    monkeypatch: pytest.MonkeyPatch, _reset_sdk_capture: None
+) -> None:
+    """No override → config env tier (or default) flows to SDK."""
+    from clauded.claude_bridge import ClaudeBridge
+
+    monkeypatch.setattr("clauded.claude_bridge.ClaudeSDKClient", _FakeSDKClient)
+    sc = SessionConfig()  # no override
+    bridge = ClaudeBridge(
+        project_path="/tmp", config=_config(perm_mode="acceptEdits"),
+        session_config=sc,
+    )
+    await bridge.start()
+    assert _FakeSDKClient.captured_options[-1].permission_mode == "acceptEdits"
+
+
+# ---------------------------------------------------------------------------
+# S3 — persistence: write + read paths.
+# ---------------------------------------------------------------------------
+
+
+def test_session_store_round_trips_permission_mode_override(tmp_path: Path) -> None:
+    """SessionStore.save_session writes the new field; get reads it back."""
+    from clauded.session_store import SessionStore
+
+    store = SessionStore(data_dir=str(tmp_path))
+    store.save_session(
+        thread_id=42, session_id="sess-1", project_path="/tmp/p",
+        model=None, system_prompt="",
+        permission_mode_override="bypassPermissions",
+    )
+    info = store.get_session_info(42)
+    assert info is not None
+    assert info["permission_mode_override"] == "bypassPermissions"
+
+
+def test_session_store_legacy_row_without_field_returns_none(
+    tmp_path: Path,
+) -> None:
+    """Pre-#211 rows lack the field → ``stored.get("permission_mode_override")``
+    returns None (no crash, no KeyError)."""
+    from clauded.session_store import SessionStore
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    legacy = {
+        "1": {
+            "session_id": "old",
+            "project_path": "/tmp",
+            "model": None,
+            "system_prompt": "",
+            "last_active": "x",
+            # NOTE: no permission_mode_override field — legacy row
+        }
+    }
+    (data_dir / "sessions.json").write_text(json.dumps(legacy))
+    store = SessionStore(data_dir=str(data_dir))
+    info = store.get_session_info(1)
+    assert info is not None
+    # .get returns None for the missing key (safe-defaulted by callers)
+    assert info.get("permission_mode_override") is None
+
+
+def test_save_session_state_persists_explicit_override() -> None:
+    """SessionManager.save_session_state passes bridge.permission_mode_override
+    through to the store. Explicit-override case."""
+    from clauded.session_manager import SessionManager
+
+    bridge = MagicMock()
+    bridge.session_id = "sess"
+    bridge.project_path = "/tmp"
+    bridge.system_prompt = ""
+    bridge.permission_mode_override = "plan"
+
+    sm = SessionManager(MagicMock())
+    sm._sessions[1] = bridge
+
+    captured: dict = {}
+
+    def _fake_save(thread_id, session_id, project_path, *, model=None,
+                   system_prompt=None, permission_mode_override=None):
+        captured["permission_mode_override"] = permission_mode_override
+        captured["model"] = model
+
+    sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
+    sm.save_session_state(1)
+    assert captured["permission_mode_override"] == "plan"
+    # #211 doesn't change the #210 model=None invariant
+    assert captured["model"] is None
+
+
+def test_save_session_state_persists_none_when_no_user_override() -> None:
+    """User has never run /mode set → store gets None."""
+    from clauded.session_manager import SessionManager
+
+    bridge = MagicMock()
+    bridge.session_id = "sess"
+    bridge.project_path = "/tmp"
+    bridge.system_prompt = ""
+    bridge.permission_mode_override = None  # never set
+
+    sm = SessionManager(MagicMock())
+    sm._sessions[2] = bridge
+
+    captured: dict = {}
+
+    def _fake_save(thread_id, session_id, project_path, *, model=None,
+                   system_prompt=None, permission_mode_override=None):
+        captured["permission_mode_override"] = permission_mode_override
+
+    sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
+    sm.save_session_state(2)
+    assert captured["permission_mode_override"] is None
+
+
+# ---------------------------------------------------------------------------
+# S3 — read path: auto-resume threads the field into SessionConfig.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_thread_resume_threads_permission_mode_override() -> None:
+    """``bot._handle_thread_message`` resume block must inject
+    ``stored.get("permission_mode_override")`` into SessionConfig so the
+    next bridge inherits the user's persisted choice."""
+    import discord
+    from clauded.bot import ClaudedBot
+
+    stored = {
+        "session_id": "sess-old",
+        "project_path": "/tmp",
+        "model": None,
+        "system_prompt": "",
+        "permission_mode_override": "bypassPermissions",
+        "last_active": "x",
+    }
+
+    bot = MagicMock()
+    bot._user = MagicMock(id=42, name="ClaudeBot")
+    bot._user.name = "ClaudeBot"
+    bot.user = bot._user
+    bot.allow_unbound_fallback = False
+    bot.config = _config(perm_mode="default")
+    bot.project_manager = MagicMock()
+    bot.project_manager.is_bound = MagicMock(return_value=True)
+    bot.project_manager.should_refuse_unbound = MagicMock(return_value=False)
+    bot.project_manager.get_path_or_default = MagicMock(
+        return_value=(Path("/tmp"), True)
+    )
+    bot.project_manager.get_system_prompt = MagicMock(return_value="")
+    bot.project_manager.get_extra_dirs = MagicMock(return_value=[])
+    bot.project_manager.get_mcp_servers = MagicMock(return_value=None)
+    bot.project_manager.get_env = MagicMock(return_value=None)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=None)
+    bot.session_manager.get_stored_session = MagicMock(return_value=stored)
+    bot.session_manager.create_session = AsyncMock()
+    bot.session_manager.get_lock = MagicMock(return_value=MagicMock(
+        __aenter__=AsyncMock(), __aexit__=AsyncMock(),
+    ))
+    bot._logged_third_party_thread = set()
+    bot._pre_tool_notifications = False
+    bot._notify_enabled = {}
+    bot._compose_user_text = AsyncMock(return_value=("hi", None))
+
+    msg = MagicMock()
+
+    class _FakeThread(discord.Thread):
+        def __init__(self) -> None:
+            pass
+
+    thread = _FakeThread()
+    object.__setattr__(thread, "id", 99)
+    object.__setattr__(thread, "owner_id", 42)
+    object.__setattr__(thread, "parent_id", 1234)
+    msg.channel = thread
+    msg.id = 1
+    msg.content = "hi"
+    msg.author = MagicMock(id=1)
+    msg.author.__str__ = MagicMock(return_value="alice")
+    msg.mentions = []
+    msg.role_mentions = []
+    msg.reply = AsyncMock()
+
+    try:
+        await ClaudedBot._handle_thread_message(bot, msg, parent_id=1234)
+    except Exception:
+        pass
+
+    assert bot.session_manager.create_session.await_count >= 1
+    sc = bot.session_manager.create_session.await_args_list[0].args[3]
+    assert isinstance(sc, SessionConfig)
+    assert sc.permission_mode_override == "bypassPermissions", (
+        f"#211 read path: persisted permission_mode_override did NOT thread "
+        f"through to SessionConfig; got {sc.permission_mode_override!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_resume_threads_permission_mode_override() -> None:
+    """/session resume must inject ``stored.get("permission_mode_override")``."""
+    from clauded.cogs.session import session_resume
+    from clauded.bot import ClaudedBot
+
+    stored = {
+        "session_id": "sess-old",
+        "project_path": "/tmp",
+        "model": None,
+        "system_prompt": "",
+        "permission_mode_override": "plan",
+    }
+
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_stored_session = MagicMock(return_value=stored)
+    bot.session_manager.stop_session = AsyncMock()
+    bot.session_manager.create_session = AsyncMock()
+    bot.session_manager.get_lock = MagicMock(return_value=MagicMock(
+        __aenter__=AsyncMock(), __aexit__=AsyncMock(),
+    ))
+    bot.config = _config()
+
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel_id = 99
+    interaction.channel = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+
+    import clauded.cogs.session as session_mod
+    session_mod.reject_if_unbound = AsyncMock(return_value=False)
+
+    await session_resume.callback(interaction)
+    assert bot.session_manager.create_session.await_count == 1
+    sc = bot.session_manager.create_session.await_args.args[3]
+    assert sc.permission_mode_override == "plan"
+
+
+# ---------------------------------------------------------------------------
+# S1/S5 — /mode set + /mode cycle + /mode current command callbacks.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mode_set_calls_bridge_and_persists() -> None:
+    from clauded.cogs.mode import mode_set
+    from clauded.bot import ClaudedBot
+
+    bridge = _bridge(override=None, env_mode="default")
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=bridge)
+    bot.session_manager.save_session_state = MagicMock()
+
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel.id = 1
+    interaction.response.send_message = AsyncMock()
+
+    import discord
+    choice = discord.app_commands.Choice(name="plan 🔒", value="plan")
+    await mode_set.callback(interaction, choice)
+
+    bridge.set_permission_mode.assert_awaited_once_with("plan")
+    bot.session_manager.save_session_state.assert_called_once_with(1)
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert kwargs.get("ephemeral") is True
+    embed = kwargs.get("embed")
+    assert embed is not None
+    assert "plan" in (embed.title or "")
+
+
+@pytest.mark.asyncio
+async def test_mode_set_no_session_replies_with_hint() -> None:
+    from clauded.cogs.mode import mode_set
+    from clauded.bot import ClaudedBot
+
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=None)
+
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel.id = 1
+    interaction.response.send_message = AsyncMock()
+
+    import discord
+    choice = discord.app_commands.Choice(name="plan", value="plan")
+    await mode_set.callback(interaction, choice)
+    args = interaction.response.send_message.await_args
+    msg = args.args[0]
+    assert "No active session" in msg
+    assert args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_mode_cycle_five_steps_returns_to_default() -> None:
+    """5 successive cycles from ``default`` → all 4 modes + back to ``default``."""
+    from clauded.cogs.mode import mode_cycle
+    from clauded.bot import ClaudedBot
+
+    # We simulate a bridge whose effective mode advances each call.
+    state = {"mode": "default"}
+
+    async def _set_pm(mode: str) -> None:
+        state["mode"] = mode
+
+    bridge = MagicMock()
+    bridge.is_active = True
+    bridge.set_permission_mode = AsyncMock(side_effect=_set_pm)
+    type(bridge).effective_permission_mode = property(
+        lambda self: state["mode"]
+    )
+
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=bridge)
+    bot.session_manager.save_session_state = MagicMock()
+
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel.id = 7
+    interaction.response.send_message = AsyncMock()
+
+    expected_sequence = [
+        "acceptEdits", "plan", "bypassPermissions", "default", "acceptEdits",
+    ]
+    for expected in expected_sequence:
+        await mode_cycle.callback(interaction)
+        assert state["mode"] == expected, (
+            f"cycle drift: expected {expected!r}, got {state['mode']!r}"
+        )
+    # 5 SDK calls, 5 persists
+    assert bridge.set_permission_mode.await_count == 5
+    assert bot.session_manager.save_session_state.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_mode_current_displays_source_override() -> None:
+    from clauded.cogs.mode import mode_current
+    from clauded.bot import ClaudedBot
+
+    bridge = _bridge(override="plan", env_mode="default")
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=bridge)
+
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel.id = 1
+    interaction.response.send_message = AsyncMock()
+    await mode_current.callback(interaction)
+
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    assert "plan" in embed.description
+    assert "override" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_mode_current_displays_source_env() -> None:
+    from clauded.cogs.mode import mode_current
+    from clauded.bot import ClaudedBot
+
+    bridge = _bridge(override=None, env_mode="acceptEdits")
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=bridge)
+
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel.id = 1
+    interaction.response.send_message = AsyncMock()
+    await mode_current.callback(interaction)
+
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    assert "acceptEdits" in embed.description
+    assert "env" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_mode_current_displays_source_default() -> None:
+    from clauded.cogs.mode import mode_current
+    from clauded.bot import ClaudedBot
+
+    bridge = _bridge(override=None, env_mode="default")
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=bridge)
+
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel.id = 1
+    interaction.response.send_message = AsyncMock()
+    await mode_current.callback(interaction)
+
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    assert "default" in embed.description
+
+
+def test_mode_group_has_three_subcommands() -> None:
+    """Pin: the group has exactly set/cycle/current (per PRD §Goals)."""
+    from clauded.cogs.mode import mode_group
+
+    names = {c.name for c in mode_group.commands}
+    assert names == {"set", "cycle", "current"}, f"Unexpected: {names}"
+
+
+# ---------------------------------------------------------------------------
+# S4 — footer renders mode line ONLY when non-default.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_footer_includes_mode_line_when_non_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drive a minimal render that yields a single ResultMessage, then
+    inspect the final ``_safe_edit`` call's content — it must contain
+    a second ``-#`` line with the mode emoji + name."""
+    from clauded.discord_renderer import DiscordRenderer
+    from clauded.claude_bridge import ResultMessage
+
+    target = MagicMock()
+    target.send = AsyncMock(return_value=MagicMock())
+    renderer = DiscordRenderer(target)
+    renderer._safe_edit = AsyncMock(return_value=True)
+    renderer._safe_send = AsyncMock(return_value=MagicMock())
+
+    # Simulate a "no text body" turn where there's no live cursor; the
+    # footer takes the standalone-send path. We just want to verify the
+    # ``-# 🔒 plan`` line is present in whatever the renderer sends.
+    bridge = MagicMock()
+    bridge.effective_permission_mode = "plan"
+
+    # Synthesize a minimal ResultMessage
+    result = ResultMessage(
+        subtype="success",
+        duration_ms=1000,
+        duration_api_ms=500,
+        is_error=False,
+        num_turns=1,
+        session_id="s",
+        total_cost_usd=0.005,
+        usage={"input_tokens": 100, "output_tokens": 50},
+    )
+
+    async def _events(_):
+        yield result
+
+    bridge.send_message = _events
+    # Drive the renderer
+    await renderer.render_response(bridge, "hello")
+    # Find the footer in the sent messages
+    sent_content_blobs: list[str] = []
+    for call in renderer._safe_send.await_args_list:
+        sent_content_blobs.append(call.kwargs.get("content", ""))
+    for call in renderer._safe_edit.await_args_list:
+        sent_content_blobs.append(call.kwargs.get("content", ""))
+    joined = "\n".join(sent_content_blobs)
+    assert "🔒 plan" in joined, (
+        f"#211 footer: expected '🔒 plan' line in non-default mode; got:\n{joined!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_footer_omits_mode_line_when_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default mode → no second footer line, no mode emoji anywhere."""
+    from clauded.discord_renderer import DiscordRenderer
+    from clauded.claude_bridge import ResultMessage
+
+    target = MagicMock()
+    target.send = AsyncMock(return_value=MagicMock())
+    renderer = DiscordRenderer(target)
+    renderer._safe_edit = AsyncMock(return_value=True)
+    renderer._safe_send = AsyncMock(return_value=MagicMock())
+
+    bridge = MagicMock()
+    bridge.effective_permission_mode = "default"
+
+    result = ResultMessage(
+        subtype="success",
+        duration_ms=1000,
+        duration_api_ms=500,
+        is_error=False,
+        num_turns=1,
+        session_id="s",
+        total_cost_usd=0.005,
+        usage={"input_tokens": 100, "output_tokens": 50},
+    )
+
+    async def _events(_):
+        yield result
+
+    bridge.send_message = _events
+    await renderer.render_response(bridge, "hello")
+    sent_content_blobs: list[str] = []
+    for call in renderer._safe_send.await_args_list:
+        sent_content_blobs.append(call.kwargs.get("content", ""))
+    for call in renderer._safe_edit.await_args_list:
+        sent_content_blobs.append(call.kwargs.get("content", ""))
+    joined = "\n".join(sent_content_blobs)
+    # None of the 3 non-default emojis should appear:
+    assert "🔒" not in joined
+    assert "✏️" not in joined
+    assert "⚡" not in joined
+
+
+# ---------------------------------------------------------------------------
+# S5 — /health + /session info include the mode.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_health_displays_permission_mode_when_session_active() -> None:
+    from clauded.cogs.ops import health_check
+    from clauded.bot import ClaudedBot
+
+    bridge = _bridge(override="plan", env_mode="default")
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.list_sessions = MagicMock(return_value={1: bridge})
+    bot.session_manager.get_session = MagicMock(return_value=bridge)
+    bot.project_manager = MagicMock()
+    bot.project_manager._projects = {}
+    bot._start_time = 0
+    bot._claude_version = "1.0"
+
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel = MagicMock()
+    interaction.channel.id = 1
+    interaction.response.send_message = AsyncMock()
+    await health_check.callback(interaction)
+
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    # Find the Permission mode field
+    field_names = [f.name for f in embed.fields]
+    assert "Permission mode" in field_names, (
+        f"#211: /health embed missing 'Permission mode' field; got {field_names}"
+    )
+    mode_field = next(f for f in embed.fields if f.name == "Permission mode")
+    assert "plan" in mode_field.value
+    assert "override" in mode_field.value
+
+
+@pytest.mark.asyncio
+async def test_session_info_displays_permission_mode() -> None:
+    from clauded.cogs.session import session_info
+    from clauded.bot import ClaudedBot
+
+    bridge = _bridge(override=None, env_mode="acceptEdits")
+    # session_info reads model-side fields too — set them defensively
+    bridge._model_override = None
+    bridge._sdk_model = None
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=bridge)
+    bot.config = _config(perm_mode="acceptEdits")
+
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel_id = 1
+    interaction.response.send_message = AsyncMock()
+    await session_info.callback(interaction)
+
+    body = interaction.response.send_message.await_args.args[0]
+    assert "Mode:" in body
+    assert "acceptEdits" in body
+    assert "env" in body

--- a/tests/test_permission_mode.py
+++ b/tests/test_permission_mode.py
@@ -888,3 +888,206 @@ async def test_session_info_displays_permission_mode() -> None:
     assert "Mode:" in body
     assert "acceptEdits" in body
     assert "env" in body
+
+
+# ---------------------------------------------------------------------------
+# R1 architect — persistence-dichotomy user-visible labels (PR #221 R1)
+# ---------------------------------------------------------------------------
+
+
+def test_format_mode_display_includes_persisted_lifetime_for_override():
+    """R1 architect important #1: `/mode current` source label must
+    surface the persistence semantic so users don't experience the
+    /mode-persistent vs /model-ephemeral asymmetry as a bug."""
+    from clauded.cogs.mode import _format_mode_display
+    out = _format_mode_display("plan", "override")
+    assert "persisted" in out, (
+        f"override source should be labeled 'persisted'; got: {out!r}"
+    )
+    # Mode + emoji + source all present
+    assert "plan" in out
+    assert "🔒" in out
+
+
+def test_format_mode_display_includes_env_pinned_for_env():
+    from clauded.cogs.mode import _format_mode_display
+    out = _format_mode_display("acceptEdits", "env")
+    assert "env-pinned" in out, (
+        f"env source should be labeled 'env-pinned'; got: {out!r}"
+    )
+
+
+def test_format_mode_display_includes_cli_default_for_default():
+    from clauded.cogs.mode import _format_mode_display
+    out = _format_mode_display("default", "default")
+    assert "CLI default" in out, (
+        f"default source should be labeled 'CLI default'; got: {out!r}"
+    )
+
+
+def test_mode_emoji_imports_cleanly_from_discord_renderer():
+    """R1 architect important #2: cyclic import resolved. MODE_EMOJI
+    lives in `discord_renderer.py` (rendering concern); `cogs/mode.py`
+    imports it back without a lazy fallback. Pin the import shape
+    against accidental re-introduction of the cycle."""
+    # Both sides reference the SAME dict object (no aliasing surprise).
+    from clauded.discord_renderer import MODE_EMOJI as renderer_emoji
+    from clauded.cogs.mode import MODE_EMOJI as cog_emoji
+    assert renderer_emoji is cog_emoji
+    # Exactly 3 entries, default deliberately excluded
+    assert set(renderer_emoji.keys()) == {"acceptEdits", "plan", "bypassPermissions"}
+
+
+# ---------------------------------------------------------------------------
+# R1 security HIGH — admin gate + audit log (PR #221 R1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mode_set_refuses_non_admin_caller():
+    """R1 security HIGH: /mode set must refuse callers without
+    administrator permission. Before the fix, any guild member could
+    `/mode set bypassPermissions` and persist the elevation across
+    bot restart.
+    """
+    from clauded.cogs.mode import mode_set
+    from clauded.bot import ClaudedBot
+    from unittest.mock import MagicMock, AsyncMock
+    import discord
+
+    bot_spec = MagicMock(spec=ClaudedBot)
+    bot_spec.session_manager = MagicMock()
+    bot_spec.session_manager.get_session = MagicMock()  # never reached
+    interaction = MagicMock()
+    interaction.client = bot_spec
+    interaction.channel.id = 1
+    # Non-admin caller: guild_permissions.administrator = False
+    interaction.user.guild_permissions = MagicMock(administrator=False)
+    interaction.response.send_message = AsyncMock()
+
+    choice = discord.app_commands.Choice(name="bypassPermissions", value="bypassPermissions")
+    await mode_set.callback(interaction, choice)
+
+    # Refusal must be the FIRST send_message call
+    interaction.response.send_message.assert_awaited()
+    call = interaction.response.send_message.await_args
+    msg = call.args[0] if call.args else call.kwargs.get("content", "")
+    assert "Administrator" in msg or "admin" in msg.lower(), (
+        f"Expected admin-required refusal; got: {msg!r}"
+    )
+    # Crucially: the bridge lookup was NOT reached (no privilege escalation
+    # before the gate)
+    bot_spec.session_manager.get_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mode_cycle_refuses_non_admin_caller():
+    """R1 security HIGH: /mode cycle has same admin gate."""
+    from clauded.cogs.mode import mode_cycle
+    from clauded.bot import ClaudedBot
+    from unittest.mock import MagicMock, AsyncMock
+
+    bot_spec = MagicMock(spec=ClaudedBot)
+    bot_spec.session_manager = MagicMock()
+    bot_spec.session_manager.get_session = MagicMock()
+    interaction = MagicMock()
+    interaction.client = bot_spec
+    interaction.channel.id = 1
+    interaction.user.guild_permissions = MagicMock(administrator=False)
+    interaction.response.send_message = AsyncMock()
+
+    await mode_cycle.callback(interaction)
+
+    interaction.response.send_message.assert_awaited()
+    call = interaction.response.send_message.await_args
+    msg = call.args[0] if call.args else call.kwargs.get("content", "")
+    assert "Administrator" in msg or "admin" in msg.lower()
+    bot_spec.session_manager.get_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mode_current_allows_non_admin_read():
+    """/mode current is read-only — non-admin should still be able to
+    see the current mode. Mirror of /health visibility."""
+    from clauded.cogs.mode import mode_current
+    from clauded.bot import ClaudedBot
+    from unittest.mock import MagicMock, AsyncMock
+
+    bot_spec = MagicMock(spec=ClaudedBot)
+    bot_spec.session_manager = MagicMock()
+    bridge = MagicMock()
+    bridge._permission_mode_override = "plan"
+    bridge._config = MagicMock(claude_permission_mode="default")
+    bot_spec.session_manager.get_session = MagicMock(return_value=bridge)
+    interaction = MagicMock()
+    interaction.client = bot_spec
+    interaction.channel.id = 1
+    interaction.user.guild_permissions = MagicMock(administrator=False)
+    interaction.response.send_message = AsyncMock()
+
+    await mode_current.callback(interaction)
+
+    interaction.response.send_message.assert_awaited()
+    # Should NOT be the "Administrator required" refusal
+    call = interaction.response.send_message.await_args
+    if call.args:
+        content_str = str(call.args[0])
+    else:
+        content_str = call.kwargs.get("content", "")
+        embed = call.kwargs.get("embed")
+        if embed is not None:
+            content_str += str(getattr(embed, "title", ""))
+            content_str += str(getattr(embed, "description", ""))
+    assert "Administrator" not in content_str, (
+        f"/mode current must NOT gate on admin (it's read-only); got: {content_str!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mode_set_emits_security_audit_log(caplog):
+    """R1 security HIGH: every successful permission_mode write logs
+    WARNING with WHO/WHERE/WHAT-CHANGED for forensic reconstruction.
+    Matches ops.unbound_fallback_toggle precedent.
+    """
+    import logging
+    from clauded.cogs.mode import mode_set
+    from clauded.bot import ClaudedBot
+    from unittest.mock import MagicMock, AsyncMock
+    import discord
+
+    bot_spec = MagicMock(spec=ClaudedBot)
+    bridge = MagicMock()
+    bridge.is_active = True
+    bridge.effective_permission_mode = "default"
+    bridge.set_permission_mode = AsyncMock()
+    bot_spec.session_manager = MagicMock()
+    bot_spec.session_manager.get_session = MagicMock(return_value=bridge)
+    bot_spec.session_manager.save_session_state = MagicMock()
+
+    interaction = MagicMock()
+    interaction.client = bot_spec
+    interaction.channel.id = 42
+    interaction.guild_id = 99
+    interaction.channel_id = 42
+    interaction.user.guild_permissions = MagicMock(administrator=True)
+    interaction.user.name = "test_admin"
+    interaction.user.id = 1234
+    interaction.response.send_message = AsyncMock()
+
+    choice = discord.app_commands.Choice(name="bypassPermissions", value="bypassPermissions")
+    caplog.set_level(logging.WARNING, logger="clauded.cogs.mode")
+    await mode_set.callback(interaction, choice)
+
+    # Find the SECURITY: audit log
+    audit = [r for r in caplog.records if "SECURITY:" in r.getMessage() and "permission_mode" in r.getMessage()]
+    assert audit, f"No SECURITY: audit log emitted; records: {[r.getMessage() for r in caplog.records]}"
+    log_msg = audit[0].getMessage()
+    # WHO
+    assert "test_admin" in log_msg
+    assert "1234" in log_msg
+    # WHERE
+    assert "99" in log_msg  # guild
+    assert "42" in log_msg  # channel
+    # WHAT-CHANGED
+    assert "default" in log_msg
+    assert "bypassPermissions" in log_msg


### PR DESCRIPTION
Closes #211 (enhancement, CLI parity).

## Approved PRD
`docs/prd/v1.18-permission-mode-cmd.md` — DDD 5/16 locked.

## What
`/mode set/cycle/current` group + footer second line (non-default mode only) + persistence across restart.

- `/mode set <mode>` — explicit set; autocomplete to 4 modes
- `/mode cycle` — advance `default → acceptEdits → plan → bypassPermissions → default`
- `/mode current` — show current + source (override / env / default)
- SDK runtime switch via `ClaudeSDKClient.set_permission_mode()` (no session restart)
- Persisted as `permission_mode_override` field in `data/sessions.json` (fresh schema field — no #210 pollution legacy)
- Footer adds `-# {EMOJI} {mode}` line only when ≠ default
- `/health` + `/session info` show current mode

## Modes
4 only (per user decision #5): `default`, `acceptEdits`, `plan`, `bypassPermissions`. SDK's `dontAsk` / `auto` not exposed.

Emoji: `✏️ acceptEdits` / `🔒 plan` / `⚡ bypassPermissions`

## Tests
+32 in `tests/test_permission_mode.py`. SDK contract pin via `typing.get_args(PermissionMode)`.

## pytest
**770 / 0** (was 738; +32).

## Status
🚧 Draft — pending 7-perspective review.
