### PR TITLE
fix(renderer): ToolResultBlock no-match crashes turn — UnboundLocalError (#226)

### DIFF
--- a/docs/prd/v1.18-fix-toolresult-unbound-is_medium.md
+++ b/docs/prd/v1.18-fix-toolresult-unbound-is_medium.md
@@ -1,0 +1,153 @@
+# PRD — Fix UnboundLocalError on ToolResultBlock without matching rolling-log line (#226)
+
+**Status**: APPROVED (DDD 5/17 user-locked: "is_medium default + logger warning + 修后开新 issue #227 改 retry 语义")
+**Issue**: [#226](https://github.com/HXYerror/claudeD/issues/226)
+**Branch**: `fix/v1.18-toolresult-unbound-is_medium`
+**Severity**: P0 (every trigger = lost turn + lost conversation per current Retry semantic)
+
+---
+
+## Problem
+
+Per PM forensics (`discord_renderer.py:1416-1610`), the `for i in range(len(tool_log_lines) - 1, -1, -1):` loop conditionally assigns `is_medium`, `content_str`, and `medium_index` ONLY when a matching rolling-log line is found:
+
+```python
+for i in range(len(tool_log_lines) - 1, -1, -1):
+    line = tool_log_lines[i]
+    if not line.startswith("🔄 "):
+        continue
+    matches_name = line.startswith("🔄 " + name)
+    if not (matches_name or matches_alias):
+        continue
+    content_str = _extract_block_content_text(block.content)
+    is_short = ...
+    is_medium = ...
+    if is_err: ...
+    elif is_short: ...
+    elif is_medium: ...
+    else: ...
+    break
+```
+
+If the loop finishes without `break` (no matching `🔄 ToolName` line in `tool_log_lines[-15:]`), these three locals are never bound. Lines 1515, 1580, 1600 unconditionally read them → `UnboundLocalError: cannot access local variable 'is_medium' where it is not associated with a value`.
+
+Python's exception bubbles to renderer top-level catch → bridge marked dead → user sees `❌ Claude session crashed`. Per current #148 cascade-failure semantic, Retry button creates **fresh** session, losing all conversation context.
+
+## When does no-match happen?
+
+1. **Rolling log truncation**: only last 15 lines kept (`tool_log_lines[-15:]`). A tool that ran > 15 events ago has its `🔄 ToolName` evicted; its ToolResultBlock arrives after.
+2. **Event-ordering edge**: SDK fires ToolResultBlock before the corresponding ToolUseBlock has been processed (rare, but seen in long subagent flows).
+3. **Race / partial state**: if a previous error mid-stream truncated the rolling log array, ResultBlock for an earlier tool can no-match.
+
+## User decisions (DDD 5/17)
+
+| # | Decision |
+|---|---|
+| 1 | Approach A: initialize defaults before the for-loop (`is_medium = False`, `content_str = ""`, `medium_index = None`) |
+| 2 | Manager-recommended refactor (Approach B helper extraction) — out of scope; track as follow-up |
+| 3 | Add `log.warning` for no-match case to help #223 / #224 logger blind-spot epic |
+| 4 | Retry semantic improvement (resume vs fresh) — separate issue #227, NOT in this PR |
+
+## Goals
+
+1. Stop the UnboundLocalError on the **no-matching-rolling-log-line** path.
+2. Graceful degradation: when no match, the tool result event silently no-ops (the rolling log was evicted; nothing to update). No fake render, no crash.
+3. Operator visibility: `log.warning("ToolResultBlock no-matched: tool_id=%s name=%s", ...)` so the #223 epic has data to reason about frequency.
+4. Regression test pin: `tests/test_tool_result_shorttier.py` gains a case "ToolResultBlock without matching rolling-log line — no crash, no render, log.warning fired".
+
+## Non-goals
+
+- Refactor to extract helper (#226-followup; PM recommended but out of scope)
+- Change rolling-log eviction limit (15 → larger)
+- Change Retry button semantic to resume (separate issue #227)
+- Audit other UnboundLocalError-class scope bugs in the renderer
+
+## Design
+
+### Initialize defaults before the for-loop
+
+`discord_renderer.py:1416-1503`. Insert before the `for i in range(...)`:
+
+```python
+# #226: initialize defaults so no-match path (rolling log evicted /
+# ToolResultBlock arrives before its ToolUseBlock) doesn't crash the
+# renderer with UnboundLocalError when downstream code reads these.
+is_medium = False
+content_str = ""
+medium_index: int | None = None
+matched = False  # track for the warning log
+
+for i in range(len(tool_log_lines) - 1, -1, -1):
+    line = tool_log_lines[i]
+    if not line.startswith("🔄 "):
+        continue
+    matches_name = ...
+    if not (matches_name or matches_alias):
+        continue
+    # ← from here, the existing assignment logic stays
+    matched = True
+    content_str = _extract_block_content_text(block.content)
+    is_short = ...
+    is_medium = ...
+    ...
+    break
+
+if not matched:
+    log.warning(
+        "ToolResultBlock no-matched any rolling-log line; "
+        "tool_id=%s name=%s alias=%r rolling_log_len=%d "
+        "(likely rolling-log eviction or out-of-order event)",
+        tool_id, name, alias, len(tool_log_lines),
+    )
+    # is_medium=False, content_str="", medium_index=None → downstream
+    # code's "if is_medium and not is_err and tool_id" guard is False
+    # → medium-tier persistence + view registration skipped. Safe no-op.
+```
+
+`alias` is computed earlier in the same scope (`alias = tool_marker_aliases.get(name, "")`). Available.
+
+### Why this is safe
+
+The downstream guards (`if is_medium and not is_err and tool_id:` etc.) all gate on `is_medium`. With `is_medium = False` default, those branches don't execute. No fake button is registered, no fake rolling-log update is sent. The ToolResultBlock event is silently dropped — which is the correct degradation (rolling log line is gone, so there's nothing user-visible to update).
+
+The footer / cost-aggregation logic doesn't depend on these locals.
+
+## Acceptance criteria
+
+### Behavioral
+- [ ] ToolResultBlock arrives without matching rolling-log line → NO UnboundLocalError, NO crash embed
+- [ ] In that case: `log.warning` fired exactly once with tool_id / name / alias / rolling_log_len
+- [ ] Existing matched-path behavior byte-identical (short / medium / xlong rendering unchanged)
+- [ ] No new test failures elsewhere
+
+### Tests (regression pins per acceptance + PM tester focus)
+- [ ] `tests/test_tool_result_shorttier.py`: new test `test_226_toolresult_no_matching_rolling_log_does_not_crash`
+  - Build a tool_log_lines where no entry starts with `🔄 ToolName`
+  - Drive `render_response` with a single ToolResultBlock event
+  - Assert: no exception, no `_safe_send` called with crash content, `log.warning` fired
+- [ ] `tests/test_tool_result_shorttier.py`: regression pin `test_226_log_warning_includes_diagnostics`
+  - Same setup; assert log message contains `tool_id`, `name`, `alias`, `rolling_log_len`
+
+## Out of scope
+
+- #226-followup: helper extraction (`_match_tool_in_rolling_log` returning Optional[ToolMatch]). Worth doing but bigger surface — separate PR.
+- #227: retry resume semantic
+- Other UnboundLocalError audit in renderer (other long for-loops with conditional assignment) — separate audit-pass issue
+
+## Risks
+
+- **Audit miss**: same scope pattern may exist elsewhere in the long render_response function. PRD §Non-goals explicitly deferred. PM Lessons (per #226 PM body): tester check should add "every assert AFTER a `for ... continue` loop must verify variable initialization" as a code-review checklist.
+- **Eviction frequency**: if no-match happens often (rolling log eviction is the common case for long turns), the `log.warning` will be noisy. Mitigation: only log per (turn, tool_id) — dedupe via a set tracked in the same scope.
+
+Actually, on reflection: dedupe NOT needed since each ResultBlock fires the warning at most once per event. Multiple ResultBlocks for the SAME tool_id in the same turn shouldn't happen. Document this assumption.
+
+## Plan
+
+Single coding agent OR manager-direct (per session precedent — if coding agent refuses malware policy, manager implements; small contained fix):
+
+1. **S1** — Insert defaults + `matched` flag + `log.warning` block in `discord_renderer.py:1416`.
+2. **S2** — Tests: +2 in `tests/test_tool_result_shorttier.py`. Use existing test scaffolding.
+
+## Sign-off
+
+DDD-approved per hxy 5/17 in test guild.

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1413,6 +1413,21 @@ class DiscordRenderer:
                                     "WebFetch": "🌐",
                                 }
                                 alias = tool_marker_aliases.get(name, "")
+                                # #226: pre-loop defaults so the no-match
+                                # path (rolling-log eviction past the
+                                # last-15 window / ToolResultBlock arrives
+                                # before its ToolUseBlock) doesn't crash
+                                # the renderer with UnboundLocalError.
+                                # Downstream guards (`if is_medium and
+                                # not is_err and tool_id:` etc.) all gate
+                                # on `is_medium`; with the False default,
+                                # those branches skip cleanly and the
+                                # event is a safe no-op (correct since
+                                # there's no rolling-log line to update).
+                                is_medium = False
+                                content_str = ""
+                                medium_index: int | None = None
+                                matched = False  # for the diagnostic log below
                                 for i in range(len(tool_log_lines) - 1, -1, -1):
                                     line = tool_log_lines[i]
                                     if not line.startswith("🔄 "):
@@ -1459,6 +1474,7 @@ class DiscordRenderer:
                                     if is_err:
                                         error_text = content_str[:100] if content_str else "Failed"
                                         tool_log_lines[i] = f"{status} {name}: {error_text}"
+                                        matched = True
                                     elif is_short:
                                         # Strip backticks to avoid breaking the
                                         # rolling-log embed's markdown. Collapse
@@ -1470,6 +1486,7 @@ class DiscordRenderer:
                                             .replace("\n", " │ ")
                                         )
                                         tool_log_lines[i] = f"{status} {name} → {safe}"
+                                        matched = True
                                     elif is_medium:
                                         # Rolling log shows summary + the
                                         # same ``#N`` index that the button
@@ -1498,9 +1515,24 @@ class DiscordRenderer:
                                             f"{line_count} lines / "
                                             f"{len(content_str)} chars (⬇ click to view)"
                                         )
+                                        matched = True
                                     else:
                                         tool_log_lines[i] = f"{status} {name}"
+                                        matched = True
                                     break
+                                if not matched:
+                                    # #226: rolling-log line for this tool
+                                    # was evicted (kept only last 15) or
+                                    # the event arrived out of order.
+                                    # Logged for #223 / #224 diagnostic
+                                    # epic; downstream guards on `is_medium
+                                    # = False` make this a safe no-op.
+                                    log.warning(
+                                        "ToolResultBlock no-matched rolling-log line; "
+                                        "tool_id=%s name=%s alias=%r rolling_log_len=%d "
+                                        "(likely rolling-log eviction or out-of-order event)",
+                                        tool_id, name, alias, len(tool_log_lines),
+                                    )
                                 has_errors = any("❌" in l for l in tool_log_lines)
                                 tool_embed = discord.Embed(
                                     title="🔧 Tool Activity",

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1426,7 +1426,7 @@ class DiscordRenderer:
                                 # there's no rolling-log line to update).
                                 is_medium = False
                                 content_str = ""
-                                medium_index: int | None = None
+                                medium_index = None
                                 matched = False  # for the diagnostic log below
                                 for i in range(len(tool_log_lines) - 1, -1, -1):
                                     line = tool_log_lines[i]
@@ -1474,7 +1474,6 @@ class DiscordRenderer:
                                     if is_err:
                                         error_text = content_str[:100] if content_str else "Failed"
                                         tool_log_lines[i] = f"{status} {name}: {error_text}"
-                                        matched = True
                                     elif is_short:
                                         # Strip backticks to avoid breaking the
                                         # rolling-log embed's markdown. Collapse
@@ -1486,7 +1485,6 @@ class DiscordRenderer:
                                             .replace("\n", " │ ")
                                         )
                                         tool_log_lines[i] = f"{status} {name} → {safe}"
-                                        matched = True
                                     elif is_medium:
                                         # Rolling log shows summary + the
                                         # same ``#N`` index that the button
@@ -1515,10 +1513,14 @@ class DiscordRenderer:
                                             f"{line_count} lines / "
                                             f"{len(content_str)} chars (⬇ click to view)"
                                         )
-                                        matched = True
                                     else:
                                         tool_log_lines[i] = f"{status} {name}"
-                                        matched = True
+                                    # #226 R1 simplicity: hoist `matched =
+                                    # True` out of the 4 branches —
+                                    # duplicating the flag across branches
+                                    # re-creates the bug class being fixed
+                                    # ("branch forgot to set flag").
+                                    matched = True
                                     break
                                 if not matched:
                                     # #226: rolling-log line for this tool

--- a/tests/test_tool_result_shorttier.py
+++ b/tests/test_tool_result_shorttier.py
@@ -738,3 +738,134 @@ def test_207_rolling_log_uses_bold_n_prefix_matching_button_order():
     button_label = f"📄 #{medium_index} {name}"
     assert f"#{medium_index} {name}" in button_label
     assert f"#{medium_index} {name}" in line  # same shared identifier in both surfaces
+
+
+# ---------------------------------------------------------------------------
+# #226 — UnboundLocalError fix: ToolResultBlock without matching rolling-log line
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_226_toolresult_no_matching_rolling_log_does_not_crash(caplog):
+    """#226: when a ToolResultBlock arrives but no `🔄 ToolName` line is
+    found in tool_log_lines (out-of-order event — ResultBlock for a tool
+    we never saw a ToolUseBlock for), the renderer used to crash with
+    `UnboundLocalError: cannot access local variable 'is_medium'`.
+    Defaults pre-loop now prevent the crash; a log.warning surfaces the
+    no-match for diagnostic.
+
+    Reproducer: a ToolResultBlock arrives for tool_id `"ghost-tool"`
+    that has NO matching `🔄 ToolName` line because no ToolUseBlock for
+    "ghost-tool" was ever emitted (simulates the out-of-order race that
+    PM forensics identified as one of the no-match causes).
+    """
+    import sys, logging
+    sys.path.insert(0, "src")
+    from claude_agent_sdk.types import (
+        AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
+    )
+    from clauded.discord_renderer import DiscordRenderer
+
+    # One real tool to seed tool_log_lines with a `🔄 Bash` line (proves
+    # the rolling log is alive and has entries), then a ResultBlock for
+    # a *different* tool name that was never ToolUseBlock-ed.
+    events = [
+        AssistantMessage(
+            content=[ToolUseBlock(id="real-tool", name="Bash", input={"command": "echo 1"})],
+            model="claude-sonnet-4-5", parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[
+                # ToolResultBlock for a ghost tool: never had a ToolUseBlock
+                # so no `🔄 GhostTool` line exists in tool_log_lines.
+                ToolResultBlock(
+                    tool_use_id="ghost-tool",
+                    content="orphan result",
+                    is_error=False,
+                ),
+            ],
+            model="claude-sonnet-4-5", parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result", duration_ms=10, duration_api_ms=5,
+            is_error=False, num_turns=1, session_id="sess-226",
+            total_cost_usd=0.0,
+        ),
+    ]
+
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+    caplog.set_level(logging.WARNING, logger="clauded.discord_renderer")
+    # MUST NOT raise (was UnboundLocalError pre-fix)
+    await renderer.render_response(FakeBridge(events), "do things")
+
+    # The diagnostic warning must have fired for the orphan result
+    warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING
+        and "no-matched rolling-log" in r.getMessage()
+    ]
+    assert warnings, (
+        f"Expected diagnostic warning for no-matched ToolResultBlock; "
+        f"got log records: {[(r.levelname, r.getMessage()[:80]) for r in caplog.records]}"
+    )
+    # Warning includes the diagnostic fields per #223 / #224 epic
+    msg = warnings[0].getMessage()
+    assert "ghost-tool" in msg, f"Warning missing tool_id: {msg!r}"
+    assert "rolling_log_len=" in msg, f"Warning missing rolling_log_len: {msg!r}"
+
+
+@pytest.mark.asyncio
+async def test_226_matched_path_still_works_after_defaults_added(caplog):
+    """Regression pin: the matched path (rolling log has the line) still
+    transitions `🔄 Bash → ✅ Bash → 42` correctly. Pre-fix code worked
+    because matching branches assigned all variables; post-fix code now
+    has pre-loop defaults but matched branches must still set
+    `matched = True` so the no-match warning DOESN'T fire incorrectly."""
+    import sys, logging
+    sys.path.insert(0, "src")
+    from claude_agent_sdk.types import (
+        AssistantMessage, ToolUseBlock, ToolResultBlock, ResultMessage,
+    )
+    from clauded.discord_renderer import DiscordRenderer
+
+    events = [
+        # Single tool use + matching result — typical happy path
+        AssistantMessage(
+            content=[ToolUseBlock(id="tool-1", name="Bash", input={"command": "echo 42"})],
+            model="claude-sonnet-4-5", parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[ToolResultBlock(tool_use_id="tool-1", content="42", is_error=False)],
+            model="claude-sonnet-4-5", parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result", duration_ms=10, duration_api_ms=5,
+            is_error=False, num_turns=1, session_id="sess-226-ok",
+            total_cost_usd=0.0,
+        ),
+    ]
+
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+    caplog.set_level(logging.WARNING, logger="clauded.discord_renderer")
+    await renderer.render_response(FakeBridge(events), "do one thing")
+
+    # NO no-matched warning should have fired (the matched path took it)
+    spurious = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING
+        and "no-matched rolling-log" in r.getMessage()
+    ]
+    assert not spurious, (
+        f"Matched path falsely emitted no-match warning: "
+        f"{[r.getMessage() for r in spurious]}"
+    )
+    # Rolling log embed shows the short-tier inline content
+    rolling = [
+        m for m in target._sent
+        if m.embeds and (m.embeds[0].title or "") == "🔧 Tool Activity"
+    ]
+    assert rolling
+    desc = rolling[-1].embeds[0].description
+    assert "✅ Bash → 42" in desc, f"Expected short-tier `✅ Bash → 42`; got: {desc!r}"


### PR DESCRIPTION
Closes #226 (P0).

## Bug
Renderer crashes with `UnboundLocalError: cannot access local variable 'is_medium'` when a ToolResultBlock arrives without a matching `🔄 ToolName` line in tool_log_lines. Every trigger = lost turn + lost conversation (current Retry semantic builds fresh session).

## Fix
Pre-loop initialize `is_medium = False`, `content_str = ""`, `medium_index = None`, plus a `matched` flag. After loop, `if not matched` fires `log.warning(...)` for #223 / #224 diagnostic. Downstream guards on `is_medium` make the no-match path a safe no-op.

## Tests
+2 in `test_tool_result_shorttier.py`. **791 / 0** (was 789, +2).

## Companion issue
**#227** tracks the retry-semantic improvement (resume vs fresh-start). User confirmed retry should preserve SDK conversation; #226 only stops the crash.

## Status
🚧 Draft — pending R1.

## Note
Manager implemented directly (precedent: coding agent recently refused due to malware-policy false-positive on first-party Discord bot).
