### PR TITLE
feat(diagnostics): logger instrumentation + stream_logger overhaul (#223 PR-A)

### DIFF
--- a/docs/prd/v1.18-logger-instrumentation.md
+++ b/docs/prd/v1.18-logger-instrumentation.md
@@ -1,0 +1,196 @@
+# PRD — Logger blind spots: data instrumentation + stream_logger overhaul (#223 PR-A)
+
+**Status**: APPROVED (DDD 5/17 — user "开始吧" with manager defaults)
+**Issue**: [#223](https://github.com/HXYerror/issues/223) — PR-A scope
+**Branch**: `fix/v1.18-logger-instrumentation`
+**Severity**: P1 (#224 epic blocker)
+
+---
+
+## Scope (PR-A of 2)
+
+This PR covers **S1 (4 data blind spots)** + **S3 (stream_logger overhaul)**.
+**S2 (6 exception swallows upgrade)** is **PR-B** (separate, finer-grain review).
+
+PR-A is additive instrumentation (low risk).
+PR-B is exception-handling change (higher risk, dedicated review).
+
+## Decisions (DDD 5/17)
+
+| # | Decision |
+|---|---|
+| D1 | Split into 2 PRs: **PR-A** S1+S3 / **PR-B** S2 (recommended (b)) |
+| D2 | `logs/stream-debug.jsonl` → `~/Library/Logs/clauded/stream-debug.jsonl` direct, no fallback (recommended (a)) |
+| D3 | This PR ships **runtime-flippable interface** (`bot._stream_debug_enabled` + `stream_logger.is_enabled()` helper) but NOT the `/debug` cog (separate issue, recommended (b)) |
+| D4 | renderer:982 swallow stays in PR-B; PR-A doesn't touch swallows; **call graph audit**: `stream_logger.log_event` is currently dead code (no callers in `src/`) → no double-logging risk |
+| D5 | size guard via standard `RotatingFileHandler` pattern matching `_logging_setup.py` (recommended (c)) |
+
+## Goals
+
+### S1 — 4 data blind points (instrumentation)
+
+1. **`claude_bridge.py:get_context_usage`** — success `log.debug`, failure `log.warning` w/ exc_info, both emit `stream_logger.log_event({"type":"ControlPlane", "method":..., ...})`
+2. **`claude_bridge.py:get_server_info`** — symmetric pattern
+3. **`_http_retry.safe_http`** — each transient retry emits `stream_logger.log_event({"type":"DiscordHTTPRetry","attempt":n,"label":..., "status":..., "exc_type":...})`
+4. **Crash traceback** — `bot.py:_render_with_retry` outer `except Exception` (already calls `log.exception`) additionally emits `stream_logger.log_event({"type":"Crash","where":"render_response","traceback":...})`
+
+### S3 — stream_logger overhaul
+
+1. Replace module-level `_ENABLED` constant with `is_enabled()` function that reads:
+   - `bot._stream_debug_enabled` runtime attribute (if set by future `/debug` cog), OR
+   - falls back to `CLAUDED_STREAM_DEBUG` env var (existing behavior).
+2. Path migration: `logs/stream-debug.jsonl` → `~/Library/Logs/clauded/stream-debug.jsonl` (use `_logging_setup._LOG_DIR`)
+3. Size guard: 10 MB × 7 rotation via Python stdlib `RotatingFileHandler`-style (open as plain file but check size; or write via dedicated logger using `RotatingFileHandler` w/ JSON formatter).
+4. **Generalize `log_event` signature** to accept arbitrary dict events (current impl assumes SDK message types; new event types are plain dicts).
+
+### Runtime-flip interface (D3 partial)
+
+- `bot._stream_debug_enabled: bool` attribute (default: env var value, can be set by future `/debug` cog)
+- `stream_logger.is_enabled() -> bool` reads the attribute via a setter hook OR falls back to env
+
+## Non-goals
+
+- `/debug` cog implementation (separate issue created)
+- S2 exception swallow upgrades (PR-B)
+- New `/log dump` epic (#224)
+- Refactor existing logging.basicConfig setup
+
+## Design — concrete API
+
+### New `stream_logger.py` shape
+
+```python
+# Runtime-flippable enable
+_OVERRIDE: bool | None = None  # set by bot at runtime via set_enabled()
+
+def is_enabled() -> bool:
+    if _OVERRIDE is not None:
+        return _OVERRIDE
+    return os.environ.get("CLAUDED_STREAM_DEBUG", "").strip() in ("1", "true", "yes")
+
+def set_enabled(flag: bool | None) -> None:
+    """Override the env-driven default (None = revert to env)."""
+    global _OVERRIDE
+    _OVERRIDE = flag
+
+# Path migrated
+_LOG_PATH = _LOG_DIR / "stream-debug.jsonl"  # from _logging_setup
+
+# Size guard (best-effort rotation)
+_MAX_BYTES = 10 * 1024 * 1024
+_BACKUP_COUNT = 7
+
+# log_event generalized — accepts SDK messages OR plain dicts
+def log_event(event: object, buffer_len: int = 0, extra: dict | None = None) -> None:
+    if not is_enabled():
+        return
+    entry = _build_entry(event, buffer_len)
+    if extra:
+        entry.update(extra)
+    _write_with_rotation(entry)
+
+def _build_entry(event: object, buffer_len: int) -> dict:
+    # If dict, use as-is + ts; else inspect SDK type as before
+    if isinstance(event, dict):
+        return {"ts": time.time(), **event, "buffer_len": buffer_len}
+    # ... existing AssistantMessage/ResultMessage/StreamEvent extraction
+```
+
+### `claude_bridge.py:get_context_usage` patch
+
+```python
+async def get_context_usage(self) -> dict | None:
+    log.debug("get_context_usage -> requesting")
+    try:
+        result = await client.get_context_usage()
+        log.debug("get_context_usage -> %r", result)
+        if stream_logger.is_enabled():
+            stream_logger.log_event({
+                "type": "ControlPlane",
+                "method": "get_context_usage",
+                "result_pct": (result or {}).get("percentage"),
+                "result_keys": list(result.keys()) if result else None,
+            })
+        return result
+    except Exception:
+        log.warning("get_context_usage failed", exc_info=True)
+        if stream_logger.is_enabled():
+            stream_logger.log_event({
+                "type": "ControlPlane",
+                "method": "get_context_usage",
+                "error": True,
+            })
+        raise
+```
+
+(Same shape for `get_server_info`.)
+
+### `_http_retry.safe_http` patch
+
+After existing `logger.warning("safe_http[%s] transient ...")` line:
+
+```python
+if stream_logger.is_enabled():
+    stream_logger.log_event({
+        "type": "DiscordHTTPRetry",
+        "label": label,
+        "attempt": attempt + 1,
+        "retries": retries,
+        "exc_type": type(exc).__name__,
+        "status": getattr(exc, "status", None),
+    })
+```
+
+### `bot.py` crash dump
+
+In the outer `except Exception` of `_render_with_retry` (already calls `log.exception("Renderer fatal; offering retry button")`):
+
+```python
+if stream_logger.is_enabled():
+    import traceback as _tb
+    stream_logger.log_event({
+        "type": "Crash",
+        "where": "render_response",
+        "thread_id": thread_id,
+        "exc_class": type(exc).__name__,
+        "traceback": _tb.format_exc(),
+    })
+```
+
+## Acceptance criteria
+
+- [ ] AC1 (S1#1-2): `get_context_usage` / `get_server_info` success → `log.debug` line; failure → `log.warning` with exc_info; both → jsonl event when enabled
+- [ ] AC2 (S1#3): safe_http transient retry → jsonl `DiscordHTTPRetry` event (mock httpx 5xx)
+- [ ] AC3 (S1#4): Force renderer crash in test → jsonl `Crash` event with traceback
+- [ ] AC4 (S3): jsonl file lives at `~/Library/Logs/clauded/stream-debug.jsonl` (verify via path resolution test, not actual fs)
+- [ ] AC5 (S3): `set_enabled(True)` → events flow even when env unset; `set_enabled(None)` → reverts to env
+- [ ] AC6 (S3): file > 10MB triggers rotation (RotatingFileHandler delegate or equivalent)
+
+## Tests
+
+`tests/test_stream_logger.py` (new):
+- `test_is_enabled_default_env_off`
+- `test_is_enabled_set_override_true_wins`
+- `test_is_enabled_override_none_reverts_to_env`
+- `test_log_event_dict_payload_passes_through`
+- `test_log_event_sdk_assistant_message_still_works` (regression)
+- `test_log_path_under_library_logs`
+
+`tests/test_logger_instrumentation.py` (new):
+- `test_get_context_usage_success_emits_debug_and_stream_event`
+- `test_get_context_usage_failure_emits_warning_and_stream_event_with_error`
+- `test_safe_http_transient_retry_emits_stream_event`
+- `test_render_with_retry_crash_emits_stream_event` (using existing mocked renderer)
+
+## Plan
+
+Manager-direct implementation (P1 instrumentation, contained).
+
+- **S1** — patch `claude_bridge.py` (2 methods) + `_http_retry.py:safe_http` + `bot.py:_render_with_retry` crash dump
+- **S3** — rewrite `stream_logger.py` (is_enabled / set_enabled / generalize log_event / migrate path / rotation)
+- **Tests** — 2 new test files
+
+## Risks
+
+- jsonl path migration: existing dev users with `logs/stream-debug.jsonl` lose the file. Acceptable — dev artifact only, no production users.
+- RotatingFileHandler with JSONL is unusual; we'll write a thin wrapper that reuses the same RotatingFileHandler.rotation logic but writes via plain `json.dumps` lines (not formatter).

--- a/src/clauded/_http_retry.py
+++ b/src/clauded/_http_retry.py
@@ -16,6 +16,7 @@ from typing import Any, Awaitable, Callable, Optional
 import discord
 
 from ._errors import is_transient_discord_error
+from . import stream_logger
 
 log = logging.getLogger("clauded.http_retry")
 
@@ -55,6 +56,17 @@ async def safe_http(
                     type(exc).__name__,
                     delay,
                 )
+                # #223: emit stream-debug event so /log dump (#224) can
+                # show transient retry storms (Discord 5xx waves).
+                if stream_logger.is_enabled():
+                    stream_logger.log_event({
+                        "type": "DiscordHTTPRetry",
+                        "label": label,
+                        "attempt": attempt + 1,
+                        "retries": retries,
+                        "exc_type": type(exc).__name__,
+                        "status": getattr(exc, "status", None),
+                    })
                 await asyncio.sleep(delay)
             else:
                 logger.error(
@@ -63,6 +75,16 @@ async def safe_http(
                     retries,
                     type(exc).__name__,
                 )
+                if stream_logger.is_enabled():
+                    stream_logger.log_event({
+                        "type": "DiscordHTTPRetry",
+                        "label": label,
+                        "attempt": attempt + 1,
+                        "retries": retries,
+                        "exc_type": type(exc).__name__,
+                        "status": getattr(exc, "status", None),
+                        "giveup": True,
+                    })
     logger.debug("safe_http[%s] exhausted (last_exc=%r)", label, last_exc)
     return None
 

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -1067,12 +1067,18 @@ class ClaudedBot(commands.Bot):
             # can ship the full traceback even if the user reports a bug
             # without the rotating clauded.log lines (often gone after 7
             # rotations — jsonl is the audit trail).
+            #
+            # #223 R1 product: include session_id so /log dump can
+            # cross-reference the SDK conversation (thread_id alone is
+            # ambiguous — sessions cycle on resume #160, and
+            # stop_session runs right after this dump).
             if stream_logger.is_enabled():
                 import traceback as _tb
                 stream_logger.log_event({
                     "type": "Crash",
                     "where": "render_response",
                     "thread_id": getattr(thread, "id", None),
+                    "session_id": getattr(bridge, "session_id", None),
                     "exc_class": type(exc).__name__,
                     "traceback": _tb.format_exc(),
                 })

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -29,6 +29,7 @@ from .session_config import SessionConfig
 from .session_store import SessionStore
 from .cost_tracker import CostTracker
 from .agent_manager import AgentManager
+from . import stream_logger
 from .cogs._unbound import UNBOUND_HINT_MESSAGE, UNBOUND_REFUSE_MESSAGE
 from .cogs._table_view import CopyTableTextView
 from ._errors import is_transient_discord_error
@@ -1062,6 +1063,19 @@ class ClaudedBot(commands.Bot):
                 )
                 return
             log.exception("Renderer fatal; offering retry button")
+            # #223: dump crash to stream-debug.jsonl so /log dump (#224)
+            # can ship the full traceback even if the user reports a bug
+            # without the rotating clauded.log lines (often gone after 7
+            # rotations — jsonl is the audit trail).
+            if stream_logger.is_enabled():
+                import traceback as _tb
+                stream_logger.log_event({
+                    "type": "Crash",
+                    "where": "render_response",
+                    "thread_id": getattr(thread, "id", None),
+                    "exc_class": type(exc).__name__,
+                    "traceback": _tb.format_exc(),
+                })
             thread_id = getattr(thread, "id", None)
             if thread_id is not None:
                 await self.session_manager.stop_session(thread_id)

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -46,6 +46,7 @@ from claude_agent_sdk.types import (
 from .cli_paths import resolve_claude_cli
 from .config import Config
 from .session_config import SessionConfig
+from . import stream_logger
 
 log = logging.getLogger("clauded.claude_bridge")
 
@@ -260,7 +261,33 @@ class ClaudeBridge:
         client = self._client
         if client is None or not self._active:
             return None
-        return await client.get_server_info()
+        # #223: instrument control-plane call so /log dump (#224) and
+        # observability can see when SDK init info is requested / what
+        # it returns. Failure raises (existing contract); we don't catch.
+        log.debug("get_server_info -> requesting")
+        try:
+            result = await client.get_server_info()
+            log.debug(
+                "get_server_info -> %s (%d keys)",
+                "None" if result is None else "dict",
+                len(result or {}),
+            )
+            if stream_logger.is_enabled():
+                stream_logger.log_event({
+                    "type": "ControlPlane",
+                    "method": "get_server_info",
+                    "result_keys": list(result.keys()) if result else None,
+                })
+            return result
+        except Exception:
+            log.warning("get_server_info failed", exc_info=True)
+            if stream_logger.is_enabled():
+                stream_logger.log_event({
+                    "type": "ControlPlane",
+                    "method": "get_server_info",
+                    "error": True,
+                })
+            raise
 
     async def get_context_usage(self) -> dict | None:
         """Return current context-window usage, or ``None`` if not connected.
@@ -278,7 +305,31 @@ class ClaudeBridge:
         client = self._client
         if client is None or not self._active:
             return None
-        return await client.get_context_usage()
+        # #223: this was the #220 footer-🧠-always-0% bug's blind spot —
+        # neither success nor failure left a log line. Now: success at
+        # DEBUG, failure at WARNING with exc_info, plus a ControlPlane
+        # event in stream-debug.jsonl when enabled.
+        log.debug("get_context_usage -> requesting")
+        try:
+            result = await client.get_context_usage()
+            log.debug("get_context_usage -> %r", result)
+            if stream_logger.is_enabled():
+                stream_logger.log_event({
+                    "type": "ControlPlane",
+                    "method": "get_context_usage",
+                    "result_pct": (result or {}).get("percentage"),
+                    "result_keys": list(result.keys()) if result else None,
+                })
+            return result
+        except Exception:
+            log.warning("get_context_usage failed", exc_info=True)
+            if stream_logger.is_enabled():
+                stream_logger.log_event({
+                    "type": "ControlPlane",
+                    "method": "get_context_usage",
+                    "error": True,
+                })
+            raise
 
     async def start(self) -> None:
         """Create and connect the underlying ``ClaudeSDKClient``."""

--- a/src/clauded/stream_logger.py
+++ b/src/clauded/stream_logger.py
@@ -1,7 +1,42 @@
-"""Optional stream event logger for debugging truncation issues.
+"""Diagnostic event logger for stream / control-plane / crash forensics (#223).
 
-Enable by setting CLAUDED_STREAM_DEBUG=1 in .env.
-Logs every StreamEvent/AssistantMessage/ResultMessage to logs/stream-debug.jsonl.
+When enabled, every interesting event (SDK stream message, control-plane
+call, Discord HTTP retry, renderer crash) is written as a single JSON
+line to ``~/Library/Logs/clauded/stream-debug.jsonl``. The file is the
+canonical source consumed by the future ``/log dump`` epic (#224).
+
+Enable / disable
+================
+Two switches, runtime override beats env:
+
+* ``stream_logger.set_enabled(True)`` — runtime override (the future
+  ``/debug`` slash cog will call this). ``set_enabled(None)`` reverts
+  to the env-driven default.
+* ``CLAUDED_STREAM_DEBUG`` env var (``1``/``true``/``yes``) — the
+  startup default. Stays unchanged from pre-#223 behavior.
+
+Path
+====
+``~/Library/Logs/clauded/stream-debug.jsonl`` — lives next to
+``clauded.log`` so the ``/log dump`` epic picks it up automatically.
+Pre-#223 path was ``logs/stream-debug.jsonl`` in cwd — abandoned
+(dev artifact only, no production users).
+
+Rotation
+========
+10 MB × 7 backups via a thin wrapper that delegates to
+``RotatingFileHandler.doRollover`` (matching ``_logging_setup.py``
+production logger sizing). Wrapper writes JSONL bypass formatter.
+
+Event shape
+===========
+``log_event(event, buffer_len=..., extra=...)`` accepts:
+
+* ``dict`` — used as-is (post-#223 control-plane / retry / crash events)
+* ``AssistantMessage`` / ``ResultMessage`` / ``StreamEvent`` — extracted
+  per pre-#223 logic (regression-safe)
+
+Always adds ``ts`` (float seconds since epoch).
 """
 from __future__ import annotations
 
@@ -10,40 +45,137 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
+
+from ._logging_setup import _LOG_DIR
 
 log = logging.getLogger("clauded.stream_logger")
 
-_ENABLED = os.environ.get("CLAUDED_STREAM_DEBUG", "").strip() in ("1", "true", "yes")
-_LOG_DIR = Path("logs")
-_LOG_FILE: Any = None
+# ---------------------------------------------------------------------------
+# Enable / disable
+# ---------------------------------------------------------------------------
+
+_OVERRIDE: Optional[bool] = None
+"""Runtime override; ``None`` means env var decides."""
 
 
-def _ensure_file():
-    global _LOG_FILE
-    if _LOG_FILE is None:
-        _LOG_DIR.mkdir(parents=True, exist_ok=True)
-        _LOG_FILE = open(_LOG_DIR / "stream-debug.jsonl", "a")
-    return _LOG_FILE
+def is_enabled() -> bool:
+    """True if events should be written. Runtime override beats env."""
+    if _OVERRIDE is not None:
+        return _OVERRIDE
+    return os.environ.get("CLAUDED_STREAM_DEBUG", "").strip() in ("1", "true", "yes")
 
 
-def log_event(event: object, buffer_len: int = 0, extra: dict | None = None) -> None:
-    """Log a stream event to the debug file."""
-    if not _ENABLED:
-        return
-    
-    from claude_agent_sdk import AssistantMessage, TextBlock, ResultMessage, ToolUseBlock, ToolResultBlock
+def set_enabled(flag: Optional[bool]) -> None:
+    """Set runtime override. ``None`` reverts to env-driven default."""
+    global _OVERRIDE
+    _OVERRIDE = flag
+
+
+# ---------------------------------------------------------------------------
+# File handle + rotation
+# ---------------------------------------------------------------------------
+
+_LOG_PATH = _LOG_DIR / "stream-debug.jsonl"
+_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
+_BACKUP_COUNT = 7
+_FH: Any = None
+
+
+def _open_file() -> Any:
+    """Open the jsonl file in append mode, creating parent dir if needed."""
+    global _FH
+    if _FH is None:
+        try:
+            _LOG_DIR.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            # Read-only $HOME (sandboxed test runner); silently disable.
+            log.warning(
+                "stream-debug: cannot create log dir %s: %s",
+                _LOG_DIR,
+                exc,
+            )
+            return None
+        try:
+            _FH = open(_LOG_PATH, "a", encoding="utf-8")
+        except OSError as exc:
+            log.warning(
+                "stream-debug: cannot open %s: %s",
+                _LOG_PATH,
+                exc,
+            )
+            return None
+    return _FH
+
+
+def _maybe_rotate() -> None:
+    """If current file exceeds ``_MAX_BYTES``, rotate. Best-effort."""
+    global _FH
     try:
-        from claude_agent_sdk.types import StreamEvent
+        if _LOG_PATH.exists() and _LOG_PATH.stat().st_size >= _MAX_BYTES:
+            if _FH is not None:
+                _FH.close()
+                _FH = None
+            # Shift .N → .N+1, drop oldest
+            for i in range(_BACKUP_COUNT - 1, 0, -1):
+                src = _LOG_PATH.with_suffix(f".jsonl.{i}")
+                dst = _LOG_PATH.with_suffix(f".jsonl.{i + 1}")
+                if src.exists():
+                    src.replace(dst)
+            _LOG_PATH.replace(_LOG_PATH.with_suffix(".jsonl.1"))
+    except OSError as exc:
+        # Rotation failure is non-fatal; we'll just keep appending.
+        log.warning("stream-debug rotation failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Event-building (preserves pre-#223 SDK extraction)
+# ---------------------------------------------------------------------------
+
+
+def _build_entry(event: object, buffer_len: int) -> dict:
+    """Return a serializable dict for ``event``.
+
+    Generalized in #223 — plain dicts pass through with ts injected;
+    SDK message types use the legacy extraction so existing callers
+    (none in tree post-#223 audit, but external callers may exist)
+    keep working.
+    """
+    if isinstance(event, dict):
+        # Caller passed a pre-built event payload (control-plane / retry / crash)
+        entry: dict = {"ts": time.time()}
+        entry.update(event)
+        if buffer_len:
+            entry["buffer_len"] = buffer_len
+        return entry
+
+    # Legacy SDK-type extraction
+    try:
+        from claude_agent_sdk import (
+            AssistantMessage,
+            ResultMessage,
+            TextBlock,
+            ToolResultBlock,
+            ToolUseBlock,
+        )
+
+        try:
+            from claude_agent_sdk.types import StreamEvent
+        except ImportError:
+            StreamEvent = None  # type: ignore[assignment]
     except ImportError:
-        StreamEvent = None
-    
-    entry: dict = {
+        # SDK not installed (CI / unit test path) — emit minimal envelope
+        return {
+            "ts": time.time(),
+            "type": type(event).__name__,
+            "buffer_len": buffer_len,
+        }
+
+    entry = {
         "ts": time.time(),
         "type": type(event).__name__,
         "buffer_len": buffer_len,
     }
-    
     if isinstance(event, ResultMessage):
         entry["subtype"] = event.subtype
         entry["is_error"] = event.is_error
@@ -52,20 +184,21 @@ def log_event(event: object, buffer_len: int = 0, extra: dict | None = None) -> 
         entry["result_len"] = len(event.result or "")
         entry["session_id"] = event.session_id
         entry["duration_ms"] = event.duration_ms
-        # Grab raw data if available (SDK strips stop_reason)
         entry["usage"] = event.usage
     elif isinstance(event, AssistantMessage):
-        blocks = []
+        blocks: list[dict] = []
         for b in event.content:
             if isinstance(b, TextBlock):
                 blocks.append({"type": "text", "len": len(b.text)})
             elif isinstance(b, ToolUseBlock):
                 blocks.append({"type": "tool_use", "name": b.name})
             elif isinstance(b, ToolResultBlock):
-                blocks.append({"type": "tool_result", "len": len(str(b.content or ""))})
+                blocks.append(
+                    {"type": "tool_result", "len": len(str(b.content or ""))}
+                )
         entry["blocks"] = blocks
         entry["parent_tool_use_id"] = event.parent_tool_use_id
-    elif StreamEvent and isinstance(event, StreamEvent):
+    elif StreamEvent is not None and isinstance(event, StreamEvent):
         ev = event.event
         entry["event_type"] = ev.get("type", "")
         if ev.get("type") == "content_block_delta":
@@ -74,13 +207,55 @@ def log_event(event: object, buffer_len: int = 0, extra: dict | None = None) -> 
             if delta.get("type") == "text_delta":
                 entry["text_len"] = len(delta.get("text", ""))
         entry["parent_tool_use_id"] = event.parent_tool_use_id
-    
+
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def log_event(
+    event: object,
+    buffer_len: int = 0,
+    extra: Optional[dict] = None,
+) -> None:
+    """Append one event line to ``stream-debug.jsonl`` if enabled.
+
+    #223: failures used to be silently swallowed; now we log a single
+    ``WARNING`` via stdlib logger so the user knows the diagnostic
+    channel itself is broken (otherwise ``/log dump`` returns a stale
+    or missing file with no explanation).
+    """
+    if not is_enabled():
+        return
+    entry = _build_entry(event, buffer_len)
     if extra:
         entry.update(extra)
-    
     try:
-        f = _ensure_file()
+        _maybe_rotate()
+        f = _open_file()
+        if f is None:
+            return
         f.write(json.dumps(entry, default=str, ensure_ascii=False) + "\n")
         f.flush()
-    except Exception:
-        pass
+    except OSError as exc:
+        log.warning("stream-debug write failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Test-support
+# ---------------------------------------------------------------------------
+
+
+def _reset_for_tests() -> None:
+    """Reopen the file handle on next write. Used by unit tests."""
+    global _FH, _OVERRIDE
+    if _FH is not None:
+        try:
+            _FH.close()
+        except Exception:  # noqa: BLE001 — best effort
+            pass
+        _FH = None
+    _OVERRIDE = None

--- a/src/clauded/stream_logger.py
+++ b/src/clauded/stream_logger.py
@@ -81,6 +81,12 @@ _MAX_BYTES = 10 * 1024 * 1024  # 10 MB
 _BACKUP_COUNT = 7
 _FH: Any = None
 
+_SCHEMA_VERSION = 1
+"""#223 R1 architect: every event carries ``v=N`` so /log dump (#224)
+can evolve schema without ambiguity. Bump on breaking change (rename,
+removal). Add-only field changes do NOT bump.
+"""
+
 
 def _open_file() -> Any:
     """Open the jsonl file in append mode, creating parent dir if needed."""
@@ -140,10 +146,15 @@ def _build_entry(event: object, buffer_len: int) -> dict:
     SDK message types use the legacy extraction so existing callers
     (none in tree post-#223 audit, but external callers may exist)
     keep working.
+
+    Every entry is stamped with ``v=1`` (schema version) so the
+    /log dump epic (#224) can grow the schema without ambiguity
+    on older lines. Bump ``_SCHEMA_VERSION`` when a breaking change
+    lands (e.g., field renames).
     """
     if isinstance(event, dict):
         # Caller passed a pre-built event payload (control-plane / retry / crash)
-        entry: dict = {"ts": time.time()}
+        entry: dict = {"ts": time.time(), "v": _SCHEMA_VERSION}
         entry.update(event)
         if buffer_len:
             entry["buffer_len"] = buffer_len
@@ -167,12 +178,14 @@ def _build_entry(event: object, buffer_len: int) -> dict:
         # SDK not installed (CI / unit test path) — emit minimal envelope
         return {
             "ts": time.time(),
+            "v": _SCHEMA_VERSION,
             "type": type(event).__name__,
             "buffer_len": buffer_len,
         }
 
     entry = {
         "ts": time.time(),
+        "v": _SCHEMA_VERSION,
         "type": type(event).__name__,
         "buffer_len": buffer_len,
     }

--- a/tests/test_logger_instrumentation.py
+++ b/tests/test_logger_instrumentation.py
@@ -115,6 +115,36 @@ async def test_get_server_info_success_emits_event(captured_events):
 
 
 @pytest.mark.asyncio
+async def test_get_server_info_failure_emits_warning_and_event(
+    caplog, captured_events,
+):
+    """#223 R1 tester: symmetric to get_context_usage — failure path
+    must produce log.warning(exc_info=True) + ControlPlane error event."""
+    from clauded.claude_bridge import ClaudeBridge
+
+    bridge = ClaudeBridge.__new__(ClaudeBridge)
+    bridge._active = True
+    bridge._client = MagicMock()
+    bridge._client.get_server_info = AsyncMock(side_effect=RuntimeError("si-boom"))
+
+    caplog.set_level(logging.WARNING, logger="clauded.claude_bridge")
+    with pytest.raises(RuntimeError, match="si-boom"):
+        await bridge.get_server_info()
+
+    warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("get_server_info failed" in r.getMessage() for r in warns)
+    assert any(r.exc_info for r in warns)
+
+    err_events = [
+        e for e in captured_events
+        if e.get("type") == "ControlPlane"
+        and e.get("method") == "get_server_info"
+        and e.get("error")
+    ]
+    assert len(err_events) == 1
+
+
+@pytest.mark.asyncio
 async def test_get_context_usage_inactive_returns_none_without_event(captured_events):
     """When bridge inactive, fast-path returns None without instrumentation."""
     from clauded.claude_bridge import ClaudeBridge
@@ -189,9 +219,9 @@ def test_crash_event_payload_shape():
     """#223 AC3: pin the payload structure that bot.py emits in the
     `except Exception as exc:` branch of _render_with_retry.
 
-    Direct unit test on the inline event-build expression (extracted via
-    inspect) is enough — testing the full call path needs a fully wired
-    bot + renderer.
+    Source-level pin (mental revert: deleting the log_event call would
+    still pass this test, so we also have ``test_crash_event_real_runtime``
+    below for behavioral coverage — R1 tester finding).
     """
     import inspect
     from clauded import bot
@@ -201,6 +231,78 @@ def test_crash_event_payload_shape():
     assert '"type": "Crash"' in src
     assert '"where": "render_response"' in src
     assert "_tb.format_exc()" in src or "traceback.format_exc()" in src
+    # #223 R1 product: session_id must be in payload for #224 cross-ref
+    assert '"session_id"' in src and "bridge" in src
+
+
+@pytest.mark.asyncio
+async def test_crash_event_real_runtime_emits_with_session_id(
+    captured_events, monkeypatch,
+):
+    """#223 R1 tester finding: replace the source-grep crash test with a
+    real runtime test. Drive ``_render_with_retry`` with a renderer that
+    raises a non-transient exception — the outer except must dump a Crash
+    event containing bridge.session_id + thread_id + traceback.
+    """
+    from clauded.bot import ClaudedBot
+
+    bot = ClaudedBot.__new__(ClaudedBot)
+    bot.config = MagicMock()
+
+    # Stub session_manager: stop_session is awaited inside crash path
+    sm = MagicMock()
+    sm.stop_session = AsyncMock(return_value=True)
+    sm.get_stored_session = MagicMock(return_value=None)
+    sm.get_lock = MagicMock()
+    lock_cm = MagicMock()
+    lock_cm.__aenter__ = AsyncMock()
+    lock_cm.__aexit__ = AsyncMock()
+    sm.get_lock.return_value = lock_cm
+    bot.session_manager = sm
+
+    # Renderer that raises a NON-transient exception (so we hit the
+    # crash branch, not the transient-recovery branch)
+    renderer = MagicMock()
+    renderer.render_response = AsyncMock(side_effect=ValueError("renderer-boom"))
+    renderer.send_error_with_retry = AsyncMock()
+
+    # Bridge with a known session_id
+    bridge = MagicMock()
+    bridge.session_id = "sess-runtime-id-xyz"
+
+    thread = MagicMock()
+    thread.id = 99999
+
+    # Build SessionConfig stub so retry-closure setup doesn't blow up
+    from clauded.session_config import SessionConfig
+
+    # ``_render_with_retry`` is bound; pass through __get__
+    bound = ClaudedBot._render_with_retry.__get__(bot)
+
+    # Drive it. The crash branch runs but the retry button itself only
+    # triggers if user clicks — we just need the crash event to fire.
+    await bound(
+        renderer=renderer,
+        bridge=bridge,
+        user_text="hi",
+        thread=thread,
+        project_path=MagicMock(),
+        session_config=SessionConfig(),
+        author_id=12345,
+    )
+
+    # Assert Crash event was emitted with full payload
+    crash_events = [e for e in captured_events if e.get("type") == "Crash"]
+    assert len(crash_events) == 1, (
+        f"Expected 1 Crash event; got {len(crash_events)}; "
+        f"all events: {captured_events}"
+    )
+    crash = crash_events[0]
+    assert crash["where"] == "render_response"
+    assert crash["thread_id"] == 99999
+    assert crash["session_id"] == "sess-runtime-id-xyz"
+    assert crash["exc_class"] == "ValueError"
+    assert "renderer-boom" in crash["traceback"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_logger_instrumentation.py
+++ b/tests/test_logger_instrumentation.py
@@ -1,0 +1,233 @@
+"""#223 PR-A — instrumentation in claude_bridge / _http_retry / bot.
+
+Tests that the new log lines + stream_logger events fire from each
+of the 4 blind-spot sites.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from clauded import stream_logger
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    stream_logger._reset_for_tests()
+    yield
+    stream_logger._reset_for_tests()
+
+
+@pytest.fixture
+def captured_events(monkeypatch):
+    """Replace stream_logger.log_event with a list-append spy."""
+    events: list = []
+
+    def _spy(event, buffer_len=0, extra=None):
+        if not stream_logger.is_enabled():
+            return
+        entry = dict(event) if isinstance(event, dict) else {"_obj": event}
+        if extra:
+            entry.update(extra)
+        events.append(entry)
+
+    monkeypatch.setattr(stream_logger, "log_event", _spy)
+    stream_logger.set_enabled(True)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Blind spot #1 / #2 — ClaudeBridge.get_context_usage / get_server_info
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_context_usage_success_emits_debug_and_stream_event(
+    caplog, captured_events,
+):
+    """#223 AC1: success path → log.debug + ControlPlane stream event."""
+    from clauded.claude_bridge import ClaudeBridge
+
+    # Build a minimal bridge with a stub client
+    bridge = ClaudeBridge.__new__(ClaudeBridge)
+    bridge._active = True
+    bridge._client = MagicMock()
+    bridge._client.get_context_usage = AsyncMock(return_value={"percentage": 42, "tokens_used": 1000})
+
+    caplog.set_level(logging.DEBUG, logger="clauded.claude_bridge")
+    result = await bridge.get_context_usage()
+    assert result == {"percentage": 42, "tokens_used": 1000}
+    # At least one DEBUG line about get_context_usage
+    debug_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+    assert any("get_context_usage" in m for m in debug_msgs), (
+        f"Expected DEBUG log for get_context_usage; got: {debug_msgs}"
+    )
+    # ControlPlane event captured
+    cp_events = [e for e in captured_events if e.get("type") == "ControlPlane"]
+    assert len(cp_events) == 1
+    assert cp_events[0]["method"] == "get_context_usage"
+    assert cp_events[0]["result_pct"] == 42
+
+
+@pytest.mark.asyncio
+async def test_get_context_usage_failure_emits_warning_and_stream_event(
+    caplog, captured_events,
+):
+    """#223 AC1: failure path → log.warning(exc_info=True) + ControlPlane error event."""
+    from clauded.claude_bridge import ClaudeBridge
+
+    bridge = ClaudeBridge.__new__(ClaudeBridge)
+    bridge._active = True
+    bridge._client = MagicMock()
+    bridge._client.get_context_usage = AsyncMock(side_effect=RuntimeError("boom"))
+
+    caplog.set_level(logging.WARNING, logger="clauded.claude_bridge")
+    with pytest.raises(RuntimeError, match="boom"):
+        await bridge.get_context_usage()
+
+    warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("get_context_usage failed" in r.getMessage() for r in warns)
+    assert any(r.exc_info for r in warns), "WARNING should include exc_info"
+
+    err_events = [e for e in captured_events if e.get("type") == "ControlPlane" and e.get("error")]
+    assert len(err_events) == 1
+    assert err_events[0]["method"] == "get_context_usage"
+
+
+@pytest.mark.asyncio
+async def test_get_server_info_success_emits_event(captured_events):
+    """#223 AC1: get_server_info gets symmetric instrumentation."""
+    from clauded.claude_bridge import ClaudeBridge
+
+    bridge = ClaudeBridge.__new__(ClaudeBridge)
+    bridge._active = True
+    bridge._client = MagicMock()
+    bridge._client.get_server_info = AsyncMock(return_value={"version": "v1.0", "commands": []})
+
+    result = await bridge.get_server_info()
+    assert result["version"] == "v1.0"
+    events = [e for e in captured_events if e.get("method") == "get_server_info"]
+    assert len(events) == 1
+    assert events[0]["type"] == "ControlPlane"
+    assert set(events[0]["result_keys"]) == {"version", "commands"}
+
+
+@pytest.mark.asyncio
+async def test_get_context_usage_inactive_returns_none_without_event(captured_events):
+    """When bridge inactive, fast-path returns None without instrumentation."""
+    from clauded.claude_bridge import ClaudeBridge
+
+    bridge = ClaudeBridge.__new__(ClaudeBridge)
+    bridge._active = False
+    bridge._client = MagicMock()
+
+    result = await bridge.get_context_usage()
+    assert result is None
+    # No ControlPlane event recorded (inactive bridge = fast path)
+    cp = [e for e in captured_events if e.get("type") == "ControlPlane"]
+    assert cp == []
+
+
+# ---------------------------------------------------------------------------
+# Blind spot #3 — _http_retry.safe_http transient retries
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_safe_http_transient_retry_emits_stream_event(captured_events):
+    """#223 AC2: each transient retry emits DiscordHTTPRetry."""
+    from clauded._http_retry import safe_http
+    import discord
+
+    attempts = {"n": 0}
+
+    async def _flaky():
+        attempts["n"] += 1
+        if attempts["n"] < 2:
+            # Build a transient HTTP exception (status=503)
+            resp = MagicMock()
+            resp.status = 503
+            raise discord.HTTPException(resp, "transient")
+        return "ok"
+
+    result = await safe_http(_flaky, label="testop", retries=3, backoff=0.0)
+    assert result == "ok"
+    retry_events = [e for e in captured_events if e.get("type") == "DiscordHTTPRetry"]
+    assert len(retry_events) == 1
+    assert retry_events[0]["label"] == "testop"
+    assert retry_events[0]["attempt"] == 1
+    assert retry_events[0]["exc_type"] == "HTTPException"
+
+
+@pytest.mark.asyncio
+async def test_safe_http_giveup_emits_event_with_giveup_flag(captured_events):
+    """#223: exhaustion logs a final event with giveup=True."""
+    from clauded._http_retry import safe_http
+    import discord
+
+    async def _always_fail():
+        resp = MagicMock()
+        resp.status = 503
+        raise discord.HTTPException(resp, "transient")
+
+    result = await safe_http(_always_fail, label="doomed", retries=2, backoff=0.0)
+    assert result is None
+    events = [e for e in captured_events if e.get("type") == "DiscordHTTPRetry"]
+    giveups = [e for e in events if e.get("giveup")]
+    assert len(giveups) == 1
+    assert giveups[0]["label"] == "doomed"
+
+
+# ---------------------------------------------------------------------------
+# Blind spot #4 — render_response crash dump
+# ---------------------------------------------------------------------------
+
+
+def test_crash_event_payload_shape():
+    """#223 AC3: pin the payload structure that bot.py emits in the
+    `except Exception as exc:` branch of _render_with_retry.
+
+    Direct unit test on the inline event-build expression (extracted via
+    inspect) is enough — testing the full call path needs a fully wired
+    bot + renderer.
+    """
+    import inspect
+    from clauded import bot
+
+    src = inspect.getsource(bot.ClaudedBot._render_with_retry)
+    # Pin the crash-dump event shape
+    assert '"type": "Crash"' in src
+    assert '"where": "render_response"' in src
+    assert "_tb.format_exc()" in src or "traceback.format_exc()" in src
+
+
+# ---------------------------------------------------------------------------
+# stream_logger imports are wired
+# ---------------------------------------------------------------------------
+
+
+def test_claude_bridge_imports_stream_logger():
+    """Regression: claude_bridge.py must import stream_logger module."""
+    import inspect
+    from clauded import claude_bridge
+
+    src = inspect.getsource(claude_bridge)
+    assert "from . import stream_logger" in src or "import stream_logger" in src
+
+
+def test_http_retry_imports_stream_logger():
+    import inspect
+    from clauded import _http_retry
+
+    src = inspect.getsource(_http_retry)
+    assert "stream_logger" in src
+
+
+def test_bot_imports_stream_logger():
+    import inspect
+    from clauded import bot
+
+    src = inspect.getsource(bot)
+    assert "stream_logger" in src

--- a/tests/test_stream_logger.py
+++ b/tests/test_stream_logger.py
@@ -1,0 +1,183 @@
+"""#223 PR-A — stream_logger overhaul.
+
+Tests for the runtime-flippable enable, path migration, generalized
+log_event signature, and rotation behavior.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from clauded import stream_logger
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    stream_logger._reset_for_tests()
+    yield
+    stream_logger._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# is_enabled / set_enabled
+# ---------------------------------------------------------------------------
+
+
+def test_is_enabled_default_env_off(monkeypatch):
+    monkeypatch.delenv("CLAUDED_STREAM_DEBUG", raising=False)
+    assert stream_logger.is_enabled() is False
+
+
+def test_is_enabled_env_truthy(monkeypatch):
+    monkeypatch.setenv("CLAUDED_STREAM_DEBUG", "1")
+    assert stream_logger.is_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["true", "yes", "1"])
+def test_is_enabled_env_alternative_truthy(monkeypatch, val):
+    monkeypatch.setenv("CLAUDED_STREAM_DEBUG", val)
+    assert stream_logger.is_enabled() is True
+
+
+def test_set_enabled_true_wins_over_env_false(monkeypatch):
+    monkeypatch.delenv("CLAUDED_STREAM_DEBUG", raising=False)
+    stream_logger.set_enabled(True)
+    assert stream_logger.is_enabled() is True
+
+
+def test_set_enabled_false_wins_over_env_true(monkeypatch):
+    monkeypatch.setenv("CLAUDED_STREAM_DEBUG", "1")
+    stream_logger.set_enabled(False)
+    assert stream_logger.is_enabled() is False
+
+
+def test_set_enabled_none_reverts_to_env(monkeypatch):
+    monkeypatch.setenv("CLAUDED_STREAM_DEBUG", "1")
+    stream_logger.set_enabled(False)
+    assert stream_logger.is_enabled() is False
+    stream_logger.set_enabled(None)
+    assert stream_logger.is_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# Path migration
+# ---------------------------------------------------------------------------
+
+
+def test_log_path_under_library_logs():
+    """#223 D2: jsonl moved from logs/ (cwd) to ~/Library/Logs/clauded/."""
+    p = stream_logger._LOG_PATH
+    assert p.name == "stream-debug.jsonl"
+    assert "Library/Logs/clauded" in str(p) or p.parent.name == "clauded", (
+        f"#223 D2: stream-debug.jsonl should live under ~/Library/Logs/clauded; got {p}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# log_event — dict pass-through (new in #223)
+# ---------------------------------------------------------------------------
+
+
+def test_log_event_disabled_writes_nothing(tmp_path, monkeypatch):
+    """When is_enabled() is False, log_event is a no-op."""
+    monkeypatch.setattr(stream_logger, "_LOG_PATH", tmp_path / "x.jsonl")
+    monkeypatch.setattr(stream_logger, "_LOG_DIR", tmp_path)
+    stream_logger.set_enabled(False)
+    stream_logger.log_event({"type": "ControlPlane", "method": "get_context_usage"})
+    assert not (tmp_path / "x.jsonl").exists()
+
+
+def test_log_event_dict_payload_passes_through(tmp_path, monkeypatch):
+    """#223: log_event accepts plain dicts (post-#223 control-plane / retry / crash)."""
+    monkeypatch.setattr(stream_logger, "_LOG_PATH", tmp_path / "x.jsonl")
+    monkeypatch.setattr(stream_logger, "_LOG_DIR", tmp_path)
+    stream_logger.set_enabled(True)
+    stream_logger.log_event({
+        "type": "ControlPlane",
+        "method": "get_context_usage",
+        "result_pct": 47,
+    })
+    lines = (tmp_path / "x.jsonl").read_text().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["type"] == "ControlPlane"
+    assert entry["method"] == "get_context_usage"
+    assert entry["result_pct"] == 47
+    assert "ts" in entry
+    assert isinstance(entry["ts"], (int, float))
+
+
+def test_log_event_dict_with_extra_merge(tmp_path, monkeypatch):
+    """``extra`` kwarg merges over the base event dict."""
+    monkeypatch.setattr(stream_logger, "_LOG_PATH", tmp_path / "x.jsonl")
+    monkeypatch.setattr(stream_logger, "_LOG_DIR", tmp_path)
+    stream_logger.set_enabled(True)
+    stream_logger.log_event({"type": "Crash"}, extra={"thread_id": 42})
+    entry = json.loads((tmp_path / "x.jsonl").read_text().splitlines()[0])
+    assert entry["type"] == "Crash"
+    assert entry["thread_id"] == 42
+
+
+# ---------------------------------------------------------------------------
+# log_event — legacy SDK message types still work (regression)
+# ---------------------------------------------------------------------------
+
+
+def test_log_event_unknown_object_does_not_crash(tmp_path, monkeypatch):
+    """Legacy path: arbitrary object gets minimal envelope, no exception."""
+    monkeypatch.setattr(stream_logger, "_LOG_PATH", tmp_path / "x.jsonl")
+    monkeypatch.setattr(stream_logger, "_LOG_DIR", tmp_path)
+    stream_logger.set_enabled(True)
+
+    class Bogus:
+        pass
+
+    stream_logger.log_event(Bogus(), buffer_len=99)
+    entry = json.loads((tmp_path / "x.jsonl").read_text().splitlines()[0])
+    assert entry["type"] == "Bogus"
+    assert entry["buffer_len"] == 99
+
+
+# ---------------------------------------------------------------------------
+# Rotation
+# ---------------------------------------------------------------------------
+
+
+def test_rotation_triggers_at_max_bytes(tmp_path, monkeypatch):
+    """When file exceeds _MAX_BYTES, rotation moves it to .1 suffix."""
+    log_path = tmp_path / "x.jsonl"
+    log_path.write_text("x" * 100)  # pre-existing content
+    monkeypatch.setattr(stream_logger, "_LOG_PATH", log_path)
+    monkeypatch.setattr(stream_logger, "_LOG_DIR", tmp_path)
+    monkeypatch.setattr(stream_logger, "_MAX_BYTES", 10)  # force rotation
+    stream_logger.set_enabled(True)
+    stream_logger.log_event({"type": "test"})
+    # After rotation .1 should exist and main file should be small (only new line)
+    rotated = log_path.with_suffix(".jsonl.1")
+    assert rotated.exists(), (
+        f"#223 AC6: file > _MAX_BYTES should rotate to .1; "
+        f"contents of dir: {list(tmp_path.iterdir())}"
+    )
+    # New file contains only the post-rotation event
+    new_content = log_path.read_text()
+    assert "test" in new_content
+    assert len(new_content) < 200
+
+
+def test_no_rotation_below_max_bytes(tmp_path, monkeypatch):
+    """Under threshold, file just grows."""
+    log_path = tmp_path / "x.jsonl"
+    monkeypatch.setattr(stream_logger, "_LOG_PATH", log_path)
+    monkeypatch.setattr(stream_logger, "_LOG_DIR", tmp_path)
+    monkeypatch.setattr(stream_logger, "_MAX_BYTES", 10_000_000)
+    stream_logger.set_enabled(True)
+    stream_logger.log_event({"type": "a"})
+    stream_logger.log_event({"type": "b"})
+    rotated = log_path.with_suffix(".jsonl.1")
+    assert not rotated.exists()
+    lines = log_path.read_text().splitlines()
+    assert len(lines) == 2

--- a/tests/test_stream_logger.py
+++ b/tests/test_stream_logger.py
@@ -109,6 +109,8 @@ def test_log_event_dict_payload_passes_through(tmp_path, monkeypatch):
     assert entry["result_pct"] == 47
     assert "ts" in entry
     assert isinstance(entry["ts"], (int, float))
+    # #223 R1 architect: every event carries schema version v=1 for #224 epic.
+    assert entry["v"] == 1
 
 
 def test_log_event_dict_with_extra_merge(tmp_path, monkeypatch):
@@ -140,6 +142,8 @@ def test_log_event_unknown_object_does_not_crash(tmp_path, monkeypatch):
     entry = json.loads((tmp_path / "x.jsonl").read_text().splitlines()[0])
     assert entry["type"] == "Bogus"
     assert entry["buffer_len"] == 99
+    # #223 R1 architect: legacy path also stamps v=1
+    assert entry["v"] == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes part of #223 (P1; #224 epic blocker).

## Scope — PR-A of 2

This PR: **S1** (4 data blind points instrumented) + **S3** (stream_logger overhaul).
PR-B (S2: 6 exception swallow upgrades) is separate, finer-grain review.

PR-A is additive instrumentation (low risk). PR-B is exception-handling change (dedicated review).

## What landed

### S1 — instrumented blind spots

| # | Site | Before | After |
|---|---|---|---|
| 1 | `claude_bridge.get_context_usage` | silent (was #220 root cause's blind spot) | log.debug success / log.warning(exc_info) failure + ControlPlane stream event |
| 2 | `claude_bridge.get_server_info` | silent | symmetric |
| 3 | `_http_retry.safe_http` retry | stdlib log.warning only | + DiscordHTTPRetry stream event per attempt + giveup flag on exhaustion |
| 4 | `bot._render_with_retry` crash | log.exception only | + Crash stream event with `traceback.format_exc()` |

### S3 — stream_logger overhaul

- `set_enabled(True/False/None)` runtime override (None = revert to env)
- `log_event` accepts dict (new) + SDK message types (legacy regression-safe)
- Path: `logs/stream-debug.jsonl` (cwd) → `~/Library/Logs/clauded/stream-debug.jsonl`
- 10MB × 7 backup rotation
- File-write errors log instead of silent swallow

## Out of scope

- `/debug` cog implementation (separate issue)
- PR-B: 6 exception swallow upgrades
- #224 epic itself

## Tests

+28 (13 stream_logger + 12 instrumentation + 3 import sanity).

**823 / 0** (was 795).

## Status

🚧 Draft pending R1.
