### PR TITLE
fix(launchagent): remove ProcessType=Background (#232)

### DIFF
--- a/docs/prd/v1.15-launchagent.md
+++ b/docs/prd/v1.15-launchagent.md
@@ -321,3 +321,31 @@ Total ~560 LOC. Python only ~110; rest shell/XML/docs.
 | User has `.zshrc` setting PATH differently from plist | plist sets explicit `PATH=/opt/homebrew/bin:...` — same as `claude` resolves elsewhere in repo |
 | pmset wake-detection regex fragile across macOS versions | Heuristic only; on parse failure age=0 → check proceeds normally |
 | `launchctl bootstrap` denied (SIP/sandbox edge) | Install script `exit 1` on failure with error message |
+
+---
+
+## #232 follow-up (2026-05-18) — `ProcessType=Background` was wrong
+
+`ProcessType=Background` in the plist template above (line 55) told
+launchd that clauded is a low-priority occasional task. launchd's
+resource manager interpreted clauded's continuous WebSocket / SDK
+streaming activity as "inefficient" and SIGKILL'd the process every
+**15-25 minutes**, dropping all in-memory bridge state.
+
+Hard evidence:
+```
+$ log show --predicate 'process == "launchd" AND eventMessage CONTAINS "clauded"' --info --last 2h
+... Successfully spawned clauded[81495] because inefficient
+... Successfully spawned clauded[85519] because inefficient
+... Successfully spawned clauded[89842] because inefficient
+... Successfully spawned clauded[90348] because inefficient
+... Successfully spawned clauded[95102] because inefficient
+```
+
+User-visible symptom: long-turn sessions (sub-agent / refactor / > 5
+min) almost always lost context, since `save_session_state` only
+fires after a `ResultMessage` arrives.
+
+**Fix**: removed the `ProcessType` key entirely, falling back to the
+implicit `Standard` default (no launchd-side resource judgement).
+See PRD `docs/prd/v1.18-fix-launchagent-process-type.md`.

--- a/docs/prd/v1.18-fix-launchagent-process-type.md
+++ b/docs/prd/v1.18-fix-launchagent-process-type.md
@@ -1,0 +1,105 @@
+# PRD — Fix LaunchAgent ProcessType=Background (#232)
+
+**Status**: APPROVED ("开干，直接干" 5/18)
+**Issue**: [#232](https://github.com/HXYerror/issues/232)
+**Branch**: `fix/v1.18-launchagent-process-type`
+**Severity**: P0 (critical user-facing — every long turn lost context)
+
+## Problem
+
+User reported `2026-05-18 17:08 CST`: every 15-25 minutes the bot mid-turn
+suddenly "session 被重置"; new turn starts fresh with `resume=None`.
+
+Hard evidence from `log show --predicate 'process == "launchd" AND
+eventMessage CONTAINS "clauded"' --info --last 2h`:
+
+```
+15:55:33 service inactive; Successfully spawned clauded[81495] because inefficient
+16:15:43 service inactive; Successfully spawned clauded[85519] because inefficient
+16:38:29 service inactive; Successfully spawned clauded[89842] because inefficient
+16:46:08 service inactive; Successfully spawned clauded[90348] because inefficient
+17:04:59 service inactive; Successfully spawned clauded[95102] because inefficient
+```
+
+`because inefficient` is the launchd resource-manager kill reason for
+`ProcessType=Background` services that look CPU/IO-active too long.
+
+## Root cause
+
+`~/Library/LaunchAgents/com.hxy.clauded.plist` (+ `scripts/com.hxy.clauded.plist.template`):
+
+```xml
+<key>ProcessType</key><string>Background</string>
+```
+
+`Background` is for low-priority occasional tasks (backup, defrag).
+clauded is a long-running interactive service: continuous Discord gateway
+WebSocket + SDK long-poll + per-turn streaming + long Claude CLI child
+processes (≥ 30s, up to 15 min). This load pattern exactly trips the
+"inefficient" detection → SIGKILL every 15-25 min.
+
+Cascade: bot killed mid-turn → `save_session_state` only runs on
+`ResultMessage` arrival → `data/sessions.json` not written → next user
+message: bridge is None → `stored.session_id` None → fresh session.
+Long turns ≈ guaranteed context loss.
+
+## Decision (DDD 5/18)
+
+**Approach A** — delete `ProcessType` key entirely; fall back to default
+`Standard` (no launchd-side resource judgement).
+
+Rejected:
+- B (`Interactive`): would over-prioritize clauded on user's machine
+- C (`Adaptive`): not meaningfully different from Standard for this workload
+- D (`EnableTransactions=true`): would need ctypes binding to libxpc;
+  complexity + maintenance + platform-specific. Way out of proportion.
+
+## Goals
+
+1. Remove `<key>ProcessType</key><string>Background</string>` from:
+   - `scripts/com.hxy.clauded.plist.template` (repo source)
+   - `~/Library/LaunchAgents/com.hxy.clauded.plist` (installed instance)
+2. Leave a `<!-- #232 ... -->` comment in template explaining why the
+   key is absent (so a future "let's set ProcessType for hygiene"
+   refactor doesn't reintroduce the bug)
+3. Reload via `launchctl bootout / bootstrap` so the new plist is live
+4. Add follow-up note to `docs/prd/v1.15-launchagent.md`
+
+## Non-goals
+
+- Change `save_session_state` timing (separate issue / scope creep)
+- Detect "this restart was a launchd kill" at startup (#223 stretch goal)
+- Linux/systemd parity (macOS-only project)
+- Tune `KeepAlive` / `ThrottleInterval` (they're correct)
+
+## Acceptance
+
+Per #232 issue body §AC:
+
+- [x] AC1: `launchctl print` after reload shows no `process type` line
+      (key absent → implicit Standard)
+- [x] AC2: template synced
+- [x] AC3: PRD #139 note appended
+- [ ] AC4: bot runs ≥ 60 min, `log show ... clauded | grep "because inefficient"` empty
+      → **verified in next 60 min, not gated on merge**
+- [ ] AC5: 25-min sleep turn completes without bot restart
+      → **post-merge verification**
+- [ ] AC6: manual kickstart + resume from `data/sessions.json` works
+      → **standing test, already exercised every reload**
+
+## Tests
+
+`tests/test_launchagent_plist.py` (new): plist-shape pins so a future
+refactor can't silently reintroduce `ProcessType=Background`.
+
+## Plan
+
+Manager direct (1-line removal × 3 files; ops-level change, no logic).
+
+## Risks
+
+- Default `Standard` could theoretically raise priority above the user's
+  expectations. Practically zero — no `nice` / IO priority bump comes
+  from launchd defaults; Standard = "let the kernel scheduler decide".
+- Template / installed plist drift: a future install script run with
+  unchanged template would re-install correctly post-fix.

--- a/scripts/com.hxy.clauded.plist.template
+++ b/scripts/com.hxy.clauded.plist.template
@@ -16,11 +16,16 @@
     <key>RunAtLoad</key><true/>
     <key>KeepAlive</key><true/>
     <key>ThrottleInterval</key><integer>30</integer>
-    <key>ProcessType</key><string>Background</string>
     <key>StandardOutPath</key><string>{{HOME}}/Library/Logs/clauded/out.log</string>
     <!-- #168 dropped: ``StandardErrorPath`` previously pointed at err.log, which
          mirrored every Python log line (Python's stderr handler in bot.py +
          launchd's redirect both wrote the same content). RotatingFileHandler
          at ~/Library/Logs/clauded/clauded.log is now the canonical log. -->
+    <!-- #232 removed: ``ProcessType=Background`` told launchd this is a
+         low-priority occasional task, so it SIGKILL'd us every 15-25 min
+         with the "because inefficient" reason. clauded is a long-running
+         interactive service (Discord gateway + SDK long-poll). Falling
+         back to the implicit default (Standard) gives us no launchd-side
+         resource judgement. See docs/prd/v1.18-fix-launchagent-process-type.md. -->
 </dict>
 </plist>

--- a/tests/test_launchagent_plist.py
+++ b/tests/test_launchagent_plist.py
@@ -1,0 +1,61 @@
+"""#232 — pin LaunchAgent plist shape so ProcessType=Background can't return.
+
+This template is consumed by `scripts/install-launchagent.sh`. A future
+"clean up the plist" refactor that re-adds the wrong ProcessType would
+silently re-introduce the every-15-min SIGKILL bug class.
+"""
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+
+import pytest
+
+TEMPLATE = Path(__file__).parent.parent / "scripts" / "com.hxy.clauded.plist.template"
+
+
+def _render_template() -> dict:
+    """Substitute {{HOME}}/{{REPO}} and parse as plist."""
+    text = TEMPLATE.read_text()
+    text = text.replace("{{HOME}}", "/Users/test")
+    text = text.replace("{{REPO}}", "/repo")
+    return plistlib.loads(text.encode("utf-8"))
+
+
+def test_process_type_key_absent():
+    """#232: ProcessType key must NOT be set. Default (Standard) is correct."""
+    data = _render_template()
+    assert "ProcessType" not in data, (
+        f"#232: plist must NOT have ProcessType key (Standard default is "
+        f"correct for long-running interactive services). Found: "
+        f"{data.get('ProcessType')!r}"
+    )
+
+
+def test_keep_alive_and_throttle_preserved():
+    """Regression: removing ProcessType must not nuke KeepAlive / throttle."""
+    data = _render_template()
+    assert data.get("KeepAlive") is True
+    assert data.get("ThrottleInterval") == 30
+    assert data.get("RunAtLoad") is True
+
+
+def test_label_and_paths():
+    """Sanity: the essential identity stays."""
+    data = _render_template()
+    assert data["Label"] == "com.hxy.clauded"
+    assert "/repo/.venv/bin/clauded" in data["ProgramArguments"]
+    assert data["WorkingDirectory"] == "/repo"
+    assert "/Users/test/Library/Logs/clauded" in data["StandardOutPath"]
+
+
+def test_comment_explains_absence():
+    """Pin the #232 explainer comment so it's not stripped by accident."""
+    text = TEMPLATE.read_text()
+    assert "#232 removed" in text, (
+        "#232: the why-this-key-is-absent comment must stay; without it a "
+        "future plist-cleanup refactor would silently restore ProcessType."
+    )
+    assert "because inefficient" in text, (
+        "Pin the launchd reason string in the comment for future grep-back"
+    )


### PR DESCRIPTION
Closes #232 (P0 critical user-facing).

## Why

Every 15-25 min launchd SIGKILL'd the bot ("because inefficient") because `ProcessType=Background` told it this is a low-priority occasional task. Long turns ≈ guaranteed context loss.

## Fix (Approach A)

Remove the `ProcessType` key. plist falls back to default `Standard`, no launchd resource judgement.

3-line change:
- `scripts/com.hxy.clauded.plist.template` — key removed + #232 explainer comment
- `~/Library/LaunchAgents/com.hxy.clauded.plist` — same + live-reloaded via `launchctl bootout/bootstrap` (verified `launchctl print` post-reload)
- `docs/prd/v1.15-launchagent.md` — follow-up note

## Tests +4

`test_launchagent_plist.py` pins:
- ProcessType key absence
- KeepAlive / ThrottleInterval / RunAtLoad regression
- Identity (Label / paths)
- The #232 explainer comment can't be stripped

**838 / 0** (was 834, +4).

## Verification

Pre-merge: AC1-3 ✓ (key removed, reload, baseline shows Standard)
Post-merge: AC4-6 (60+ min clean launchd log; 25-min long turn; kickstart-resume) — standing observation, not merge-gated.
