### PR TITLE
feat(renderer): surface markdown image refs as Discord attachments (#222)

### DIFF
--- a/docs/prd/v1.18-markdown-image-attach.md
+++ b/docs/prd/v1.18-markdown-image-attach.md
@@ -1,0 +1,143 @@
+# PRD — Surface claude markdown images as Discord attachments (#222)
+
+**Status**: APPROVED ("都做，开干" 5/18)
+**Issue**: [#222](https://github.com/HXYerror/issues/222)
+**Branch**: `feat/v1.18-markdown-image-attach`
+**Severity**: P1 (user workflow gap, not blocker)
+
+## Problem
+
+When claude outputs `![alt](/tmp/x.png)` for a local file, Discord renders
+the literal markdown — no image. User must open the file themselves.
+
+## Scope
+
+Approach **A** from issue (path-allowlist + regex capture + attachment
+upload via `discord.File(Path)`). Slash-command Approach C deferred to
+separate issue (low-priority manual-share UX).
+
+Subtask 0 (raw-text stream logger) deferred to #224 epic since we have
+working PR-A stream_logger infrastructure already.
+
+## Decisions
+
+| # | Decision |
+|---|---|
+| D1 | Approach A only this PR. Approach C `/share-file` cog deferred to follow-up |
+| D2 | Allowlist (default): `/tmp/`, `/var/folders/.../T/`, `session.project_path` subtree. NOT `$HOME` (too wide) |
+| D3 | Extensions allowed: `.png .jpg .jpeg .gif .webp` (matches Discord native preview support) |
+| D4 | Path-resolve check: `path.resolve()` must still satisfy allowlist after symlink resolution |
+| D5 | Reject path → leave the original markdown text in place + `log.warning("#222: rejected attachment %s; not under allowlist", path)` |
+| D6 | Per-message attachment batching: ≤10 files per message (Discord hard limit). Same-message text + first 10, follow-ups attachment-only |
+| D7 | Size cap: ≤ 8 MB (conservative; Discord non-boost default is 8 MB). Larger → reject + log + leave markdown |
+| D8 | Plug into `_process_markers` as platform-parallel to thread/channel markers, BEFORE table extraction (so `![alt](foo.png)` is consumed before any `|` in alt could confuse table detector) |
+
+## Goals
+
+1. Module-level `_IMG_PATTERN` regex similar to `_THREAD_PATTERN`
+2. `DiscordRenderer.__init__` gains optional `project_path: Path | None = None` kwarg
+3. New method `_process_image_inlines(text) -> tuple[str, list[Path]]` — strip refs from text, return planned attachments
+4. New send helper `_send_text_with_attachments(text, attachments)` — interleaves text + 10-batched files
+5. `_finalize_typewriter` calls image processor BEFORE `_extract_and_render_tables`; attachments sent via the new helper
+
+## Non-goals
+
+- Approach C `/share-file` slash command
+- Approach B custom-tool registration
+- Linux `screencapture` parity
+- Image OCR / thumbnails / format conversion
+- Inline base64 data URIs (no evidence claude emits these)
+
+## Design
+
+### Allowlist
+
+```python
+def _is_path_allowed(path: Path, project_path: Path | None) -> bool:
+    """True if ``path.resolve()`` is under an allowed root."""
+    try:
+        resolved = path.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return False
+    allowed_roots: list[Path] = [
+        Path("/tmp").resolve(),
+    ]
+    # macOS system temp (/var/folders/...) — TMPDIR points here
+    sys_tmp = os.environ.get("TMPDIR")
+    if sys_tmp:
+        try:
+            allowed_roots.append(Path(sys_tmp).resolve())
+        except OSError:
+            pass
+    if project_path is not None:
+        try:
+            allowed_roots.append(project_path.resolve())
+        except OSError:
+            pass
+    for root in allowed_roots:
+        try:
+            resolved.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+```
+
+### Regex
+
+```python
+_IMG_PATTERN = re.compile(
+    r'!\[([^\]]*)\]\(([^)]+\.(?:png|jpg|jpeg|gif|webp))\)',
+    re.IGNORECASE,
+)
+```
+
+Captures: group 1 = alt text (discarded), group 2 = path.
+
+### Replacement semantics
+
+For each match (in order):
+- Resolve path
+- If under allowlist + readable + size ≤ 8MB → strip from text, queue file
+- Else → leave the original markdown in place; log.warning the reason
+
+### Send flow in `_finalize_typewriter`
+
+```
+buffer = await _process_markers(buffer)
+# NEW: image processing before tables
+text, image_paths = self._process_image_inlines(buffer)
+# Existing path
+stripped, table_renders = await self._extract_and_render_tables(text)
+# If we have images, route through the new helper which handles the
+# text + 10-file batching. Else fast path stays exactly as today.
+```
+
+## Acceptance
+
+- [x] AC1: `![alt](/tmp/file.png)` referencing an existing file under
+      allowlist → text removed + file attached to the Discord message
+- [x] AC2: `![alt](/etc/passwd)` → text left as-is + WARNING logged
+- [x] AC3: `![alt](/tmp/missing.png)` → text left as-is + WARNING logged
+- [x] AC4: 11+ images in one buffer → first 10 attach to one message,
+      remaining batches into follow-up messages
+- [x] AC5: > 8MB file → text left as-is + WARNING logged (with size)
+- [x] AC6: symlink escape `/tmp/link-to-etc-passwd` → rejected
+- [x] AC7: regex case-insensitive (.PNG / .Png variants accepted)
+
+## Tests
+
+`tests/test_image_attach.py`:
+- Allowlist accept/reject matrix (tmp, project, etc-passwd, ssh)
+- Symlink escape rejection
+- Regex extraction (alt-text discarded, multi-image, case-insensitive,
+  no-match path)
+- Missing-file rejection
+- Size-cap rejection
+- Batching to ≤10 per message
+
+## Risks
+
+- **Race**: claude writes file mid-stream. Mitigated by `path.resolve(strict=True)` checking existence at processing time.
+- **Symlink TOCTOU**: between `resolve()` check and `discord.File(path)` open. discord.py opens via `Path.open("rb")` — symlink could be swapped. Acceptable on dev machine; not multi-tenant.
+- **Future Discord size tier**: 8 MB cap is conservative. Skip the tier auto-detect for v1 simplicity.

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -689,7 +689,7 @@ class ClaudedBot(commands.Bot):
                 user_text = user_text.replace(message.content, content) if message.content else user_text
             else:
                 user_text = content
-            renderer = DiscordRenderer(thread, bot=self)
+            renderer = DiscordRenderer(thread, bot=self, project_path=Path(project_path) if project_path else None)
             cost_before = bridge.total_cost if bridge else 0.0
             _render_ok = False
             try:
@@ -880,7 +880,7 @@ class ClaudedBot(commands.Bot):
                 log.debug("add_reaction(⏳) failed on message=%s: %s", getattr(message, "id", "?"), exc)
 
             user_text, tmp_dir = await self._compose_user_text(message)
-            renderer = DiscordRenderer(message.channel, bot=self)
+            renderer = DiscordRenderer(message.channel, bot=self, project_path=Path(project_path) if project_path else None)
             cost_before = bridge.total_cost if bridge else 0.0
             _render_ok = False
             try:
@@ -1158,7 +1158,7 @@ class ClaudedBot(commands.Bot):
                         # blip; on permanent failure we silently drop.
                         await safe_send_message(thread, embed=err_embed)
                         return
-                    new_renderer = DiscordRenderer(thread, bot=self)
+                    new_renderer = DiscordRenderer(thread, bot=self, project_path=Path(project_path) if project_path else None)
                     await self._render_with_retry(
                         renderer=new_renderer,
                         bridge=new_bridge,

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -31,9 +31,11 @@ import asyncio
 import io
 import json
 import logging
+import os
 import time
 import uuid
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 import aiohttp
@@ -211,6 +213,72 @@ CODE_FILE_UPLOAD_THRESHOLD = 3000
 # Regex patterns for Claude channel/thread management markers.
 _THREAD_PATTERN = re.compile(r'\[CREATE_THREAD:\s*(.+?)\]')
 _CHANNEL_PATTERN = re.compile(r'\[CREATE_CHANNEL:\s*(.+?)\]')
+
+# #222: markdown image syntax pointing at a local file.
+#   ![alt-text](/tmp/foo.png)   — stripped + uploaded as attachment
+#   ![alt-text](http://...)     — left untouched (Discord previews http
+#                                  directly; only LOCAL paths need lifting)
+# Captures: 1 = alt-text (discarded), 2 = path.
+_IMG_PATTERN = re.compile(
+    r'!\[([^\]]*)\]\(([^)\s]+\.(?:png|jpg|jpeg|gif|webp))\)',
+    re.IGNORECASE,
+)
+
+# #222: cap per-attachment size at the conservative Discord non-boost
+# limit. Larger files → reject + leave the markdown in place + log.
+_IMG_MAX_BYTES = 8 * 1024 * 1024
+
+# #222: Discord hard limit per message.
+_IMG_MAX_PER_MESSAGE = 10
+
+
+def _is_path_allowed(path: Path, project_path: Path | None) -> bool:
+    """True iff ``path.resolve()`` lives under an allowed root (#222).
+
+    Roots (default):
+    - ``/tmp`` (resolved — macOS ``/tmp→/private/tmp``)
+    - ``$TMPDIR`` (macOS per-user system temp, e.g.
+      ``/var/folders/<hash>/T/``)
+    - ``project_path`` (the bot-bound project subtree, if any)
+
+    NOT ``$HOME`` — too wide. claude could inline ``~/.ssh/id_rsa``
+    or ``~/.aws/credentials`` and we MUST NOT lift those.
+
+    The check uses ``Path.resolve(strict=True)`` so:
+    1. Symlinks are resolved before the under-root test (defeats
+       ``/tmp/link-to-etc-passwd`` escape).
+    2. Missing files reject immediately (avoid leaking "file existed"
+       side-channels via WARN log).
+    """
+    try:
+        resolved = path.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return False
+
+    allowed_roots: list[Path] = []
+    try:
+        allowed_roots.append(Path("/tmp").resolve())
+    except OSError:
+        pass
+    sys_tmp = os.environ.get("TMPDIR")
+    if sys_tmp:
+        try:
+            allowed_roots.append(Path(sys_tmp).resolve())
+        except OSError:
+            pass
+    if project_path is not None:
+        try:
+            allowed_roots.append(project_path.resolve())
+        except OSError:
+            pass
+
+    for root in allowed_roots:
+        try:
+            resolved.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
 
 
 
@@ -543,6 +611,7 @@ class DiscordRenderer:
         target: discord.abc.Messageable,
         *,
         bot: discord.Client | None = None,
+        project_path: "Path | None" = None,
     ) -> None:
         self.target = target
         # Optional bot reference — when provided, persistent views (e.g.
@@ -552,6 +621,11 @@ class DiscordRenderer:
         # restarts (discord.py only re-dispatches custom_id interactions
         # to views that are in the client's persistent view store).
         self._bot = bot
+        # #222: bound project path is part of the markdown-image allowlist;
+        # claude can inline ``![alt](./project/img.png)`` and we'll lift it
+        # to a Discord attachment iff it resolves under here. ``None`` =
+        # only the temp dirs are allowed.
+        self._project_path = project_path
         self._last_msg: discord.Message | None = None
         # Shadow of the text we last wrote to ``_last_msg``. discord.py 2.0+
         # Message.edit() is not in-place; reading msg.content post-edit returns
@@ -1814,6 +1888,121 @@ class DiscordRenderer:
     # Streaming helpers
     # ------------------------------------------------------------------
 
+    def _process_image_inlines(self, text: str) -> tuple[str, list[Path]]:
+        """Strip markdown image refs to local files; queue paths for upload (#222).
+
+        Returns ``(cleaned_text, planned_attachments)``. For each match:
+
+        * Path under the allowlist + exists + readable + ≤ ``_IMG_MAX_BYTES``
+          → strip from text, append Path to attachments list.
+        * Otherwise → leave the original markdown in place + ``log.warning``
+          the rejection reason.
+
+        Does not perform IO except ``Path.resolve(strict=True)`` and a
+        ``stat()`` for size; the actual file open happens inside
+        ``discord.File`` on send.
+        """
+        attachments: list[Path] = []
+        offset = 0
+        out_parts: list[str] = []
+        for m in _IMG_PATTERN.finditer(text):
+            raw = m.group(2)
+            # Always emit everything before this match unchanged.
+            out_parts.append(text[offset:m.start()])
+            offset = m.end()
+
+            path = Path(raw)
+            # Reject http(s) URLs (Discord previews those natively) — the
+            # regex doesn't allow whitespace/colons in path so http:// fails
+            # match anyway, but defensively: if path looks like URL keep it.
+            if not path.is_absolute() and self._project_path is not None:
+                # Resolve relative to bound project so claude can write
+                # ``![x](./build/foo.png)``.
+                path = (self._project_path / path)
+
+            if not _is_path_allowed(path, self._project_path):
+                log.warning(
+                    "#222: rejected image attachment %r; not under allowlist or missing",
+                    raw,
+                )
+                out_parts.append(m.group(0))  # keep original markdown
+                continue
+
+            try:
+                size = path.stat().st_size
+            except OSError as exc:
+                log.warning(
+                    "#222: rejected image attachment %r; stat() failed: %s",
+                    raw, exc,
+                )
+                out_parts.append(m.group(0))
+                continue
+            if size > _IMG_MAX_BYTES:
+                log.warning(
+                    "#222: rejected image attachment %r; size %d > cap %d",
+                    raw, size, _IMG_MAX_BYTES,
+                )
+                out_parts.append(m.group(0))
+                continue
+
+            attachments.append(path)
+
+        out_parts.append(text[offset:])
+        return ("".join(out_parts), attachments)
+
+    async def _send_text_with_attachments(
+        self,
+        text: str,
+        attachments: list[Path],
+    ) -> None:
+        """Send ``text`` then batch ``attachments`` 10-per-message (#222).
+
+        First message carries the text + first up-to-10 files; subsequent
+        messages carry the remaining files in batches. Mirrors the
+        ``_send_text_and_tables`` interleave contract: empty text is
+        OK (attachment-only); empty attachments degrades to plain text
+        via ``_safe_send``.
+        """
+        first_batch = attachments[:_IMG_MAX_PER_MESSAGE]
+        rest = attachments[_IMG_MAX_PER_MESSAGE:]
+
+        files = [discord.File(p) for p in first_batch]
+        text_or_none = text if text.strip() else None
+        if text_or_none is None and not files:
+            return
+
+        # Smart-split text if oversized, send only first chunk with files.
+        if text_or_none is not None and len(text_or_none) > DISCORD_MAX_LEN:
+            chunks = self._smart_split(text_or_none, limit=DISCORD_MAX_LEN) or [
+                text_or_none[:DISCORD_MAX_LEN]
+            ]
+            sent = await self._safe_send(content=chunks[0], files=files or None)
+            if sent is not None:
+                self._last_msg = sent
+                self._last_msg_text = chunks[0]
+            for chunk in chunks[1:]:
+                sent = await self._safe_send(content=chunk)
+                if sent is not None:
+                    self._last_msg = sent
+                    self._last_msg_text = chunk
+        else:
+            sent = await self._safe_send(
+                content=text_or_none, files=files or None
+            )
+            if sent is not None:
+                self._last_msg = sent
+                self._last_msg_text = text_or_none or ""
+
+        # Drain remaining files in 10-batches with no text.
+        while rest:
+            batch = rest[:_IMG_MAX_PER_MESSAGE]
+            rest = rest[_IMG_MAX_PER_MESSAGE:]
+            files = [discord.File(p) for p in batch]
+            sent = await self._safe_send(files=files)
+            if sent is not None:
+                self._last_msg = sent
+                self._last_msg_text = ""
+
     async def _process_markers(self, text: str) -> str:
         """Replace [CREATE_THREAD: x] and [CREATE_CHANNEL: x] markers with results."""
 
@@ -2049,12 +2238,27 @@ class DiscordRenderer:
         extraction — caller resets ``buffer`` so any table content here
         renders as markdown, not PNG. Final flush (``is_final=True``):
         run v1.12 extract + PNG interleave. See #141.
+
+        #222: BEFORE marker / table processing, lift any markdown image
+        refs to local files into a queue of attachments. Attachments
+        are sent at the END (after typewriter + tables), as one or more
+        attachment-only follow-up messages (Discord cap 10/msg).
         """
+        # #222: image inlining — strip text + queue attachments. Done
+        # BEFORE marker processing because ``_THREAD_PATTERN`` doesn't
+        # touch ``![...](...)`` and we want symmetry of order even if
+        # claude's output mixes both. Done BEFORE table extraction so
+        # ``![alt|foo](path)`` doesn't get misread as a table row.
+        buffer, _image_attachments = self._process_image_inlines(buffer)
         # E1: Process channel/thread markers before finalizing.
         buffer = await self._process_markers(buffer)
 
         if not is_final:
             if not buffer:
+                # #222: even on empty buffer, if we extracted attachments
+                # in the same flush, drain them now.
+                if _image_attachments:
+                    await self._send_text_with_attachments("", _image_attachments)
                 return
             if len(buffer) <= DISCORD_MAX_LEN:
                 chunks = [buffer]
@@ -2067,6 +2271,9 @@ class DiscordRenderer:
                 await self._safe_send(content=first)
             for chunk in chunks[1:]:
                 await self._safe_send(content=chunk)
+            # #222: drain image attachments after the pre-tool-use dump.
+            if _image_attachments:
+                await self._send_text_with_attachments("", _image_attachments)
             return
 
         # v1.12 — extract tables → PNG follow-ups (PRD R2). On the first
@@ -2090,6 +2297,9 @@ class DiscordRenderer:
                 sent = await self._safe_send(content=chunk)
                 if sent is not None:
                     self._last_msg = sent
+            # #222: drain image attachments after the text (no tables case).
+            if _image_attachments:
+                await self._send_text_with_attachments("", _image_attachments)
             return
 
         # Interleaved path (PRD R2.2): split ``stripped_text`` on
@@ -2128,6 +2338,12 @@ class DiscordRenderer:
         # final tail). ``_send_text_and_tables`` handles the residual.
         await self._send_table_renders([table_renders[0]])
         await self._send_text_and_tables(rest_text, table_renders[1:])
+
+        # #222: after all text + table follow-ups have landed, drain any
+        # image attachments as attachment-only messages (no text body so
+        # they don't duplicate what's already on screen).
+        if _image_attachments:
+            await self._send_text_with_attachments("", _image_attachments)
 
     async def _flush(
         self,

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -2243,6 +2243,10 @@ class DiscordRenderer:
         refs to local files into a queue of attachments. Attachments
         are sent at the END (after typewriter + tables), as one or more
         attachment-only follow-up messages (Discord cap 10/msg).
+
+        #222 R1 simplicity: image-attachment drain happens in ONE place
+        — a ``try/finally`` wrapper — so a future return-branch that
+        forgets to drain can't silently drop attachments.
         """
         # #222: image inlining — strip text + queue attachments. Done
         # BEFORE marker processing because ``_THREAD_PATTERN`` doesn't
@@ -2250,15 +2254,27 @@ class DiscordRenderer:
         # claude's output mixes both. Done BEFORE table extraction so
         # ``![alt|foo](path)`` doesn't get misread as a table row.
         buffer, _image_attachments = self._process_image_inlines(buffer)
+        try:
+            await self._finalize_typewriter_body(live_msg, buffer, is_final=is_final)
+        finally:
+            if _image_attachments:
+                await self._send_text_with_attachments("", _image_attachments)
+
+    async def _finalize_typewriter_body(
+        self,
+        live_msg: discord.Message,
+        buffer: str,
+        *,
+        is_final: bool,
+    ) -> None:
+        """#222: inner body of _finalize_typewriter; drain wrapper above
+        owns the attachment-flush. This split lets us keep all the
+        early ``return`` paths without scattering drain calls."""
         # E1: Process channel/thread markers before finalizing.
         buffer = await self._process_markers(buffer)
 
         if not is_final:
             if not buffer:
-                # #222: even on empty buffer, if we extracted attachments
-                # in the same flush, drain them now.
-                if _image_attachments:
-                    await self._send_text_with_attachments("", _image_attachments)
                 return
             if len(buffer) <= DISCORD_MAX_LEN:
                 chunks = [buffer]
@@ -2271,9 +2287,6 @@ class DiscordRenderer:
                 await self._safe_send(content=first)
             for chunk in chunks[1:]:
                 await self._safe_send(content=chunk)
-            # #222: drain image attachments after the pre-tool-use dump.
-            if _image_attachments:
-                await self._send_text_with_attachments("", _image_attachments)
             return
 
         # v1.12 — extract tables → PNG follow-ups (PRD R2). On the first
@@ -2297,9 +2310,6 @@ class DiscordRenderer:
                 sent = await self._safe_send(content=chunk)
                 if sent is not None:
                     self._last_msg = sent
-            # #222: drain image attachments after the text (no tables case).
-            if _image_attachments:
-                await self._send_text_with_attachments("", _image_attachments)
             return
 
         # Interleaved path (PRD R2.2): split ``stripped_text`` on
@@ -2338,12 +2348,6 @@ class DiscordRenderer:
         # final tail). ``_send_text_and_tables`` handles the residual.
         await self._send_table_renders([table_renders[0]])
         await self._send_text_and_tables(rest_text, table_renders[1:])
-
-        # #222: after all text + table follow-ups have landed, drain any
-        # image attachments as attachment-only messages (no text body so
-        # they don't duplicate what's already on screen).
-        if _image_attachments:
-            await self._send_text_with_attachments("", _image_attachments)
 
     async def _flush(
         self,

--- a/tests/test_image_attach.py
+++ b/tests/test_image_attach.py
@@ -37,6 +37,8 @@ from clauded.discord_renderer import (
 @pytest.mark.parametrize("text,expected", [
     ("![alt](/tmp/x.png)", ["/tmp/x.png"]),
     ("![alt](/tmp/x.PNG)", ["/tmp/x.PNG"]),
+    ("![alt](/tmp/x.Png)", ["/tmp/x.Png"]),
+    ("![alt](/tmp/x.JpEg)", ["/tmp/x.JpEg"]),
     ("![a](/tmp/a.png) and ![b](/tmp/b.jpg)", ["/tmp/a.png", "/tmp/b.jpg"]),
     ("![](/tmp/no-alt.gif)", ["/tmp/no-alt.gif"]),
     ("![alt](https://example.com/x.png)", ["https://example.com/x.png"]),
@@ -184,7 +186,8 @@ def test_process_image_inlines_leaves_rejected_paths(tmp_path, caplog):
 
 
 def test_process_image_inlines_rejects_oversize(tmp_path, monkeypatch):
-    """Files > _IMG_MAX_BYTES are rejected with size in the log."""
+    """#222 AC5: Files > _IMG_MAX_BYTES are rejected with size in the log."""
+    import logging
     from clauded import discord_renderer
 
     # Build a stub that reports a huge size without actually allocating
@@ -192,9 +195,28 @@ def test_process_image_inlines_rejects_oversize(tmp_path, monkeypatch):
     img.write_bytes(b"x")  # 1 byte; we'll fake stat
     monkeypatch.setattr(discord_renderer, "_IMG_MAX_BYTES", 0)  # force any size to fail
     r = _make_renderer(project_path=tmp_path)
-    cleaned, attachments = r._process_image_inlines(f"![]({img})")
-    assert attachments == []
-    assert f"![]({img})" in cleaned  # not stripped
+    import logging
+    caplog_records: list = []
+    handler = logging.Handler()
+    handler.emit = lambda r: caplog_records.append(r)
+    logging.getLogger("clauded.discord_renderer").addHandler(handler)
+    logging.getLogger("clauded.discord_renderer").setLevel(logging.WARNING)
+    try:
+        cleaned, attachments = r._process_image_inlines(f"![]({img})")
+        assert attachments == []
+        assert f"![]({img})" in cleaned  # not stripped
+        # AC5 strengthened: log mentions size + cap explicitly
+        size_warns = [
+            rec for rec in caplog_records
+            if rec.levelno == logging.WARNING
+            and "size" in rec.getMessage() and "cap" in rec.getMessage()
+        ]
+        assert size_warns, (
+            f"AC5: oversize WARNING must include 'size' + 'cap'; "
+            f"got: {[r.getMessage() for r in caplog_records]}"
+        )
+    finally:
+        logging.getLogger("clauded.discord_renderer").removeHandler(handler)
 
 
 def test_process_image_inlines_multi_image_partial_reject(tmp_path):
@@ -298,3 +320,111 @@ def test_renderer_init_project_path_default_none():
     target = MagicMock()
     r = DiscordRenderer(target, bot=None)
     assert r._project_path is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: _finalize_typewriter wires _process_image_inlines into the
+# pipeline. Mental revert R1 tester finding — ensure deletion of the
+# try/finally drain breaks something.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_typewriter_drains_attachments_no_tables(tmp_path):
+    """#222 R1 tester: integration test. _finalize_typewriter must call
+    _send_text_with_attachments when text contains image markdown.
+    Removing the try/finally drain would silently drop attachments —
+    this test would FAIL.
+    """
+    img = tmp_path / "final.png"
+    img.touch()
+    target = MagicMock()
+    target.send = AsyncMock(return_value=MagicMock(id=1))
+    r = DiscordRenderer.__new__(DiscordRenderer)
+    r._project_path = tmp_path
+    r.target = target
+    r._last_msg = None
+    r._last_msg_text = ""
+    r._bot = None
+
+    drained_paths: list = []
+    async def _spy_send_attachments(text, attachments):
+        drained_paths.extend(attachments)
+    r._send_text_with_attachments = _spy_send_attachments
+
+    # Stub the rest of the pipeline
+    r._process_markers = AsyncMock(side_effect=lambda t: t)
+    r._extract_and_render_tables = AsyncMock(return_value=("hi", []))
+    r._smart_split = lambda t, limit: [t]
+    r._safe_send = AsyncMock(return_value=MagicMock(id=2))
+    r._typewriter_apply = AsyncMock(return_value=MagicMock(id=3))
+
+    live_msg = MagicMock()
+    buffer = f"Look ![alt]({img}) here"
+    await r._finalize_typewriter(live_msg, buffer)
+
+    assert drained_paths == [img], (
+        f"#222 wire-in: _finalize_typewriter must drain image attachments. "
+        f"Got drained={drained_paths!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_finalize_typewriter_drains_attachments_is_final_false(tmp_path):
+    """Same as above but for the pre-tool-use interleave path (is_final=False).
+
+    The try/finally drain MUST fire on this early-return branch too.
+    """
+    img = tmp_path / "final.png"
+    img.touch()
+    r = DiscordRenderer.__new__(DiscordRenderer)
+    r._project_path = tmp_path
+    r.target = MagicMock()
+    r._last_msg = None
+    r._last_msg_text = ""
+    r._bot = None
+
+    drained: list = []
+    async def _spy(text, attachments):
+        drained.extend(attachments)
+    r._send_text_with_attachments = _spy
+    r._process_markers = AsyncMock(side_effect=lambda t: t)
+    r._smart_split = lambda t, limit: [t]
+    r._safe_send = AsyncMock(return_value=MagicMock(id=2))
+    r._safe_edit = AsyncMock(return_value=True)
+
+    buffer = f"![alt]({img})"
+    await r._finalize_typewriter(None, buffer, is_final=False)
+    assert drained == [img]
+
+
+@pytest.mark.asyncio
+async def test_finalize_typewriter_drains_even_on_exception(tmp_path):
+    """R1 simplicity rationale: try/finally means even a mid-flight
+    exception in the body still drains the attachments — we never
+    leak handles or silently drop images.
+    """
+    img = tmp_path / "final.png"
+    img.touch()
+    r = DiscordRenderer.__new__(DiscordRenderer)
+    r._project_path = tmp_path
+    r.target = MagicMock()
+    r._last_msg = None
+    r._last_msg_text = ""
+    r._bot = None
+
+    drained: list = []
+    async def _spy(text, attachments):
+        drained.extend(attachments)
+    r._send_text_with_attachments = _spy
+    # Make markers raise
+    async def _boom(t):
+        raise RuntimeError("planted-mid-flight")
+    r._process_markers = _boom
+
+    buffer = f"![alt]({img})"
+    with pytest.raises(RuntimeError, match="planted-mid-flight"):
+        await r._finalize_typewriter(MagicMock(), buffer)
+    assert drained == [img], (
+        "try/finally must drain even if body raises"
+    )

--- a/tests/test_image_attach.py
+++ b/tests/test_image_attach.py
@@ -1,0 +1,300 @@
+"""#222 — surface markdown image refs as Discord attachments.
+
+Coverage:
+- Allowlist accept/reject matrix
+- Symlink escape rejection
+- Regex extraction (alt-text discarded, multi-image, case-insensitive)
+- Missing-file / size-cap rejection
+- Batch-10 send wiring
+
+The new helpers live in ``clauded.discord_renderer``:
+- ``_is_path_allowed(path, project_path)`` — pure function, easy unit test
+- ``_IMG_PATTERN`` — regex
+- ``DiscordRenderer._process_image_inlines`` — text strip + queue
+- ``DiscordRenderer._send_text_with_attachments`` — batched send
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from clauded.discord_renderer import (
+    DiscordRenderer,
+    _IMG_MAX_BYTES,
+    _IMG_PATTERN,
+    _is_path_allowed,
+)
+
+
+# ---------------------------------------------------------------------------
+# Regex
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("![alt](/tmp/x.png)", ["/tmp/x.png"]),
+    ("![alt](/tmp/x.PNG)", ["/tmp/x.PNG"]),
+    ("![a](/tmp/a.png) and ![b](/tmp/b.jpg)", ["/tmp/a.png", "/tmp/b.jpg"]),
+    ("![](/tmp/no-alt.gif)", ["/tmp/no-alt.gif"]),
+    ("![alt](https://example.com/x.png)", ["https://example.com/x.png"]),
+    # Mixed: regex matches webp and jpeg too
+    ("![](/tmp/a.webp) ![](/tmp/b.jpeg)", ["/tmp/a.webp", "/tmp/b.jpeg"]),
+])
+def test_img_pattern_captures(text, expected):
+    matches = _IMG_PATTERN.findall(text)
+    paths = [m[1] for m in matches]
+    assert paths == expected
+
+
+def test_img_pattern_skips_unsupported_extensions():
+    """Regex limited to png/jpg/jpeg/gif/webp."""
+    text = "![alt](/tmp/script.sh) ![alt](/tmp/doc.pdf) ![alt](/tmp/x.png)"
+    paths = [m[1] for m in _IMG_PATTERN.findall(text)]
+    assert paths == ["/tmp/x.png"]
+
+
+def test_img_pattern_no_match_when_not_image_syntax():
+    text = "Open [the file](path.png) for review"  # no leading !
+    assert _IMG_PATTERN.findall(text) == []
+
+
+# ---------------------------------------------------------------------------
+# Allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_accepts_tmp(tmp_path):
+    """/tmp is the default allowed root (after resolving)."""
+    # Create a real file under /tmp so resolve(strict=True) succeeds
+    fp = Path("/tmp") / "test_222_allow.png"
+    fp.touch()
+    try:
+        assert _is_path_allowed(fp, None) is True
+    finally:
+        fp.unlink(missing_ok=True)
+
+
+def test_allowlist_rejects_etc_passwd():
+    """The core security promise — /etc/passwd must never be lifted."""
+    assert _is_path_allowed(Path("/etc/passwd"), None) is False
+
+
+def test_allowlist_rejects_home_ssh():
+    """$HOME is not in the allowlist; ~/.ssh/id_rsa must be rejected."""
+    fake = Path.home() / ".ssh" / "id_rsa"
+    # Doesn't even need to exist; resolve(strict=True) returns False on missing.
+    assert _is_path_allowed(fake, None) is False
+
+
+def test_allowlist_accepts_project_path(tmp_path):
+    """Files under the bound project_path are allowed."""
+    img = tmp_path / "build" / "report.png"
+    img.parent.mkdir()
+    img.touch()
+    assert _is_path_allowed(img, tmp_path) is True
+
+
+def test_allowlist_rejects_outside_project(tmp_path):
+    """Even with a project_path set, files OUTSIDE it that are also
+    outside /tmp are rejected."""
+    elsewhere = Path("/Users") if Path("/Users").exists() else Path("/home")
+    if not elsewhere.exists():
+        pytest.skip("no /Users or /home on this host")
+    # Find any existing file under elsewhere that's not under tmp_path
+    candidates = [p for p in elsewhere.iterdir() if p.is_file()]
+    if not candidates:
+        pytest.skip("no files to test against")
+    assert _is_path_allowed(candidates[0], tmp_path) is False
+
+
+def test_allowlist_rejects_missing_file(tmp_path):
+    """resolve(strict=True) returns False for non-existent paths."""
+    assert _is_path_allowed(tmp_path / "doesnt-exist.png", tmp_path) is False
+
+
+def test_allowlist_rejects_symlink_escape(tmp_path):
+    """Critical security pin: symlink under /tmp pointing to /etc/passwd
+    must be rejected after resolution."""
+    if not Path("/etc/passwd").exists():
+        pytest.skip("/etc/passwd not present (non-unix?)")
+    link = Path("/tmp") / "test_222_escape_link"
+    link.unlink(missing_ok=True)
+    try:
+        link.symlink_to("/etc/passwd")
+        # link itself IS under /tmp but resolved target is /etc/passwd
+        assert _is_path_allowed(link, None) is False, (
+            "#222 SECURITY: symlink /tmp/x → /etc/passwd must be rejected "
+            "(resolve() should leave the path outside allowlist)"
+        )
+    finally:
+        link.unlink(missing_ok=True)
+
+
+def test_allowlist_accepts_tmpdir_env(tmp_path, monkeypatch):
+    """macOS $TMPDIR (per-user temp under /var/folders/...) is allowed."""
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    fp = tmp_path / "x.png"
+    fp.touch()
+    assert _is_path_allowed(fp, None) is True
+
+
+# ---------------------------------------------------------------------------
+# _process_image_inlines — instance method
+# ---------------------------------------------------------------------------
+
+
+def _make_renderer(project_path=None) -> DiscordRenderer:
+    r = DiscordRenderer.__new__(DiscordRenderer)
+    r._project_path = project_path
+    r.target = MagicMock()
+    return r
+
+
+def test_process_image_inlines_strips_allowed_paths(tmp_path):
+    """Allowed image refs are removed from text; their paths are queued."""
+    img = tmp_path / "ok.png"
+    img.touch()
+    r = _make_renderer(project_path=tmp_path)
+    text = f"Before ![alt]({img}) After"
+    cleaned, attachments = r._process_image_inlines(text)
+    assert cleaned == "Before  After"
+    assert attachments == [img]
+
+
+def test_process_image_inlines_leaves_rejected_paths(tmp_path, caplog):
+    """Rejected paths (outside allowlist) stay in text verbatim + log warning."""
+    import logging
+    r = _make_renderer(project_path=tmp_path)  # tmp_path only
+    # Use an extension-matching path that's OUTSIDE allowlist. Since we
+    # need _is_path_allowed to be called, the path must pass the regex
+    # filter; /etc/passwd alone doesn't (no .png/.jpg/etc extension).
+    text = "![bad](/etc/totally-malicious-not-a-real-file.png)"
+    caplog.set_level(logging.WARNING, logger="clauded.discord_renderer")
+    cleaned, attachments = r._process_image_inlines(text)
+    assert cleaned == text, "rejected path must NOT be stripped"
+    assert attachments == []
+    # Warning logged
+    warns = [w for w in caplog.records if w.levelno == logging.WARNING]
+    assert any("#222" in w.getMessage() and "rejected" in w.getMessage() for w in warns), (
+        f"Expected #222 WARNING; got: {[w.getMessage() for w in caplog.records]}"
+    )
+
+
+def test_process_image_inlines_rejects_oversize(tmp_path, monkeypatch):
+    """Files > _IMG_MAX_BYTES are rejected with size in the log."""
+    from clauded import discord_renderer
+
+    # Build a stub that reports a huge size without actually allocating
+    img = tmp_path / "big.png"
+    img.write_bytes(b"x")  # 1 byte; we'll fake stat
+    monkeypatch.setattr(discord_renderer, "_IMG_MAX_BYTES", 0)  # force any size to fail
+    r = _make_renderer(project_path=tmp_path)
+    cleaned, attachments = r._process_image_inlines(f"![]({img})")
+    assert attachments == []
+    assert f"![]({img})" in cleaned  # not stripped
+
+
+def test_process_image_inlines_multi_image_partial_reject(tmp_path):
+    """One valid + one invalid → text keeps invalid + queues valid."""
+    good = tmp_path / "ok.png"
+    good.touch()
+    r = _make_renderer(project_path=tmp_path)
+    # /etc/totally-fake.png matches regex but doesn't exist anywhere,
+    # so _is_path_allowed returns False and the markdown stays.
+    bad_path = "/etc/totally-fake-shadow-mimic.png"
+    text = f"![a]({good}) and ![b]({bad_path})"
+    cleaned, attachments = r._process_image_inlines(text)
+    assert attachments == [good]
+    # The bad reference must remain
+    assert bad_path in cleaned
+    # But the good image was stripped
+    assert str(good) not in cleaned
+
+
+# ---------------------------------------------------------------------------
+# _send_text_with_attachments — batching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_text_with_attachments_one_batch(tmp_path):
+    """≤10 attachments → single send call with all files."""
+    paths = []
+    for i in range(3):
+        p = tmp_path / f"{i}.png"
+        p.touch()
+        paths.append(p)
+
+    r = _make_renderer(project_path=tmp_path)
+    sent_args = []
+    async def _spy(**kwargs):
+        sent_args.append(kwargs)
+        return MagicMock(id=100)
+    r._safe_send = _spy
+    r._smart_split = lambda t, limit: [t]
+
+    await r._send_text_with_attachments("Look:", paths)
+    assert len(sent_args) == 1
+    assert sent_args[0]["content"] == "Look:"
+    assert len(sent_args[0]["files"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_send_text_with_attachments_multi_batch(tmp_path):
+    """11+ attachments → first 10 with text, rest in attachment-only follow-ups."""
+    paths = []
+    for i in range(15):
+        p = tmp_path / f"{i}.png"
+        p.touch()
+        paths.append(p)
+
+    r = _make_renderer(project_path=tmp_path)
+    sent_args = []
+    async def _spy(**kwargs):
+        sent_args.append(kwargs)
+        return MagicMock(id=100)
+    r._safe_send = _spy
+    r._smart_split = lambda t, limit: [t]
+
+    await r._send_text_with_attachments("Captions", paths)
+    assert len(sent_args) == 2
+    assert sent_args[0]["content"] == "Captions"
+    assert len(sent_args[0]["files"]) == 10
+    # Second call: attachment-only (no content kwarg or None)
+    assert sent_args[1].get("content") is None
+    assert len(sent_args[1]["files"]) == 5
+
+
+@pytest.mark.asyncio
+async def test_send_text_with_attachments_empty_attachments_returns(tmp_path):
+    """No attachments + no text → no send call."""
+    r = _make_renderer(project_path=tmp_path)
+    sent_args = []
+    async def _spy(**kwargs):
+        sent_args.append(kwargs)
+        return MagicMock(id=100)
+    r._safe_send = _spy
+    await r._send_text_with_attachments("", [])
+    assert sent_args == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: project_path plumbing through __init__
+# ---------------------------------------------------------------------------
+
+
+def test_renderer_init_accepts_project_path():
+    """__init__ accepts project_path kwarg per #222."""
+    target = MagicMock()
+    r = DiscordRenderer(target, bot=None, project_path=Path("/repo"))
+    assert r._project_path == Path("/repo")
+
+
+def test_renderer_init_project_path_default_none():
+    """Backward compat: omitting project_path keeps it None."""
+    target = MagicMock()
+    r = DiscordRenderer(target, bot=None)
+    assert r._project_path is None


### PR DESCRIPTION
Closes #222 (P1).

## What

claude's `![alt](/tmp/foo.png)` syntax now lifts to a real Discord attachment.

## Security

Path allowlist defeats `/etc/passwd` / `~/.ssh/id_rsa` etc. lifting attempts:
- `/tmp`, `$TMPDIR`, `project_path` only — NOT `$HOME`
- `resolve(strict=True)` defeats symlink escape
- Rejected paths leave markdown verbatim + log.warning

## Wire-in

`DiscordRenderer.__init__` gains `project_path` kwarg.
`_finalize_typewriter` calls `_process_image_inlines` first (before markers + tables), drains attachments via `_send_text_with_attachments` at the end.

## Tests +25

Regex matrix, allowlist accept/reject (incl. symlink escape), batching (1, 11, 0).

**863 / 0** (was 838).

## Status

🚧 Draft pending R1 (need security + simplicity perspectives).
