### PR TITLE
fix(table-png): CJK font tofu via PUA-reference glyph probe (#219)

### DIFF
--- a/docs/prd/v1.18-cjk-font-tofu.md
+++ b/docs/prd/v1.18-cjk-font-tofu.md
@@ -1,0 +1,83 @@
+# PRD — CJK font tofu via glyph-coverage probe (#219)
+
+**Status**: APPROVED ("都做" 5/18, Approach B + C combined)
+**Issue**: #219
+**Branch**: `fix/v1.18-cjk-font-tofu`
+**Severity**: P1 (Chinese tables unreadable on second macOS)
+
+## Problem
+
+Same `main` branch, two macOS machines:
+- Machine A (PM's): PNG table renders Chinese correctly via PingFang
+- Machine B (user-reported): same code → English correct, Chinese all tofu (□)
+
+Root cause hypothesis (from issue audit): on Machine B, `_load_font` is
+silently falling through to Menlo. Menlo loads without exception but
+its cmap has no CJK glyphs → Pillow renders `.notdef` (hollow rectangle)
+for every Chinese codepoint.
+
+## Decisions
+
+| # | Decision |
+|---|---|
+| D1 | Approach B (glyph probe) + Approach C (broader candidates) combined |
+| D2 | Probe character: `中` (high-frequency CJK in both simp + trad) |
+| D3 | Probe technique: compare `中` mask to `U+E000` (PUA — guaranteed missing) mask. If identical → tofu. |
+| D4 | broaden `except (OSError, IOError)` → `except Exception` (per issue §(b)) |
+| D5 | Linux candidates added (Noto Sans CJK / WQY) for future-proofing |
+| D6 | macOS legacy candidates added (STHeiti / Hiragino) for non-standard installs |
+| D7 | ASCII-fallback memorialized: if all CJK fonts fail probe, use FIRST loaded ASCII font (better English than load_default everything) |
+
+## Goals
+
+1. `_font_has_cjk(font) -> bool` — Pillow probe that detects tofu rendering
+2. `_load_font(size)` iterates with probe; rejects tofu producers
+3. `FONT_CANDIDATES` grows from 3 to 11 (CJK first, ASCII last)
+4. Tests pin: probe correctness, fallback chain, broaden-except behavior
+
+## Non-goals
+
+- Approach D (bundle Noto into wheel) — defer, +10MB wheel size
+- Remote diagnostic — Approach B is robust enough that we don't need it
+- Font selection at runtime via env var — overkill
+
+## Design (key snippet)
+
+```python
+def _font_has_cjk(font):
+    try: cjk_mask = font.getmask("中")
+    except Exception: return False
+    if cjk_mask is None or cjk_mask.size == (0,0):
+        return False
+    try: tofu_mask = font.getmask("\uE000")
+    except Exception: return False
+    if cjk_mask.size != tofu_mask.size: return True
+    return bytes(cjk_mask) != bytes(tofu_mask)
+```
+
+PUA reference is the key insight: `U+E000` MUST be undefined (private-
+use spec); its mask IS the tofu placeholder. Compare against it.
+
+## Acceptance
+
+- [x] AC1: PingFang on happy mac → probe returns True
+- [x] AC2: Menlo on happy mac → probe returns False (was True under naive impl)
+- [x] AC3: `_load_font` with candidates `[Menlo, PingFang]` → returns PingFang
+- [x] AC4: `_load_font` with candidates `[Menlo]` only → returns Menlo (ASCII fallback, not default)
+- [x] AC5: `_load_font` with all-bad candidates → `ImageFont.load_default()`
+- [x] AC6: `IndexError` / `ValueError` from `truetype()` no longer crashes
+- [x] AC7: candidate list order: CJK before ASCII
+
+## Tests +13
+
+`tests/test_cjk_font_tofu.py` covers probe (5), fallback chain (5),
+broaden-except (1), candidate list shape (2).
+
+## Plan
+
+Manager-direct (1 module, contained, no security surface).
+
+## Risks
+
+- Pillow API drift: `getmask()` signature is stable since 9.x; we handle exceptions defensively.
+- `_PUA_TOFU_REFERENCE = U+E000` collision: if a future font defines a glyph at U+E000, the probe could false-reject CJK fonts. Extremely unlikely (PUA is by convention for app-internal use), but we have multiple fallbacks if it happens.

--- a/src/clauded/table_png.py
+++ b/src/clauded/table_png.py
@@ -113,23 +113,116 @@ def _replace_known_emoji(text: str) -> str:
 # --- Font resolution -----------------------------------------------------
 
 # Module-level so tests can monkeypatch the candidate list.
-# PingFang first: it has good Latin coverage AND CJK glyphs, so it works as
-# the primary font on the happy path while preventing tofu boxes for Chinese
-# text (PRD R4.2 — review I6).
+#
+# #219: priority order = CJK-capable first, then ASCII-only fallbacks.
+# A `_load_font` `getmask('中')` probe rejects fonts that LOAD but lack
+# CJK glyphs (the original Menlo-tofu bug — fontconfig says "yes I'll
+# load Menlo" then renders Chinese as empty boxes).
+#
+# CJK fonts up top so a happy mac still resolves to PingFang in one step.
+# Linux candidates kept for future docker / linux deployment (the project
+# is mac-only today, but future-proofing is free here).
 FONT_CANDIDATES = (
-    "/System/Library/Fonts/PingFang.ttc",                      # CJK first (PRD R4.2)
-    "/System/Library/Fonts/Menlo.ttc",                         # mono fallback
-    "/System/Library/Fonts/Supplemental/Arial Unicode.ttf",    # broad fallback
+    # macOS CJK
+    "/System/Library/Fonts/PingFang.ttc",                            # primary (PRD #112 R4.2)
+    "/System/Library/Fonts/STHeiti Light.ttc",                       # macOS legacy CJK
+    "/System/Library/Fonts/STHeiti Medium.ttc",
+    "/System/Library/Fonts/Hiragino Sans GB.ttc",                    # macOS GB CJK
+    "/System/Library/Fonts/Supplemental/Arial Unicode.ttf",          # broad coverage
+    # Linux CJK (docker / future deploys)
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/opentype/noto/NotoSansCJK.ttc",
+    "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc",
+    "/usr/share/fonts/truetype/wqy/wqy-microhei.ttc",
+    "/usr/share/fonts/google-noto-cjk/NotoSansCJK-Regular.ttc",
+    # ASCII-only fallback (no CJK — only chosen if probe rejects all CJK options)
+    "/System/Library/Fonts/Menlo.ttc",
 )
+
+# #219: a glyph the CJK probe must successfully draw. ``中`` is high-
+# frequency in both simplified + traditional; if a font produces an empty
+# mask for this code point we treat the font as CJK-unsupported and
+# advance to the next candidate.
+_CJK_PROBE_CHAR = "中"
+
+# #219: Pillow's getmask() for a missing glyph returns the font's
+# ".notdef" tofu box — a non-empty rectangle. To distinguish "font has
+# this glyph" from "font is rendering the tofu placeholder" we compare
+# the probe's mask to a Unicode private-use codepoint that NO font has
+# (by spec). Identical masks → both are tofu → font has no CJK.
+_PUA_TOFU_REFERENCE = "\uE000"
+
+
+def _font_has_cjk(font: ImageFont.FreeTypeFont) -> bool:
+    """True iff ``font`` actually rasterizes a real (non-tofu) glyph for ``中``.
+
+    The naive ``getmask().size > 0`` test fails because Menlo (#219 root
+    cause) loads cleanly AND returns a non-empty hollow-rectangle mask
+    for CJK code points — the ".notdef" placeholder. To discriminate, we
+    compare ``中`` 's mask to the mask of ``U+E000`` (Unicode private-
+    use area). No font defines a glyph at U+E000, so its mask IS the
+    tofu placeholder. If the two masks match exactly → 中 is also tofu
+    → reject the font.
+
+    A CJK-capable font produces a distinct, larger, ink-rich mask for
+    中 than for U+E000 (typically the U+E000 mask is also 0-sized).
+    """
+    try:
+        cjk_mask = font.getmask(_CJK_PROBE_CHAR)
+    except Exception:
+        return False
+    if cjk_mask is None or cjk_mask.size == (0, 0):
+        # Glyph missing outright — also tofu (and rarer than ".notdef").
+        return False
+    try:
+        tofu_mask = font.getmask(_PUA_TOFU_REFERENCE)
+    except Exception:
+        # Can't get the reference; conservatively say no.
+        return False
+    # If size or pixel data match, CJK is rendering as tofu.
+    if cjk_mask.size != tofu_mask.size:
+        return True
+    try:
+        return bytes(cjk_mask) != bytes(tofu_mask)
+    except Exception:
+        return cjk_mask.size != tofu_mask.size
 
 
 def _load_font(size: int):
-    """Try each candidate path; fall back to ``load_default`` (never crashes)."""
+    """Try each candidate path; fall back to ``load_default`` (never crashes).
+
+    #219: a font that LOADS without exception is not enough — the original
+    Menlo bug had ``ImageFont.truetype(menlo)`` succeed cleanly but render
+    Chinese as empty boxes (Menlo has no CJK in cmap). We now require the
+    font to ACTUALLY rasterize the CJK probe glyph before accepting it.
+
+    Fallback chain:
+    - For each candidate path, try to load it. Exceptions → next.
+    - If loaded font has CJK coverage → return it.
+    - If loaded font has NO CJK coverage → remember it as "ASCII fallback"
+      and keep looking for a CJK-capable font.
+    - If no CJK font found, fall back to the last successfully-loaded
+      ASCII-only font (so we still render English correctly).
+    - Final fallback: ``ImageFont.load_default()``.
+    """
+    ascii_fallback = None
     for path in FONT_CANDIDATES:
         try:
-            return ImageFont.truetype(path, size)
-        except (OSError, IOError):
+            f = ImageFont.truetype(path, size)
+        except Exception:
+            # #219: broaden except. Some Pillow versions raise non-OSError
+            # types (IndexError on bad ttc face, ValueError on cmap parse,
+            # etc.) and we want to advance rather than crash the renderer.
             continue
+        if _font_has_cjk(f):
+            return f
+        # Remember the FIRST successfully-loaded ASCII-only font as the
+        # last-resort fallback. Later iterations don't overwrite this so
+        # we don't "upgrade" from Menlo to some random ASCII path.
+        if ascii_fallback is None:
+            ascii_fallback = f
+    if ascii_fallback is not None:
+        return ascii_fallback
     return ImageFont.load_default()
 
 

--- a/tests/test_cjk_font_tofu.py
+++ b/tests/test_cjk_font_tofu.py
@@ -1,0 +1,217 @@
+"""#219 — CJK font tofu fix via glyph-coverage probe.
+
+Tests:
+- `_font_has_cjk` returns True for real PingFang, False for Menlo
+- `_load_font` skips ASCII-only fonts when a CJK font is available
+- `_load_font` falls back to ASCII-only when no CJK font available
+- `_load_font` falls back to `load_default` when all paths fail
+- broaden-except: non-OSError exceptions during truetype() don't crash
+- FONT_CANDIDATES order: CJK first, ASCII (Menlo) last
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from clauded.table_png import (
+    FONT_CANDIDATES,
+    _CJK_PROBE_CHAR,
+    _font_has_cjk,
+    _load_font,
+)
+
+
+# ---------------------------------------------------------------------------
+# Probe semantics
+# ---------------------------------------------------------------------------
+
+
+def test_cjk_probe_char_is_zhong():
+    """Anchor the probe character. Changing this changes the CJK contract."""
+    assert _CJK_PROBE_CHAR == "中"
+
+
+def test_font_has_cjk_true_for_real_cjk_font():
+    """A font that CAN render Chinese returns True from the probe."""
+    pingfang = Path("/System/Library/Fonts/PingFang.ttc")
+    if not pingfang.exists():
+        pytest.skip("PingFang not present on this host")
+    from PIL import ImageFont
+    f = ImageFont.truetype(str(pingfang), 14)
+    assert _font_has_cjk(f) is True
+
+
+def test_font_has_cjk_false_for_ascii_only_font():
+    """The whole point: Menlo loads cleanly but has no CJK glyphs.
+
+    This is the #219 root cause — the original code returned Menlo
+    and silently produced tofu. The new probe must reject it.
+    """
+    menlo = Path("/System/Library/Fonts/Menlo.ttc")
+    if not menlo.exists():
+        pytest.skip("Menlo not present on this host")
+    from PIL import ImageFont
+    f = ImageFont.truetype(str(menlo), 14)
+    assert _font_has_cjk(f) is False, (
+        "#219: Menlo loads but has no CJK in its cmap; the probe MUST "
+        "return False so _load_font falls through to a CJK-capable font"
+    )
+
+
+def test_font_has_cjk_handles_exceptions():
+    """If the probe machinery itself raises, fail gracefully (return False)."""
+    f = MagicMock()
+    f.getmask = MagicMock(side_effect=RuntimeError("planted-probe-fail"))
+    assert _font_has_cjk(f) is False
+
+
+def test_font_has_cjk_handles_none_mask():
+    """Some Pillow versions can return None for missing glyphs."""
+    f = MagicMock()
+    f.getmask = MagicMock(return_value=None)
+    assert _font_has_cjk(f) is False
+
+
+# ---------------------------------------------------------------------------
+# _load_font fallback chain
+# ---------------------------------------------------------------------------
+
+
+def test_load_font_returns_pingfang_on_happy_mac():
+    """Sanity: on a mac with PingFang installed, _load_font returns PingFang
+    (not Menlo, not Arial Unicode)."""
+    if not Path("/System/Library/Fonts/PingFang.ttc").exists():
+        pytest.skip("PingFang not present")
+    f = _load_font(14)
+    name, _style = f.getname()
+    assert "PingFang" in name, (
+        f"#219: happy mac must resolve to PingFang first, got {name!r}"
+    )
+
+
+def test_load_font_skips_ascii_only_when_cjk_available(monkeypatch):
+    """If candidates list = [Menlo, PingFang], we should still pick PingFang.
+
+    Verifies the probe rejects Menlo even though it loaded successfully.
+    """
+    menlo = "/System/Library/Fonts/Menlo.ttc"
+    pingfang = "/System/Library/Fonts/PingFang.ttc"
+    if not (Path(menlo).exists() and Path(pingfang).exists()):
+        pytest.skip("Required fonts missing")
+
+    from clauded import table_png
+    monkeypatch.setattr(table_png, "FONT_CANDIDATES", (menlo, pingfang))
+    f = _load_font(14)
+    name, _ = f.getname()
+    assert "PingFang" in name, (
+        f"#219: when Menlo loads but lacks CJK, _load_font must keep "
+        f"looking and find PingFang. Got: {name!r}"
+    )
+
+
+def test_load_font_falls_back_to_ascii_when_no_cjk(monkeypatch):
+    """All candidates lack CJK → return the first-loaded ASCII font.
+
+    Better to render English correctly than to load_default() everything.
+    """
+    menlo = "/System/Library/Fonts/Menlo.ttc"
+    if not Path(menlo).exists():
+        pytest.skip("Menlo not present")
+
+    from clauded import table_png
+    # No CJK-capable font in the list
+    monkeypatch.setattr(table_png, "FONT_CANDIDATES", (menlo,))
+    f = _load_font(14)
+    name, _ = f.getname()
+    assert "Menlo" in name or "menlo" in name.lower(), (
+        f"#219: with no CJK font available, fall back to first-loaded "
+        f"ASCII font (Menlo). Got: {name!r}"
+    )
+
+
+def test_load_font_falls_back_to_default_when_all_fail(monkeypatch):
+    """No font path can be loaded → ImageFont.load_default()."""
+    from clauded import table_png
+    monkeypatch.setattr(
+        table_png,
+        "FONT_CANDIDATES",
+        ("/nonexistent/1.ttf", "/nonexistent/2.ttf"),
+    )
+    f = _load_font(14)
+    # load_default() returns a Pillow internal font; just confirm it exists
+    assert f is not None
+
+
+def test_load_font_broadens_except_to_all_exceptions(monkeypatch):
+    """#219: Pillow can raise IndexError / ValueError on bad ttc faces;
+    the old `except (OSError, IOError)` missed those. The new `except
+    Exception` advances to the next candidate."""
+    from PIL import ImageFont
+    from clauded import table_png
+
+    real_truetype = ImageFont.truetype
+    call_count = {"n": 0}
+    def _flaky_truetype(path, *args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise IndexError("planted-ttc-face-index-out-of-range")
+        if call_count["n"] == 2:
+            raise ValueError("planted-cmap-parse-fail")
+        # Third call succeeds with a real font (via the real Pillow API)
+        return real_truetype("/System/Library/Fonts/PingFang.ttc", *args, **kwargs)
+
+    monkeypatch.setattr(table_png, "FONT_CANDIDATES", ("/a", "/b", "/c"))
+    monkeypatch.setattr(ImageFont, "truetype", _flaky_truetype)
+    f = _load_font(14)
+    assert call_count["n"] == 3, (
+        f"#219: non-OSError exceptions must NOT crash _load_font; "
+        f"expected 3 attempts, got {call_count['n']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Candidate list shape
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_list_cjk_before_ascii():
+    """Order matters: CJK-capable paths must come before Menlo so the
+    probe can short-circuit on a happy mac."""
+    pingfang_idx = next(
+        (i for i, p in enumerate(FONT_CANDIDATES) if "PingFang" in p), None
+    )
+    menlo_idx = next(
+        (i for i, p in enumerate(FONT_CANDIDATES) if "Menlo" in p), None
+    )
+    assert pingfang_idx is not None and menlo_idx is not None
+    assert pingfang_idx < menlo_idx, (
+        f"#219: PingFang (idx {pingfang_idx}) must come before Menlo "
+        f"(idx {menlo_idx}) so the probe finds CJK before ASCII-only"
+    )
+
+
+def test_candidate_list_has_linux_fallbacks():
+    """Future-proofing: docker / linux deploys need Noto / WQY."""
+    paths = " ".join(FONT_CANDIDATES)
+    assert "NotoSansCJK" in paths or "noto" in paths.lower(), (
+        "#219: Linux CJK fallbacks (Noto Sans CJK) must be in the list"
+    )
+    assert "wqy" in paths.lower(), (
+        "#219: WenQuanYi CJK fallback should be in the list"
+    )
+
+
+def test_candidate_list_has_macos_legacy_cjk():
+    """Old macOS / minimal installs: STHeiti / Hiragino as additional macs."""
+    paths = " ".join(FONT_CANDIDATES)
+    # At least one of these should be there
+    has_legacy = any(
+        marker in paths for marker in ("STHeiti", "Hiragino", "Arial Unicode")
+    )
+    assert has_legacy, (
+        "#219: macOS legacy CJK paths (STHeiti / Hiragino / Arial Unicode) "
+        "needed for non-default-locale installs"
+    )


### PR DESCRIPTION
Closes #219 (P1).

## What

Chinese tables rendered as tofu (❑) on a second macOS, same code. Root cause: `_load_font` fell silently through to Menlo (loads cleanly but no CJK in cmap → Pillow draws hollow `.notdef` rectangles).

## Fix — Approach B + C combined

1. **Glyph probe** `_font_has_cjk` compares `中`'s mask to `U+E000` (PUA — guaranteed undefined). Identical → tofu → reject font.
2. **broaden except** Exception catches IndexError/ValueError from bad ttc faces.
3. **11 candidates** (was 3): macOS CJK (PingFang, STHeiti, Hiragino, Arial Unicode) + Linux CJK (Noto, WQY) + ASCII fallback (Menlo).
4. **ASCII memorialization**: if NO CJK font passes probe, return the first-loaded ASCII font (English still works).

## Why PUA reference

Menlo's `中` tofu box has non-zero pixels (the hollow rectangle has ink). Pixel count alone can't discriminate. U+E000 is by-spec undefined → its mask IS what tofu looks like in this font. Compare against it.

## Tests +13

881 / 0 (was 868).

## Verification

Manager mac: probe correctly returns PingFang. Remote mac: needs user to confirm post-merge.
