### PR TITLE
fix(renderer): remove speculative sub-agent orphan embed paths (#212)

### DIFF
--- a/docs/prd/v1.18-subagent-orphan-embeds.md
+++ b/docs/prd/v1.18-subagent-orphan-embeds.md
@@ -1,0 +1,60 @@
+# PRD — Sub-agent orphan embeds (#212)
+
+**Status**: APPROVED (Approach C — delete speculative path)
+**Issue**: #212
+**Branch**: `fix/v1.18-subagent-orphan-embeds`
+**Severity**: P1
+
+## Problem
+
+User prod screenshot: 3 orphan embeds in main thread —
+`📤 Subtask Output` (×2, empty description) + `⏹️ Subtask Stopped` (red,
+no description). No `🔀 Subtask #N` anchor, no `✅ Subtask Complete`.
+
+## Root cause
+
+v1.6 PRD F4 wired `TaskOutput`/`AgentOutput`/`TaskStop`/`AgentStop` tool
+names with guessed `block.input` schema (`output` key). SDK never
+documented these names; the field name was never observed in prod data.
+Result: embeds emitted with empty descriptions, no anchor link to the
+spawning `Task` tool_use.
+
+## Decision
+
+**Approach C** — delete the speculative paths. SDK doesn't document the
+names; without verified schema, any rendering is guess-driven and
+already produces orphans. Generic tool-use fallback below still handles
+real sub-agent tool calls (#192 Fix C). When real schema is discovered
+via stream_logger forensics, re-add targeted handling with verified
+fields.
+
+## Goals
+
+1. Remove `TaskOutput`/`AgentOutput` embed-emit branch
+2. Remove `TaskStop`/`AgentStop` embed-emit branch (kept `task_depth = max(0, task_depth - 1)` semantics noted — minor display hint, not critical)
+3. Keep `result_name == "TaskStop"` short-circuit in tool-result branch (skips generic rendering for any stray TaskStop ToolResult)
+4. ADD forensic stream_logger event `SubAgentToolUse` for any of the 6 tool names — captures real schema for future data-driven re-introduction
+
+## Non-goals
+
+- Add back the embeds with NEW guessed schema
+- Modify the working `Task`/`Agent` sub-thread creation path
+- Modify Subtask Complete / Sub-agent dispatched logic
+
+## Acceptance
+
+- [x] AC1: `if name in ("TaskOutput", "AgentOutput"):` branch removed
+- [x] AC2: `if name in ("TaskStop", "AgentStop"):` branch removed
+- [x] AC3: forensic `SubAgentToolUse` event emitted for all 6 sub-agent tool names
+- [x] AC4: `Task`/`Agent` sub-thread creation path preserved
+- [x] AC5: `result_name == "TaskStop"` short-circuit preserved (carries #212 note)
+
+## Tests +5
+
+- `test_no_taskoutput_embed_path` — speculative branch + title gone
+- `test_no_taskstop_embed_path` — same for TaskStop
+- `test_subagent_tool_use_forensics_log_present` — all 6 names in forensics
+- `test_taskstop_tool_result_still_short_circuits` — result branch preserved
+- `test_task_agent_branch_preserved` — working path untouched
+
+pytest 886 / 0 (was 881; +5).

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1076,6 +1076,27 @@ class DiscordRenderer:
 
                             # --- Special tool display: Task subtask (#55, #74) ---
                             # Create a sub-thread for each sub-agent
+                            # #212 forensics: log any sub-agent tool name +
+                            # input keys to stream-debug.jsonl so we capture
+                            # real schema for future re-introduction. #223
+                            # PR-A added the stream_logger; we just emit
+                            # one event per sub-agent-ish ToolUseBlock.
+                            if name in (
+                                "TaskOutput", "AgentOutput",
+                                "TaskStop", "AgentStop",
+                                "Task", "Agent",
+                            ):
+                                _log_stream({
+                                    "type": "SubAgentToolUse",
+                                    "name": name,
+                                    "tool_id": tool_id,
+                                    "input_keys": (
+                                        list(block.input.keys())
+                                        if isinstance(block.input, dict)
+                                        else None
+                                    ),
+                                })
+
                             if name in ("Task", "Agent"):
                                 task_depth += 1
                                 desc = block.input.get("description", "")[:200]
@@ -1126,30 +1147,32 @@ class DiscordRenderer:
                                         tool_msgs[tool_id] = tmsg
                                 continue
 
-                            # --- Special tool display: TaskOutput (#74) ---
-                            if name in ("TaskOutput", "AgentOutput"):
-                                output = block.input.get("output", "")[:500]
-                                task_out_embed = discord.Embed(
-                                    title="📤 Subtask Output",
-                                    description=output,
-                                    color=COLOR_INFO,
-                                )
-                                tmsg = await self._safe_send(embed=task_out_embed)
-                                if tmsg is not None and tool_id:
-                                    tool_msgs[tool_id] = tmsg
-                                continue
-
-                            # --- Special tool display: TaskStop (#74) ---
-                            if name in ("TaskStop", "AgentStop"):
-                                task_depth = max(0, task_depth - 1)
-                                task_stop_embed = discord.Embed(
-                                    title="⏹️ Subtask Stopped",
-                                    color=COLOR_TOOL_FAILURE,
-                                )
-                                tmsg = await self._safe_send(embed=task_stop_embed)
-                                if tmsg is not None and tool_id:
-                                    tool_msgs[tool_id] = tmsg
-                                continue
+                            # --- #74 / #212: dead Subtask Output/Stop paths removed ---
+                            #
+                            # v1.6 PRD F4 speculatively wired ``TaskOutput`` /
+                            # ``AgentOutput`` / ``TaskStop`` / ``AgentStop``
+                            # tool names with guessed ``block.input`` schemas.
+                            # SDK never documented these names; the field name
+                            # (``output``) was never observed in prod stream
+                            # data, so the resulting embeds rendered with empty
+                            # descriptions and no anchor link to the spawning
+                            # ``Task`` — orphans in the main thread.
+                            #
+                            # #212 decision (Approach C): delete the
+                            # speculative paths. If the CLI does emit these
+                            # tool names, they fall through to the generic
+                            # tool-use embed below, which is already correct
+                            # (#192 Fix C also handles async-agent dispatch).
+                            # We can re-add targeted handling once stream-debug
+                            # (#223 PR-A) captures real schema.
+                            #
+                            # ``task_depth`` is still incremented in the
+                            # ``Task`` / ``Agent`` branch above and consumed
+                            # by downstream indentation logic; the missing
+                            # decrement on TaskStop is acceptable because
+                            # ``task_depth`` is a sub-thread display hint
+                            # only — spurious depth is bounded by the
+                            # parent turn ending (depth resets per render).
 
                             # --- Special tool display: TodoWrite (#56) ---
                             if name == "TodoWrite":
@@ -1471,6 +1494,13 @@ class DiscordRenderer:
                                 continue
 
                             if result_name == "TaskStop":
+                                # #212: the speculative TaskStop tool-use
+                                # branch was removed above (Approach C),
+                                # so we'd never have a ``tool_msgs[tool_id]``
+                                # to update here. Keep the early-continue
+                                # to skip generic tool-result rendering for
+                                # any TaskStop tool_result that does slip
+                                # through (it'd carry no useful info).
                                 continue
 
                             is_err = bool(getattr(block, "is_error", False))

--- a/tests/test_subagent_orphan_embed_cleanup.py
+++ b/tests/test_subagent_orphan_embed_cleanup.py
@@ -1,0 +1,81 @@
+"""#212 — remove speculative TaskOutput/AgentOutput/TaskStop/AgentStop embed paths.
+
+v1.6 PRD F4 wired up sub-agent intermediate-output embeds with guessed
+SDK tool names + schema. SDK never documented these; field name
+``output`` was never observed in prod data; the resulting embeds rendered
+empty + orphan (no anchor link to the spawning ``Task`` tool-use).
+
+Approach C: delete the speculative paths; emit a stream_logger event so
+future re-introduction is data-driven (#223 PR-A stream_logger is alive).
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from clauded.discord_renderer import DiscordRenderer
+
+
+def test_no_taskoutput_embed_path():
+    """The speculative `if name in ("TaskOutput", "AgentOutput"):` ToolUseBlock
+    branch must be removed. v1.6 F4 schema guess never matched prod."""
+    src = inspect.getsource(DiscordRenderer)
+    assert 'if name in ("TaskOutput", "AgentOutput")' not in src, (
+        "#212: speculative TaskOutput/AgentOutput embed path must be removed"
+    )
+    # Title string also gone (no place left to emit it)
+    assert "📤 Subtask Output" not in src, (
+        "#212: '📤 Subtask Output' embed title must be removed"
+    )
+
+
+def test_no_taskstop_embed_path():
+    """`TaskStop`/`AgentStop` was emitting empty red embeds. Removed."""
+    src = inspect.getsource(DiscordRenderer)
+    assert 'if name in ("TaskStop", "AgentStop")' not in src, (
+        "#212: speculative TaskStop/AgentStop embed path must be removed"
+    )
+    assert "⏹️ Subtask Stopped" not in src, (
+        "#212: '⏹️ Subtask Stopped' embed title must be removed"
+    )
+
+
+def test_subagent_tool_use_forensics_log_present():
+    """#212: when any sub-agent-ish tool name appears, we emit a
+    SubAgentToolUse event to stream_logger so we capture real schema
+    for future re-introduction (data-driven, not guessed)."""
+    src = inspect.getsource(DiscordRenderer)
+    # The forensic log block must exist
+    assert "#212 forensics" in src
+    assert '"type": "SubAgentToolUse"' in src
+    # The list of names must include all 6 (Task/Agent + Output + Stop)
+    for n in (
+        "TaskOutput", "AgentOutput",
+        "TaskStop", "AgentStop",
+        "Task", "Agent",
+    ):
+        assert f'"{n}"' in src, (
+            f"#212: sub-agent tool name {n!r} must appear in forensics list"
+        )
+
+
+def test_taskstop_tool_result_still_short_circuits():
+    """The tool_RESULT branch for `TaskStop` still continues (skips generic
+    tool-result rendering), so even if CLI emits TaskStop ToolResult we
+    don't generate noise — just stream-log it (via the tool_use forensics
+    above)."""
+    src = inspect.getsource(DiscordRenderer)
+    assert 'if result_name == "TaskStop"' in src
+    # The body of that branch is a single ``continue``
+    # We just pin the branch existence + that it carries our #212 note
+    assert "#212" in src
+
+
+def test_task_agent_branch_preserved():
+    """Sanity: the *working* Task/Agent sub-thread creation path (line 1079)
+    is NOT removed by this cleanup. Subtask Complete + dispatched still work."""
+    src = inspect.getsource(DiscordRenderer)
+    assert 'if name in ("Task", "Agent"):' in src
+    # The thread-creation flow is preserved
+    assert "Subtask #" in src  # the title format from the Task branch


### PR DESCRIPTION
Closes #212 (P1).

## Why

User screenshot: 3 orphan embeds in main thread — `📤 Subtask Output` × 2 with empty descriptions + `⏹️ Subtask Stopped` red with no description. No anchor link to the spawning `Task`.

Root cause: v1.6 PRD F4 wired these tool names with GUESSED schemas. SDK never documented them; the assumed `output` field was never observed in prod data.

## Fix — Approach C (delete speculative paths)

Without verified schema, any rendering is guess-driven and produces orphans. Delete the speculative branches; generic tool-use fallback below handles real sub-agent tool calls (#192 Fix C).

**Forensics**: emit a `SubAgentToolUse` stream_logger event for any sub-agent-ish tool name — captures real schema for future data-driven re-introduction. Builds on #223 PR-A.

## Tests +5

886 / 0 (was 881).
