### PR TITLE
feat(renderer): sub-agent rolling-log short-tier parity (#204)

### DIFF
--- a/docs/prd/v1.18-subagent-short-tier-parity.md
+++ b/docs/prd/v1.18-subagent-short-tier-parity.md
@@ -1,0 +1,45 @@
+# PRD — Sub-agent rolling-log short-tier parity (#204)
+
+**Status**: APPROVED (paused issue unpaused per user "都做" 5/18)
+**Issue**: #204
+**Branch**: `feat/v1.18-subagent-short-tier-parity`
+**Severity**: P2 (parity gap)
+
+## Problem
+
+Tool-result display tiering (#161 short tier `< 200 chars`) is only applied
+on the main thread. Sub-agent threads do a bare emoji swap, losing inline
+content surfaced by #165 / #180.
+
+## Decision
+
+Port main-thread short-tier formatting to sub-renderer path. Medium-tier
+button out of scope (needs per-sub-thread view-store persistence work —
+sub-renderer doesn't own a `ToolResultsView`).
+
+## Goals
+
+1. `_extract_block_content_text` reused in sub-renderer ToolResultBlock handler
+2. Short-tier (`< 200 chars` + non-empty) → `{status} {name} → {content}` with backtick strip + newline collapse
+3. Error tier → `{status} {name}: {error_text[:100]}`
+4. Else → legacy fallback `{status} {body}` (current behavior preserved)
+5. Tests pin all 4 branches
+
+## Non-goals
+
+- Medium-tier button (per #204 §Out of scope; needs view-store work)
+- xlong-tier .txt attachment (#181)
+- Per-tool threshold overrides
+
+## Acceptance
+
+- [x] AC1: sub-agent path uses `_extract_block_content_text(block.content)`
+- [x] AC2: short-tier produces `✅ Bash → result` format
+- [x] AC3: error-tier produces `❌ Bash: error_text` format
+- [x] AC4: fallback `✅ Bash: cmd` (current behavior) preserved
+- [x] AC5: no `ToolResultsView` plumbing in sub-renderer path
+
+## Tests +7
+
+`tests/test_subagent_short_tier_parity.py` — source-grep pins (content
+extraction, format strings, fallback, scope exclusions).

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -819,11 +819,72 @@ class DiscordRenderer:
                                 if hasattr(sub_renderer, '_tool_log_lines') and sub_renderer._tool_log_lines:
                                     is_err = bool(getattr(block, "is_error", False))
                                     status = "✅" if not is_err else "❌"
+                                    # #204: extract content + apply short-tier
+                                    # parity. Sub-agent rolling log previously
+                                    # just sliced ``[2:]`` to swap 🔄 → ✅/❌
+                                    # — losing the inline content surfaced on
+                                    # the main thread by #161 / #165 / #180.
+                                    # Medium-tier button is out-of-scope (per
+                                    # #204): sub-renderer doesn't own a
+                                    # persistent view store; per-sub-thread
+                                    # button persistence is a separate piece
+                                    # of work.
+                                    content_str = _extract_block_content_text(block.content)
+                                    is_short = (
+                                        len(content_str) < 200
+                                        and content_str.strip() != ""
+                                    )
                                     # Update last matching entry
                                     for i in range(len(sub_renderer._tool_log_lines) - 1, -1, -1):
-                                        if sub_renderer._tool_log_lines[i].startswith("🔄"):
-                                            sub_renderer._tool_log_lines[i] = f"{status} {sub_renderer._tool_log_lines[i][2:]}"
-                                            break
+                                        line = sub_renderer._tool_log_lines[i]
+                                        if not line.startswith("🔄"):
+                                            continue
+                                        # Existing line shape is ``🔄 Bash: `cmd` `` —
+                                        # `[2:]` strips the running emoji + space
+                                        # and we keep the rest as the "name fragment"
+                                        # (full ``Bash: `cmd` `` rather than just
+                                        # ``Bash`` to preserve sub-renderer's
+                                        # current display). For #204 short tier we
+                                        # need the bare tool name to format
+                                        # ``✅ Bash → content``; pull it from the
+                                        # fragment by splitting on the first ``:``
+                                        # or space.
+                                        body = line[2:].lstrip()
+                                        # Tool-name heuristic: everything up to
+                                        # the first ``:`` (Bash/Read/Edit/Write
+                                        # all use ``Name: ...`` shape) OR everything
+                                        # before the first space (WebSearch "🔍 ..."
+                                        # / fallback "name...").
+                                        if ":" in body:
+                                            tool_label = body.split(":", 1)[0].strip()
+                                        elif " " in body:
+                                            tool_label = body.split(" ", 1)[0].strip()
+                                        else:
+                                            tool_label = body.strip()
+                                        if is_err:
+                                            error_text = content_str[:100] if content_str else "Failed"
+                                            sub_renderer._tool_log_lines[i] = (
+                                                f"{status} {tool_label}: {error_text}"
+                                            )
+                                        elif is_short:
+                                            # Same backtick-strip + newline-collapse
+                                            # contract as the main-thread short tier.
+                                            safe = (
+                                                content_str.strip()
+                                                .replace("`", "'")
+                                                .replace("\n", " │ ")
+                                            )
+                                            sub_renderer._tool_log_lines[i] = (
+                                                f"{status} {tool_label} → {safe}"
+                                            )
+                                        else:
+                                            # Fallback to current behavior:
+                                            # keep the original line body, just
+                                            # flip the leading emoji.
+                                            sub_renderer._tool_log_lines[i] = (
+                                                f"{status} {body}"
+                                            )
+                                        break
                                     has_errors = any("❌" in l for l in sub_renderer._tool_log_lines)
                                     tl_embed = discord.Embed(title="🔧 Tool Activity", description="\n".join(sub_renderer._tool_log_lines[-15:]), color=COLOR_TOOL_FAILURE if has_errors else COLOR_TOOL_SUCCESS)
                                     if sub_renderer._tool_log_msg:

--- a/tests/test_subagent_short_tier_parity.py
+++ b/tests/test_subagent_short_tier_parity.py
@@ -1,0 +1,72 @@
+"""#204 — sub-agent rolling-log short-tier parity with main thread.
+
+Pre-#204 behavior: sub-agent rolling log just swapped 🔄 → ✅/❌, losing
+the inline content surfaced on the main thread by #161/#165/#180.
+
+This PR ports the short-tier (< 200 chars, non-empty) and error-text
+formatting to the sub-agent path. Medium-tier button is out of scope
+(needs per-sub-thread view-store work).
+"""
+from __future__ import annotations
+
+import inspect
+
+
+def _get_subagent_resultblock_source() -> str:
+    """Pull the sub-agent ToolResultBlock handler source via inspect."""
+    from clauded import discord_renderer
+    src = inspect.getsource(discord_renderer)
+    start = src.find("#204: extract content")
+    assert start != -1, "#204 marker comment missing"
+    end = src.find("if sub_renderer._tool_log_msg", start)
+    return src[start:end]
+
+
+def test_204_short_tier_format_present():
+    """Short-tier line format `{status} {name} → {safe}` appears in subagent path."""
+    section = _get_subagent_resultblock_source()
+    assert "tool_label} \u2192 {safe}" in section, (
+        "#204: short-tier format with arrow + content missing in sub-agent path"
+    )
+
+
+def test_204_error_tier_format_present():
+    """Error-tier line: `{status} {name}: {error_text[:100]}`."""
+    section = _get_subagent_resultblock_source()
+    assert "tool_label}: {error_text}" in section
+
+
+def test_204_uses_extract_block_content_text():
+    """#204: sub-agent path now uses the same content extraction helper as main."""
+    section = _get_subagent_resultblock_source()
+    assert "_extract_block_content_text(block.content)" in section
+
+
+def test_204_short_predicate_matches_main():
+    """Short predicate: `< 200 chars and non-empty`."""
+    section = _get_subagent_resultblock_source()
+    assert "len(content_str) < 200" in section
+
+
+def test_204_backtick_strip_and_newline_collapse():
+    """Pin the formatting behavior — content gets backticks stripped + \\n collapsed."""
+    section = _get_subagent_resultblock_source()
+    # Backtick strip — the source has a .replace call with a backtick
+    assert "`" in section and "replace" in section, "backtick strip pattern missing"
+    # Newline collapse to │
+    assert "\u2502" in section, "newline collapse to │ missing"
+
+
+def test_204_medium_tier_button_out_of_scope():
+    """Per #204, the medium-tier button is OUT of scope. The sub-agent
+    path must NOT have a button or `add_view` plumbing."""
+    section = _get_subagent_resultblock_source()
+    assert "ToolResultsView" not in section
+    assert "is_medium" not in section
+
+
+def test_204_fallback_to_legacy_line_format_when_not_short_or_err():
+    """When content is empty or too long for short tier, fall back to
+    legacy ``{status} {body}`` format (current behavior preserved)."""
+    section = _get_subagent_resultblock_source()
+    assert "{status} {body}" in section


### PR DESCRIPTION
Closes #204 (P2 paused → unpaused per "都做" 5/18).

## What

Sub-agent rolling log used to show bare `✅ Bash`. Now shows `✅ Bash → 76 pass | 0 fail` — same short-tier formatting as main thread (#161 / #165 / #180).

## Fix

Port the main-thread short-tier logic to sub-renderer ToolResultBlock handler:
- Use `_extract_block_content_text` for SDK shape normalization
- short (< 200 chars, non-empty): `✅ Name → content` with backtick strip + newline collapse
- error: `❌ Name: error_text[:100]`
- fallback: `✅ body` (legacy preserved)

## Out of scope

Medium-tier button + xlong attachment — sub-renderer doesn't own a `ToolResultsView` (per-sub-thread view-store persistence is separate work).

## Tests +7

**893 / 0** (was 886).
