### PR TITLE
feat(renderer): #161 xlong tier — ≥8000 chars → .txt attachment (#181)

### DIFF
--- a/docs/prd/v1.18-xlong-tier.md
+++ b/docs/prd/v1.18-xlong-tier.md
@@ -1,0 +1,55 @@
+# PRD — #161 xlong tier: ≥ 8000 chars → .txt attachment (#181)
+
+**Status**: APPROVED (paused → unpaused per "都做" 5/18)
+**Issue**: #181
+**Branch**: `feat/v1.18-xlong-tier`
+**Severity**: P2 (parity gap; user-visible info loss for huge outputs)
+
+## Problem
+
+#161 short (< 200) + medium (200-8000 button) tiers are live. The xlong
+bucket (≥ 8000 chars) currently falls to the bare `✅ Bash` else branch —
+user sees the emoji but loses access to the content entirely.
+
+## Decision
+
+**Approach A** — direct `.txt` attachment (per Manager rec on issue + AC list).
+Rolling-log line: `✅ {Tool}: N lines / M chars (see attached file)`
+Follow-up message: `📄 **{Tool} result** — M chars / N lines` + `discord.File`.
+
+Approach B (head/tail spoiler + button) rejected: 2× code, button rate-limit
+pressure, xlong is rare enough that the extra message is acceptable.
+
+## Goals
+
+1. New `is_xlong` predicate `not is_short and not is_err and len >= 8000 and non-empty`
+2. Pre-loop `is_xlong = False` default (mirrors #226 safety pattern)
+3. Rolling-log line format per AC: `{status} {name}: N lines / M chars (see attached file)`
+4. Follow-up `discord.File(BytesIO(utf-8-encoded), filename={tool_lower}_result.txt)`
+5. Error path unchanged (errors stay capped at 100 chars regardless of size)
+
+## Non-goals
+
+- Per-tool thresholds (Read 100/15000, WebFetch 500 — #161 backlog)
+- File compression / pagination
+- Sub-renderer xlong tier (sub-renderer doesn't own a result-attachments path)
+
+## Acceptance
+
+- [x] AC1: rolling log line uses `(see attached file)` marker
+- [x] AC2: file message uses `📄 {Tool} result — M chars / N lines` caption
+- [x] AC3: file is `{tool_lowercased}_result.txt`
+- [x] AC4: error path bypasses xlong (`if is_xlong and not is_err and tool_id:`)
+- [x] AC5: `is_xlong = False` default + threshold `>= 8000` pin
+
+## Tests +8
+
+`tests/test_xlong_tier.py` — source-grep pins on the patch section:
+predicate boundary, error exclusion, format strings, defaults, no
+regression on short/medium predicates.
+
+## Risks
+
+- Discord per-message attachment size: 8MB (non-boost). xlong starts at 8000 chars → ~8KB; safe.
+- File send failure: existing `_safe_send` HTTP retry handles transient blips. PR-B #231 added file.fp.seek WARNING for the retry case.
+- Sub-thread xlong: not handled (sub-renderer is separate; #204 deferred medium button for same reason).

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1608,6 +1608,7 @@ class DiscordRenderer:
                                 # event is a safe no-op (correct since
                                 # there's no rolling-log line to update).
                                 is_medium = False
+                                is_xlong = False  # #181 xlong tier marker
                                 content_str = ""
                                 medium_index = None
                                 matched = False  # for the diagnostic log below
@@ -1654,6 +1655,20 @@ class DiscordRenderer:
                                         and 200 <= len(content_str) < 8000
                                         and content_str.strip() != ""
                                     )
+                                    # #181 xlong tier: ``len >= 8000``. Button-
+                                    # tier rate-limit + 25-component cap make
+                                    # the medium-tier ephemeral button approach
+                                    # impractical at this size. Send the result
+                                    # as a standalone .txt file attachment
+                                    # message immediately, and surface a summary
+                                    # line on the rolling log. Errors stay
+                                    # capped at 100 chars regardless of size.
+                                    is_xlong = (
+                                        not is_short
+                                        and not is_err
+                                        and len(content_str) >= 8000
+                                        and content_str.strip() != ""
+                                    )
                                     if is_err:
                                         error_text = content_str[:100] if content_str else "Failed"
                                         tool_log_lines[i] = f"{status} {name}: {error_text}"
@@ -1695,6 +1710,18 @@ class DiscordRenderer:
                                             f"{status} **#{medium_index} {name}**: "
                                             f"{line_count} lines / "
                                             f"{len(content_str)} chars (⬇ click to view)"
+                                        )
+                                    elif is_xlong:
+                                        # #181: summary line on rolling log;
+                                        # file attachment is sent as a
+                                        # separate message AFTER the rolling-
+                                        # log embed update (so order is
+                                        # "✅ log update + 📄 file").
+                                        line_count = content_str.count("\n") + 1
+                                        tool_log_lines[i] = (
+                                            f"{status} {name}: "
+                                            f"{line_count} lines / "
+                                            f"{len(content_str)} chars (see attached file)"
                                         )
                                     else:
                                         tool_log_lines[i] = f"{status} {name}"
@@ -1825,6 +1852,28 @@ class DiscordRenderer:
                                         if f"#{medium_index} {name}" in tool_log_lines[j] and "click to view" in tool_log_lines[j]:
                                             tool_log_lines[j] = f"{status} **#{medium_index} {name}** ({len(content_str)} chars; view button unavailable)"
                                             break
+                                # #181 xlong tier: send the .txt attachment
+                                # as a follow-up message AFTER the rolling-
+                                # log embed is updated. The summary line
+                                # already promises "(see attached file)";
+                                # honor that promise here.
+                                if is_xlong and not is_err and tool_id:
+                                    line_count = content_str.count("\n") + 1
+                                    safe_name = name.lower().replace(" ", "_")
+                                    file_bytes = content_str.encode(
+                                        "utf-8", errors="replace"
+                                    )
+                                    await self._safe_send(
+                                        content=(
+                                            f"📄 **{name} result** — "
+                                            f"{len(content_str)} chars / "
+                                            f"{line_count} lines"
+                                        ),
+                                        file=discord.File(
+                                            fp=io.BytesIO(file_bytes),
+                                            filename=f"{safe_name}_result.txt",
+                                        ),
+                                    )
                             elif tool_id and tool_id in tool_msgs:
                                 orig_msg = tool_msgs[tool_id]
                                 if is_err:

--- a/tests/test_xlong_tier.py
+++ b/tests/test_xlong_tier.py
@@ -1,0 +1,90 @@
+"""#181 — xlong tier: ToolResultBlock content >= 8000 chars surfaces as .txt attachment.
+
+Pre-#181: results >= 8000 chars fell to bare `✅ Bash` else branch — user
+saw the emoji but lost access to the content entirely.
+
+Post-#181: rolling-log line shows `✅ Bash: N lines / M chars (see
+attached file)` + a follow-up message with the .txt attachment.
+"""
+from __future__ import annotations
+
+import inspect
+
+
+def _renderer_source() -> str:
+    from clauded import discord_renderer
+    return inspect.getsource(discord_renderer)
+
+
+def test_181_is_xlong_predicate_at_8000_boundary():
+    """Threshold: `len(content) >= 8000` (boundary inclusive)."""
+    src = _renderer_source()
+    # Must reference the explicit threshold
+    assert "len(content_str) >= 8000" in src, (
+        "#181: xlong predicate must be `len(content_str) >= 8000`"
+    )
+
+
+def test_181_is_xlong_excludes_errors_and_empty():
+    """xlong predicate excludes errors + empty content."""
+    src = _renderer_source()
+    # Pin the relevant subset of the predicate
+    start = src.find("is_xlong = (")
+    assert start != -1, "is_xlong assignment must exist"
+    block = src[start : start + 400]
+    assert "not is_err" in block
+    assert "content_str.strip()" in block
+
+
+def test_181_xlong_rolling_log_format():
+    """Rolling log line: `{status} {name}: N lines / M chars (see attached file)`."""
+    src = _renderer_source()
+    # Pin the format substring
+    assert "(see attached file)" in src, (
+        "#181: xlong rolling-log line must end with `(see attached file)`"
+    )
+    # Pin the chars count is in the format
+    start = src.find("(see attached file)")
+    block = src[max(0, start - 300) : start + 60]
+    assert "lines /" in block
+    assert "chars" in block
+
+
+def test_181_xlong_file_attachment_send():
+    """xlong path sends `discord.File(fp=io.BytesIO(content_bytes), filename=...)`."""
+    src = _renderer_source()
+    # Pin the send call shape — encoded bytes + io.BytesIO + safe filename
+    assert "content_str.encode(" in src, "#181: must encode content_str to bytes"
+    assert 'filename=f"{safe_name}_result.txt"' in src, (
+        "#181: file must use `{tool_lowercased}_result.txt` filename"
+    )
+    # Pin: caption format
+    assert "📄" in src, "#181: file message uses 📄 prefix per AC"
+
+
+def test_181_xlong_error_path_does_not_emit_file():
+    """Error path bypasses xlong — `if is_xlong and not is_err and tool_id:`."""
+    src = _renderer_source()
+    # Pin the send guard
+    assert "if is_xlong and not is_err and tool_id:" in src
+
+
+def test_181_is_xlong_default_false():
+    """Pre-loop default: `is_xlong = False` (mirrors #226 pattern for is_medium)."""
+    src = _renderer_source()
+    assert "is_xlong = False" in src, (
+        "#181: is_xlong must have a pre-loop False default — same #226 "
+        "no-match safety as is_medium"
+    )
+
+
+def test_181_is_short_unchanged():
+    """Short tier predicate unchanged: < 200 chars."""
+    src = _renderer_source()
+    assert "len(content_str) < 200" in src
+
+
+def test_181_is_medium_upper_bound_unchanged():
+    """Medium tier upper bound: < 8000 (now exclusive of xlong)."""
+    src = _renderer_source()
+    assert "200 <= len(content_str) < 8000" in src


### PR DESCRIPTION
Closes #181 (P2 paused → unpaused per "都做" 5/18).

## What

ToolResultBlock content >= 8000 chars now surfaces as a `.txt` attachment instead of vanishing into a bare `✅ Tool` line.

## Approach A — direct file attachment

- Rolling log: `✅ Bash: 320 lines / 12000 chars (see attached file)`
- Follow-up: `📄 Bash result — ...` + `discord.File`

Rejected B (head/tail + button) and C (refuse). xlong is rare enough that the extra message is acceptable; button rate-limit pressure made B costly.

## Defaults safety

`is_xlong = False` pre-loop default mirrors #226 — downstream check is a safe no-op on no-match.

## Tests +8

**901 / 0** (was 893).
