### PR TITLE
feat(diagnostics): /log dump bundle + auto-crash dispatcher (#224 epic)

### DIFF
--- a/docs/prd/v1.18-log-dump-epic.md
+++ b/docs/prd/v1.18-log-dump-epic.md
@@ -1,0 +1,65 @@
+# PRD — /log dump diagnostic bundle (#224 epic)
+
+**Status**: APPROVED ("都做" 5/18 covers epic)
+**Issue**: #224
+**Branch**: `feat/v1.18-log-dump-epic`
+**Severity**: P1
+
+## Scope
+
+5 subtasks all in this single PR (per crew workflow §subtask):
+
+1. **Bundle pipeline** — `diagnostics/bundle.py:generate_bundle()` produces zip
+2. **Redaction primitives** — `diagnostics/redact.py:redact_env/path/text/json`
+3. **`/log dump` cog** — `cogs/log_dump.py` (slash command, defer + executor + upload)
+4. **Auto-crash hook** — `bot.py:_maybe_dispatch_auto_crash_bundle` with 5-min cooldown
+5. **Tests** — `test_log_dump_bundle.py` (+32 tests covering all 5 subtasks)
+
+## Decisions
+
+| # | Decision |
+|---|---|
+| D1 | All 5 subtasks in one PR — coupling is tight (bundle ↔ redact ↔ cog ↔ hook); fragmentation risks half-shipped epic. |
+| D2 | Bundle layout per issue body §Bundle Contents (manifest + env-redacted + logs/ + state/ + runtime/ + diagnostics/) |
+| D3 | Env allowlist: PATH/HOME/USER/LANG/TZ/SHELL/TERM/PWD + LC_* + clauded vars. Sensitive-pattern keys → `len=N sha256=...`. Unknown keys → dropped (small + safe). |
+| D4 | Path redaction: `/Users/<actual>/` → `/Users/<user>/` using `pwd.getpwuid` |
+| D5 | system_prompt verbatim REDACTED to `len=N sha256=...` digest marker in `sessions-live.json` |
+| D6 | Size budget 8 MB (T0 guild upload limit 10 MB - 20% safety). Overrun → drop `logs/` entries |
+| D7 | Auto-crash rate-limit: 5min cooldown per thread to avoid bundle-spam during thrash bugs |
+| D8 | Bundle generation runs in `loop.run_in_executor` so event loop stays responsive |
+
+## Acceptance (all met)
+
+- AC1 slash → ephemeral feedback + thread attachment ✓
+- AC2 zip contains manifest+env+logs+state+runtime+diagnostics ✓
+- AC3 DISCORD_BOT_TOKEN / ANTHROPIC_API_KEY not in bundle (grep-tested) ✓
+- AC4 `/Users/<actual>/` redacted (grep-tested) ✓
+- AC5 ≤8MB cap with truncation fallback ✓
+- AC6 auto-crash → bundle upload to thread + rate-limit ✓
+- AC7 model_override + bot-flags visible to PM ✓
+- AC8 PM bundle inspection workflow (manual; structure pinned by tests)
+
+## Tests +32
+
+- redact_env: allowlist (3), LC_ prefix (1), drop-unknown (1), sensitive-pattern (6 parametrized), allowlist precedence (1), empty (1) = 13
+- redact_path: macOS (1), Linux (1), no-match (1), other-user (1) = 4
+- redact_text: multi-occurrence (1) = 1
+- JSON redactors: projects (1), sessions+system_prompt (1) = 2
+- generate_bundle: zip exists (1), manifest (1), no token leak (1), path redaction (1), runtime snapshot (1), omit missing state (1), log tail (1) = 7
+- /log dump cog: registered (1), executor (1), defer (1) = 3
+- Auto-crash dispatcher: method exists (1), call site (1), rate-limit (1), happy path (1) = 4
+
+pytest 933 / 0 (was 901, +32).
+
+## Risks
+
+- bundle generation in executor still touches disk; max ~5s on hot logs. Slow disk could exceed Discord's 15min interaction expiry. Mitigation: deferred response.
+- TOCTOU on log tail: file could rotate mid-read. Acceptable — we read what's there at the moment.
+- Future Pillow / Discord API drift could change `discord.File`/`safe_send_message` semantics. Tests cover the call shape, not the underlying API.
+
+## Out of scope (deferred)
+
+- PM auto-analysis (#224 mentions; separate issue)
+- External S3/gist replacement for attachment (user said "log 就附到 discord")
+- Historical bundle index / search
+- Per-thread "@PM" mentions on auto-crash

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -7,11 +7,13 @@ messages to a per-thread :class:`ClaudeBridge` session.
 
 from __future__ import annotations
 
+import functools
 import logging
 import os
 import shutil
 import tempfile
 import time
+import traceback
 import sys
 import asyncio
 from pathlib import Path
@@ -137,6 +139,12 @@ def _build_retry_session_config(
 # repo for the matching string in those files.
 # --------------------------------------------------------------------------
 _LAUNCHD_LABEL = "com.hxy.clauded"
+
+# #224 R1 simplicity: cooldown between consecutive auto-crash bundle
+# dispatches on the SAME thread. 5 minutes is the sweet spot: rare
+# enough that a thrashing bug doesn't spam attachments, short enough
+# that a 1-hour-later second crash gets its own bundle.
+AUTO_CRASH_COOLDOWN_S = 300
 # _LOG_DIR and _CACHE_DIR live in _logging_setup.py (v1.18 stage-28 trim);
 # imported above. _HEARTBEAT_PATH stays here because it belongs to the
 # heartbeat task, not to logging setup.
@@ -1187,8 +1195,6 @@ class ClaudedBot(commands.Bot):
     # #224 epic Subtask 4 — auto-crash bundle dispatch
     # ------------------------------------------------------------------
 
-    _AUTO_CRASH_COOLDOWN_S = 300  # 5 min
-
     async def _maybe_dispatch_auto_crash_bundle(
         self,
         *,
@@ -1198,7 +1204,7 @@ class ClaudedBot(commands.Bot):
     ) -> None:
         """#224: generate and upload an auto-crash diagnostic bundle.
 
-        Rate-limited per-thread (``_AUTO_CRASH_COOLDOWN_S``) so a thrash-
+        Rate-limited per-thread (``AUTO_CRASH_COOLDOWN_S``) so a thrash-
         cycle bug doesn't spam the channel with bundles. Best-effort:
         any failure inside this method is logged but never re-raised
         (the caller is already in an ``except Exception`` block recovering
@@ -1213,10 +1219,9 @@ class ClaudedBot(commands.Bot):
         # Per-thread rate-limiter (dict of thread_id -> last dispatch ts)
         if not hasattr(self, "_auto_crash_last_dispatch"):
             self._auto_crash_last_dispatch: dict[int, float] = {}
-        import time as _time
-        now = _time.time()
+        now = time.time()
         last = self._auto_crash_last_dispatch.get(thread_id, 0)
-        if now - last < self._AUTO_CRASH_COOLDOWN_S:
+        if now - last < AUTO_CRASH_COOLDOWN_S:
             log.info(
                 "#224: skip auto-crash bundle (cooldown active) thread=%s",
                 thread_id,
@@ -1226,21 +1231,19 @@ class ClaudedBot(commands.Bot):
 
         # Build the bundle. Run in executor so we don't block recovery.
         from .diagnostics import bundle as _bundle_mod
-        import functools as _ft
-        import traceback as _tb
         crash_context = {
             "where": "render_response",
             "thread_id": thread_id,
             "exc_class": type(exc).__name__,
             "exc_message": str(exc)[:500],
             "session_id": getattr(bridge, "session_id", None),
-            "traceback": _tb.format_exception(type(exc), exc, exc.__traceback__),
+            "traceback": traceback.format_exception(type(exc), exc, exc.__traceback__),
         }
         loop = asyncio.get_running_loop()
         try:
             out_path = await loop.run_in_executor(
                 None,
-                _ft.partial(
+                functools.partial(
                     _bundle_mod.generate_bundle,
                     bot=self,
                     generated_by="auto-crash",

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -317,6 +317,8 @@ class ClaudedBot(commands.Bot):
             send_to_claude, pin_message, ratelimit_info,
             debug_toggle, notify_toggle, unbound_fallback_toggle, btw_cmd,
         )
+        # #224 epic: /log dump diagnostic bundle (slash + auto-crash).
+        from .cogs.log_dump import log_group
 
         self.tree.add_command(project_group)
         self.tree.add_command(session_group)
@@ -345,6 +347,8 @@ class ClaudedBot(commands.Bot):
         self.tree.add_command(btw_cmd)
         self.tree.add_command(context_cmd)
         self.tree.add_command(diff_cmd)
+        # #224: /log dump
+        self.tree.add_command(log_group)
         # #185: do NOT sync globally here — historically claudeD synced
         # via both ``tree.sync()`` (global) AND PR-specific per-guild
         # PUT calls, so commands ended up registered in BOTH scopes and
@@ -1111,6 +1115,14 @@ class ClaudedBot(commands.Bot):
                     "exc_class": type(exc).__name__,
                     "traceback": _tb.format_exc(),
                 })
+            # #224 epic Subtask 4: auto-crash bundle dispatch. Rate-limited
+            # per thread (5min cooldown) so a thrash-cycle bug doesn't
+            # spam the channel with bundles.
+            await self._maybe_dispatch_auto_crash_bundle(
+                thread=thread,
+                exc=exc,
+                bridge=bridge,
+            )
             thread_id = getattr(thread, "id", None)
             if thread_id is not None:
                 await self.session_manager.stop_session(thread_id)
@@ -1170,6 +1182,92 @@ class ClaudedBot(commands.Bot):
                     )
 
             await renderer.send_error_with_retry(exc, _on_retry)
+
+    # ------------------------------------------------------------------
+    # #224 epic Subtask 4 — auto-crash bundle dispatch
+    # ------------------------------------------------------------------
+
+    _AUTO_CRASH_COOLDOWN_S = 300  # 5 min
+
+    async def _maybe_dispatch_auto_crash_bundle(
+        self,
+        *,
+        thread: "discord.abc.Messageable | None",
+        exc: BaseException,
+        bridge: "object | None",
+    ) -> None:
+        """#224: generate and upload an auto-crash diagnostic bundle.
+
+        Rate-limited per-thread (``_AUTO_CRASH_COOLDOWN_S``) so a thrash-
+        cycle bug doesn't spam the channel with bundles. Best-effort:
+        any failure inside this method is logged but never re-raised
+        (the caller is already in an ``except Exception`` block recovering
+        from the original crash).
+        """
+        if thread is None:
+            return
+        thread_id = getattr(thread, "id", None)
+        if thread_id is None:
+            return
+
+        # Per-thread rate-limiter (dict of thread_id -> last dispatch ts)
+        if not hasattr(self, "_auto_crash_last_dispatch"):
+            self._auto_crash_last_dispatch: dict[int, float] = {}
+        import time as _time
+        now = _time.time()
+        last = self._auto_crash_last_dispatch.get(thread_id, 0)
+        if now - last < self._AUTO_CRASH_COOLDOWN_S:
+            log.info(
+                "#224: skip auto-crash bundle (cooldown active) thread=%s",
+                thread_id,
+            )
+            return
+        self._auto_crash_last_dispatch[thread_id] = now
+
+        # Build the bundle. Run in executor so we don't block recovery.
+        from .diagnostics import bundle as _bundle_mod
+        import functools as _ft
+        import traceback as _tb
+        crash_context = {
+            "where": "render_response",
+            "thread_id": thread_id,
+            "exc_class": type(exc).__name__,
+            "exc_message": str(exc)[:500],
+            "session_id": getattr(bridge, "session_id", None),
+            "traceback": _tb.format_exception(type(exc), exc, exc.__traceback__),
+        }
+        loop = asyncio.get_running_loop()
+        try:
+            out_path = await loop.run_in_executor(
+                None,
+                _ft.partial(
+                    _bundle_mod.generate_bundle,
+                    bot=self,
+                    generated_by="auto-crash",
+                    crash_context=crash_context,
+                ),
+            )
+        except Exception:
+            log.exception("#224: auto-crash bundle generation failed")
+            return
+
+        try:
+            embed = discord.Embed(
+                title="📋 Diagnostic bundle attached",
+                description=(
+                    "Renderer crashed mid-turn. Send this `.zip` to PM "
+                    "for root-cause analysis.\n\n"
+                    f"Crash: `{type(exc).__name__}`"
+                ),
+                color=COLOR_TOOL_FAILURE,
+            )
+            await safe_send_message(
+                thread,
+                embed=embed,
+                file=discord.File(out_path),
+            )
+        except Exception:
+            log.exception("#224: auto-crash bundle upload failed")
 
 
 # ---------------------------------------------------------------------------

--- a/src/clauded/cogs/log_dump.py
+++ b/src/clauded/cogs/log_dump.py
@@ -1,0 +1,83 @@
+"""/log dump slash command (#224 epic Subtask 3).
+
+Lets an operator hit ``/log dump`` to generate a diagnostic bundle and
+attach the zip to the current thread.
+
+Behavior:
+- defer (work > 3s)
+- run :func:`clauded.diagnostics.bundle.generate_bundle` in a thread
+  executor so the event loop stays responsive
+- followup with the bundle as an attachment
+- on failure: ephemeral error message (no traceback leak)
+"""
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+from pathlib import Path
+
+import discord
+from discord import app_commands
+
+from ..diagnostics import bundle as bundle_mod
+
+log = logging.getLogger("clauded.cogs.log_dump")
+
+
+log_group = app_commands.Group(
+    name="log",
+    description="Diagnostic log tools",
+)
+
+
+@log_group.command(
+    name="dump",
+    description="Generate a diagnostic bundle and attach it to this thread.",
+)
+async def log_dump(interaction: discord.Interaction) -> None:
+    """Build + upload a /log dump bundle to the current thread."""
+    # ``thinking=True`` shows a "Bot is thinking..." indicator while we
+    # work. Bundle generation is mostly IO + small JSON; should be <5s.
+    await interaction.response.defer(thinking=True, ephemeral=False)
+
+    bot = interaction.client
+    # Run bundle assembly in an executor so disk IO + zip compression
+    # don't block the event loop.
+    loop = asyncio.get_running_loop()
+    try:
+        out_path: Path = await loop.run_in_executor(
+            None,
+            functools.partial(
+                bundle_mod.generate_bundle,
+                bot=bot,
+                generated_by="slash",
+            ),
+        )
+    except Exception as exc:
+        log.exception("#224: /log dump bundle generation failed")
+        await interaction.followup.send(
+            f"\u274c Failed to generate bundle: `{type(exc).__name__}`",
+            ephemeral=True,
+        )
+        return
+
+    try:
+        size_kb = round(out_path.stat().st_size / 1024, 1)
+    except OSError:
+        size_kb = -1
+    try:
+        await interaction.followup.send(
+            content=(
+                f"\ud83d\udccb Diagnostic bundle (`{size_kb} KB`) \u2014 "
+                f"send to PM for analysis."
+            ),
+            file=discord.File(out_path),
+        )
+    except Exception as exc:
+        log.exception("#224: /log dump upload failed")
+        await interaction.followup.send(
+            f"\u274c Bundle generated at `{out_path}` but upload failed: "
+            f"`{type(exc).__name__}`",
+            ephemeral=True,
+        )

--- a/src/clauded/diagnostics/__init__.py
+++ b/src/clauded/diagnostics/__init__.py
@@ -1,0 +1,8 @@
+"""#224 diagnostics package — /log dump bundle generator.
+
+Public API:
+
+- :mod:`clauded.diagnostics.redact` — pure-function redaction primitives
+- :mod:`clauded.diagnostics.bundle` — :func:`generate_bundle` end-to-end
+"""
+from . import redact, bundle  # noqa: F401

--- a/src/clauded/diagnostics/bundle.py
+++ b/src/clauded/diagnostics/bundle.py
@@ -208,7 +208,12 @@ def _build_manifest(
     crash_context: dict | None,
     bot: Any,
 ) -> dict:
-    """Assemble the manifest dict per PRD §Bundle Contents."""
+    """Assemble the manifest dict per PRD §Bundle Contents.
+
+    #224 R1 security: ``crash_context['traceback']`` and ``exc_message``
+    can contain ``/Users/<actual>/`` from stack frames or SDK error
+    strings. Apply path redaction before embedding into manifest.
+    """
     now = datetime.now(timezone.utc)
     start_time = getattr(bot, "_start_time", None) if bot is not None else None
     uptime_s = (
@@ -216,6 +221,20 @@ def _build_manifest(
         if isinstance(start_time, (int, float))
         else None
     )
+    # Redact crash_context in place (shallow copy so we don't mutate caller's dict).
+    redacted_crash = None
+    if crash_context is not None:
+        redacted_crash = dict(crash_context)
+        if isinstance(redacted_crash.get("traceback"), list):
+            redacted_crash["traceback"] = [
+                redact.redact_text(str(line)) for line in redacted_crash["traceback"]
+            ]
+        elif isinstance(redacted_crash.get("traceback"), str):
+            redacted_crash["traceback"] = redact.redact_text(redacted_crash["traceback"])
+        if isinstance(redacted_crash.get("exc_message"), str):
+            redacted_crash["exc_message"] = redact.redact_text(
+                redacted_crash["exc_message"]
+            )
     return {
         "bundle_version": 1,
         "generated_at": now.isoformat().replace("+00:00", "Z"),
@@ -224,8 +243,9 @@ def _build_manifest(
         "bot_uptime_s": uptime_s,
         "claude_cli_version": getattr(bot, "_claude_version", "unknown") if bot else "unknown",
         "python_version": sys.version.split()[0],
+        "python_executable": sys.executable,
         "platform": sys.platform,
-        "crash_context": crash_context,
+        "crash_context": redacted_crash,
     }
 
 
@@ -302,13 +322,15 @@ def generate_bundle(
             data = _tail_bytes(log_dir / log_name, byte_limit)
             if not data:
                 continue
-            # Path redaction on text logs (jsonl skipped — would break parsing)
-            if log_name.endswith(".log") or log_name.endswith(".log.1"):
-                try:
-                    text = data.decode("utf-8", errors="replace")
-                    data = redact.redact_text(text).encode("utf-8")
-                except Exception:
-                    pass
+            # #224 R1 security: path-redact ALL log tails, including
+            # jsonl. The earlier "would break JSON parsing" rationale
+            # was wrong: substring substitution of /Users/<actual>/
+            # → /Users/<user>/ is JSON-safe (path strings stay valid).
+            try:
+                text = data.decode("utf-8", errors="replace")
+                data = redact.redact_text(text).encode("utf-8")
+            except Exception:
+                pass
             archive_name = f"logs/{log_name}"
             if log_name == "stream-debug.jsonl":
                 archive_name = "logs/stream-debug.tail.jsonl"
@@ -337,33 +359,20 @@ def generate_bundle(
                 json.dumps(_snapshot_bot_flags(bot), indent=2, ensure_ascii=False),
             )
 
-        # diagnostics/
-        diag = {
-            "python_executable": sys.executable,
-            "sys_path_len": len(sys.path),
-        }
-        zf.writestr(
-            "diagnostics/info.json",
-            json.dumps(diag, indent=2, ensure_ascii=False),
-        )
+        # #224 R1 simplicity: diagnostics/info.json had 2 fields
+        # (python_executable + sys_path_len); merged into manifest.json's
+        # python_version/platform fields above. Directory dropped.
 
     # Write + size-budget check + truncate-on-overrun. Truncation strategy:
-    # re-build with HALF the log byte budget; rare on normal bots.
+    # drop the bulky logs/ entries; keep manifest + state + runtime (the
+    # high-value PM-debug data).
     data = buf.getvalue()
     if len(data) > size_budget:
         log.warning(
-            "#224: bundle %d bytes exceeds budget %d; re-tailing logs",
+            "#224: bundle %d bytes exceeds budget %d; dropping logs/",
             len(data), size_budget,
         )
-        return generate_bundle(
-            bot=bot,
-            data_dir=data_dir,
-            out_dir=out_dir,
-            generated_by=generated_by,
-            crash_context=crash_context,
-            log_dir=log_dir,
-            size_budget=size_budget,
-        ) if False else _emergency_truncate(
+        return _emergency_truncate(
             buf=buf,
             out_path=out_path,
             size_budget=size_budget,

--- a/src/clauded/diagnostics/bundle.py
+++ b/src/clauded/diagnostics/bundle.py
@@ -1,0 +1,396 @@
+"""#224 diagnostics — end-to-end /log dump bundle pipeline.
+
+:func:`generate_bundle` produces a single ``.zip`` file containing
+manifest + redacted env + tailed logs + state snapshots + runtime
+snapshots + diagnostics dumps. Size capped at 8 MB (Discord T0 free
+guild upload limit minus 20% buffer).
+
+Bundle layout (per PRD §Bundle Contents):
+
+::
+
+    clauded-dump-<bot_pid>-<UTC_ISO>.zip
+    ├── manifest.json
+    ├── env-redacted.txt
+    ├── logs/
+    │   ├── clauded.log              (tail)
+    │   └── stream-debug.tail.jsonl  (tail)
+    ├── state/
+    │   ├── projects.json            (path-redacted)
+    │   ├── sessions.json            (path + prompt-redacted)
+    │   └── costs.json               (verbatim)
+    ├── runtime/
+    │   ├── sessions-live.json
+    │   └── bot-flags.json
+    └── diagnostics/
+        └── manifest.txt
+
+This module imports lazily — bundle generation should not pull in
+discord.py at module-load time.
+"""
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import sys
+import time
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from . import redact
+
+log = logging.getLogger("clauded.diagnostics.bundle")
+
+# ---------------------------------------------------------------------------
+# Tunables — PRD §Size budget
+# ---------------------------------------------------------------------------
+
+BUNDLE_SIZE_BUDGET = 8 * 1024 * 1024  # 8 MB (T0 guild limit 10 MB - 20%)
+LOG_TAIL_BYTES = 1 * 1024 * 1024  # 1 MB per tailed log file
+STREAM_DEBUG_TAIL_BYTES = 5 * 1024 * 1024  # 5 MB jsonl tail
+
+# Directory where rotating logs land (matches _logging_setup._LOG_DIR).
+_LOG_DIR = Path.home() / "Library" / "Logs" / "clauded"
+
+
+# ---------------------------------------------------------------------------
+# Log tailing
+# ---------------------------------------------------------------------------
+
+
+def _tail_bytes(path: Path, byte_limit: int) -> bytes:
+    """Return at most ``byte_limit`` bytes from the END of ``path``.
+
+    Used so we don't ship the entire rotating log if it's hours-deep.
+    Returns ``b""`` if the file is missing or can't be read.
+    """
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return b""
+    try:
+        with open(path, "rb") as f:
+            if size > byte_limit:
+                f.seek(size - byte_limit)
+                # Drop the partial first line so the tail is parseable.
+                _ = f.readline()
+            return f.read()
+    except OSError as exc:
+        log.warning("#224: log tail failed for %s: %s", path, exc)
+        return b""
+
+
+# ---------------------------------------------------------------------------
+# Runtime snapshots
+# ---------------------------------------------------------------------------
+
+
+def _snapshot_live_sessions(bot: Any) -> list[dict]:
+    """Best-effort: dump ``bot.session_manager.list_sessions()`` to JSON-safe.
+
+    Each bridge contributes the non-sensitive subset of its state. We
+    deliberately exclude ``system_prompt`` text + ``env`` overlay values
+    (only the keys). Returns ``[]`` if bot/session_manager not available.
+    """
+    out: list[dict] = []
+    sm = getattr(bot, "session_manager", None)
+    if sm is None:
+        return out
+    try:
+        live = sm.list_sessions()
+    except Exception:
+        return out
+    for thread_id, bridge in live.items():
+        try:
+            entry: dict[str, Any] = {
+                "thread_id": thread_id,
+                "project_path": redact.redact_path(
+                    str(getattr(bridge, "project_path", "") or "")
+                ),
+                "session_id": getattr(bridge, "session_id", None),
+                "is_active": bool(getattr(bridge, "is_active", False)),
+                "total_cost": getattr(bridge, "total_cost", 0.0),
+                "num_turns": getattr(bridge, "num_turns", 0),
+                "model_override": getattr(bridge, "_model_override", None),
+                "sdk_model": getattr(bridge, "_sdk_model", None),
+                "permission_mode_override": getattr(bridge, "_permission_mode_override", None),
+                # system_prompt EXPLICITLY redacted (verbatim is sensitive)
+                "system_prompt_marker": redact._digest_marker(
+                    str(getattr(bridge, "system_prompt", "") or "")
+                ),
+            }
+            out.append(entry)
+        except Exception as exc:
+            log.warning("#224: session snapshot failed for thread=%s: %s", thread_id, exc)
+    return out
+
+
+def _snapshot_bot_flags(bot: Any) -> dict:
+    """Dump runtime-toggleable flags from the bot for diagnosis."""
+    keys = [
+        "_debug_logging",
+        "_pre_tool_notifications",
+        "_notify_enabled",
+        "_allow_unbound_fallback",
+        "_start_time",
+        "_claude_version",
+        "_stream_debug_enabled",
+    ]
+    out: dict = {}
+    for k in keys:
+        if hasattr(bot, k):
+            v = getattr(bot, k)
+            try:
+                # JSON-safe coerce (dicts and primitives pass; sets/tuples
+                # get listified; objects fall back to str).
+                if isinstance(v, (str, int, float, bool, list, dict)) or v is None:
+                    out[k] = v
+                elif isinstance(v, (set, tuple)):
+                    out[k] = list(v)
+                else:
+                    out[k] = str(v)
+            except Exception:
+                out[k] = "<unrenderable>"
+    return out
+
+
+# ---------------------------------------------------------------------------
+# State file copy (with redaction per type)
+# ---------------------------------------------------------------------------
+
+
+def _read_state_file(data_dir: Path, name: str) -> tuple[bytes, bool]:
+    """Read ``data_dir/<name>``. Returns (bytes, found).
+
+    ``found=False`` when the file doesn't exist — caller skips writing
+    that entry to the bundle so we don't have phantom empty files.
+    """
+    path = data_dir / name
+    if not path.exists():
+        return (b"", False)
+    try:
+        return (path.read_bytes(), True)
+    except OSError as exc:
+        log.warning("#224: state-file read failed for %s: %s", path, exc)
+        return (b"", False)
+
+
+def _redact_state_file(name: str, raw: bytes) -> bytes:
+    """Apply per-schema redaction to a state file's JSON bytes.
+
+    Falls back to the original bytes if JSON parsing fails (so we still
+    ship SOMETHING even if the file is corrupted).
+    """
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except Exception:
+        return raw
+    if name == "projects.json" and isinstance(data, dict):
+        data = redact.redact_projects_json(data)
+    elif name == "sessions.json" and isinstance(data, dict):
+        data = redact.redact_sessions_json(data)
+    # costs.json + channel_settings.json + guild_roots.json: verbatim
+    return json.dumps(data, indent=2, ensure_ascii=False).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+def _build_manifest(
+    *,
+    generated_by: str,
+    crash_context: dict | None,
+    bot: Any,
+) -> dict:
+    """Assemble the manifest dict per PRD §Bundle Contents."""
+    now = datetime.now(timezone.utc)
+    start_time = getattr(bot, "_start_time", None) if bot is not None else None
+    uptime_s = (
+        round(time.time() - start_time, 1)
+        if isinstance(start_time, (int, float))
+        else None
+    )
+    return {
+        "bundle_version": 1,
+        "generated_at": now.isoformat().replace("+00:00", "Z"),
+        "generated_by": generated_by,
+        "bot_pid": os.getpid(),
+        "bot_uptime_s": uptime_s,
+        "claude_cli_version": getattr(bot, "_claude_version", "unknown") if bot else "unknown",
+        "python_version": sys.version.split()[0],
+        "platform": sys.platform,
+        "crash_context": crash_context,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+def generate_bundle(
+    *,
+    bot: Any = None,
+    data_dir: Path | str = "data",
+    out_dir: Path | str | None = None,
+    generated_by: Literal["slash", "auto-crash"] = "slash",
+    crash_context: dict | None = None,
+    log_dir: Path | None = None,
+    size_budget: int = BUNDLE_SIZE_BUDGET,
+) -> Path:
+    """Build the diagnostic bundle and return the path to the zip.
+
+    Parameters
+    ----------
+    bot
+        ``ClaudedBot`` instance (or any duck-typed equivalent for tests).
+        Only attribute-read; never mutated.
+    data_dir
+        Where the state JSON files live (default ``data/``).
+    out_dir
+        Where to write the bundle zip (default = ``data_dir``).
+    generated_by
+        Triggered path: ``"slash"`` or ``"auto-crash"``. Lands in manifest.
+    crash_context
+        Optional payload for auto-crash: ``{"where": str, "thread_id": int,
+        "exc_class": str, "traceback": str}``. Embedded verbatim in manifest.
+    log_dir
+        Override ``~/Library/Logs/clauded`` (tests use ``tmp_path``).
+    size_budget
+        Hard cap on bundle size. Tail bytes get more aggressive if the
+        initial assembly overshoots.
+    """
+    data_dir = Path(data_dir)
+    out_dir = Path(out_dir) if out_dir is not None else data_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    log_dir = log_dir or _LOG_DIR
+
+    manifest = _build_manifest(
+        generated_by=generated_by, crash_context=crash_context, bot=bot,
+    )
+
+    ts = manifest["generated_at"].replace(":", "").replace("-", "")
+    pid = manifest["bot_pid"]
+    out_path = out_dir / f"clauded-dump-{pid}-{ts}.zip"
+
+    # Assemble in a BytesIO so we can iterate (re-tail) before writing.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        # manifest
+        zf.writestr(
+            "manifest.json",
+            json.dumps(manifest, indent=2, ensure_ascii=False),
+        )
+
+        # env (redacted)
+        env_redacted = redact.redact_env()
+        env_text = "\n".join(f"{k}={v}" for k, v in sorted(env_redacted.items()))
+        zf.writestr("env-redacted.txt", env_text)
+
+        # logs/ (tailed)
+        for log_name, byte_limit in (
+            ("clauded.log", LOG_TAIL_BYTES),
+            ("clauded.log.1", LOG_TAIL_BYTES),
+            ("stream-debug.jsonl", STREAM_DEBUG_TAIL_BYTES),
+        ):
+            data = _tail_bytes(log_dir / log_name, byte_limit)
+            if not data:
+                continue
+            # Path redaction on text logs (jsonl skipped — would break parsing)
+            if log_name.endswith(".log") or log_name.endswith(".log.1"):
+                try:
+                    text = data.decode("utf-8", errors="replace")
+                    data = redact.redact_text(text).encode("utf-8")
+                except Exception:
+                    pass
+            archive_name = f"logs/{log_name}"
+            if log_name == "stream-debug.jsonl":
+                archive_name = "logs/stream-debug.tail.jsonl"
+            zf.writestr(archive_name, data)
+
+        # state/
+        for name in (
+            "projects.json", "sessions.json", "costs.json",
+            "channel_settings.json", "guild_roots.json",
+        ):
+            raw, found = _read_state_file(data_dir, name)
+            if not found:
+                continue
+            zf.writestr(f"state/{name}", _redact_state_file(name, raw))
+
+        # runtime/
+        if bot is not None:
+            zf.writestr(
+                "runtime/sessions-live.json",
+                json.dumps(
+                    _snapshot_live_sessions(bot), indent=2, ensure_ascii=False,
+                ),
+            )
+            zf.writestr(
+                "runtime/bot-flags.json",
+                json.dumps(_snapshot_bot_flags(bot), indent=2, ensure_ascii=False),
+            )
+
+        # diagnostics/
+        diag = {
+            "python_executable": sys.executable,
+            "sys_path_len": len(sys.path),
+        }
+        zf.writestr(
+            "diagnostics/info.json",
+            json.dumps(diag, indent=2, ensure_ascii=False),
+        )
+
+    # Write + size-budget check + truncate-on-overrun. Truncation strategy:
+    # re-build with HALF the log byte budget; rare on normal bots.
+    data = buf.getvalue()
+    if len(data) > size_budget:
+        log.warning(
+            "#224: bundle %d bytes exceeds budget %d; re-tailing logs",
+            len(data), size_budget,
+        )
+        return generate_bundle(
+            bot=bot,
+            data_dir=data_dir,
+            out_dir=out_dir,
+            generated_by=generated_by,
+            crash_context=crash_context,
+            log_dir=log_dir,
+            size_budget=size_budget,
+        ) if False else _emergency_truncate(
+            buf=buf,
+            out_path=out_path,
+            size_budget=size_budget,
+        )
+
+    out_path.write_bytes(data)
+    return out_path
+
+
+def _emergency_truncate(*, buf: io.BytesIO, out_path: Path, size_budget: int) -> Path:
+    """If the assembled bundle exceeds budget, drop log/ entries entirely.
+
+    This is the last-resort path. The manifest + state are kept (they're
+    the highest-value PM-debug data); logs go on a diet.
+    """
+    in_zip = zipfile.ZipFile(io.BytesIO(buf.getvalue()), "r")
+    out_buf = io.BytesIO()
+    with zipfile.ZipFile(out_buf, "w", zipfile.ZIP_DEFLATED, compresslevel=9) as zf:
+        for info in in_zip.infolist():
+            if info.filename.startswith("logs/"):
+                continue  # drop the bulk
+            zf.writestr(info, in_zip.read(info.filename))
+        zf.writestr(
+            "logs/TRUNCATED.txt",
+            f"Logs omitted: bundle exceeded {size_budget} bytes.\n"
+            f"Original size: {len(buf.getvalue())} bytes.\n",
+        )
+    data = out_buf.getvalue()
+    out_path.write_bytes(data)
+    return out_path

--- a/src/clauded/diagnostics/redact.py
+++ b/src/clauded/diagnostics/redact.py
@@ -1,0 +1,199 @@
+"""#224 diagnostics — redaction primitives for the /log dump bundle.
+
+Three responsibilities:
+
+1. :func:`redact_env` — filter ``os.environ`` to an explicit allowlist;
+   replace sensitive keys (TOKEN / SECRET / API_KEY / etc.) with
+   ``len=<N> sha256=<first8>`` provenance markers.
+
+2. :func:`redact_path` — rewrite ``/Users/<actual>/`` (or platform
+   equivalent ``/home/<actual>/``) to ``/Users/<user>/`` so a bundle
+   doesn't leak the operator's account name.
+
+3. :func:`redact_text` — apply path redaction across an arbitrary text
+   blob (used for tail-log redaction).
+
+All functions are pure / synchronous / no IO. The bundle pipeline
+:mod:`clauded.diagnostics.bundle` composes them.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import pwd
+import re
+from typing import Iterable
+
+# ---------------------------------------------------------------------------
+# Env allowlist
+# ---------------------------------------------------------------------------
+
+# Vars that are safe to dump verbatim.
+ENV_ALLOWLIST: frozenset[str] = frozenset({
+    # OS / shell basics
+    "PATH", "HOME", "USER", "LANG", "TZ", "SHELL", "TERM", "PWD",
+    # pytest
+    "PYTEST_CURRENT_TEST",
+    # clauded knobs
+    "CLAUDED_STREAM_DEBUG",
+    "CLAUDED_SESSION_TIMEOUT",
+    "CLAUDED_BRIDGE_STOP_TIMEOUT",
+    "CLAUDED_ALLOW_UNBOUND_FALLBACK",
+    "CLAUDED_TESTBOT_ID",
+    "CLAUDED_PROJECTS_ROOT",
+    # Claude CLI / SDK knobs
+    "CLAUDE_PERMISSION_MODE",
+    "CLAUDE_MODEL",
+})
+
+# Prefix-allowlisted: any var starting with ``LC_`` is locale (LC_ALL,
+# LC_CTYPE, ...) — safe to keep.
+ENV_PREFIX_ALLOWLIST: tuple[str, ...] = ("LC_",)
+
+# Pattern matching var names that MUST be redacted (case-insensitive).
+ENV_SENSITIVE_PATTERN = re.compile(
+    r"TOKEN|SECRET|API_KEY|PASSWORD|PRIVATE_KEY|PASSPHRASE",
+    re.IGNORECASE,
+)
+
+
+def _digest_marker(value: str) -> str:
+    """Return ``len=<N> sha256=<first8>`` provenance for a redacted value."""
+    if not value:
+        return "len=0 sha256=empty"
+    digest = hashlib.sha256(value.encode("utf-8", errors="replace")).hexdigest()
+    return f"len={len(value)} sha256={digest[:8]}"
+
+
+def redact_env(env: dict[str, str] | None = None) -> dict[str, str]:
+    """Return a copy of ``env`` ready to dump to the bundle.
+
+    - Allowlisted keys → verbatim value
+    - Keys matching ``ENV_SENSITIVE_PATTERN`` → ``len=N sha256=...``
+    - Everything else → omitted entirely (keep the bundle small, avoid
+      leaking app-internal env we haven't audited)
+    """
+    if env is None:
+        env = dict(os.environ)
+    out: dict[str, str] = {}
+    for key, value in env.items():
+        # Sensitive override always wins (TOKEN-named keys never leak even
+        # if also somehow allowlisted).
+        if ENV_SENSITIVE_PATTERN.search(key):
+            out[key] = _digest_marker(value)
+            continue
+        if key in ENV_ALLOWLIST:
+            out[key] = value
+            continue
+        if any(key.startswith(p) for p in ENV_PREFIX_ALLOWLIST):
+            out[key] = value
+            continue
+        # Drop silently.
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Path redaction
+# ---------------------------------------------------------------------------
+
+
+def _current_username() -> str:
+    """Best-effort: get the OS account name. Falls back to ``$USER`` or 'user'."""
+    try:
+        return pwd.getpwuid(os.getuid()).pw_name
+    except Exception:
+        return os.environ.get("USER", "user") or "user"
+
+
+def redact_path(path: str, *, username: str | None = None) -> str:
+    """Rewrite ``/Users/<actual>/foo`` → ``/Users/<user>/foo``.
+
+    Handles macOS (``/Users``) + Linux (``/home``) prefixes. Leaves
+    paths that don't contain a per-user component untouched.
+    """
+    if not path:
+        return path
+    if username is None:
+        username = _current_username()
+    # Use re.sub so we catch both ``/Users/alice/`` and ``/Users/alice``
+    # (no trailing) without breaking on the platform's path-sep variants.
+    for prefix in ("/Users/", "/home/"):
+        # Replace ``<prefix><username>/`` and ``<prefix><username>$``
+        path = re.sub(
+            rf"{re.escape(prefix)}{re.escape(username)}(/|$)",
+            rf"{prefix}<user>\1",
+            path,
+        )
+    return path
+
+
+def redact_text(text: str, *, username: str | None = None) -> str:
+    """Apply path redaction across an arbitrary text blob.
+
+    Used for tail-log redaction. Cheap regex sweep; doesn't try to be
+    clever about partial matches or escaped paths.
+    """
+    if not text:
+        return text
+    if username is None:
+        username = _current_username()
+    for prefix in ("/Users/", "/home/"):
+        text = re.sub(
+            rf"{re.escape(prefix)}{re.escape(username)}(/|\b)",
+            rf"{prefix}<user>\1",
+            text,
+        )
+    return text
+
+
+# ---------------------------------------------------------------------------
+# JSON-shape redactors
+# ---------------------------------------------------------------------------
+
+
+def redact_projects_json(data: dict, *, username: str | None = None) -> dict:
+    """Walk a parsed ``projects.json`` dict and redact filesystem paths.
+
+    Schema (per ``project_manager.py``): map of ``binding_id -> {path: ..., ...}``.
+    """
+    if username is None:
+        username = _current_username()
+    out: dict = {}
+    for k, v in data.items():
+        if isinstance(v, dict):
+            redacted_v = dict(v)
+            for path_key in ("path", "system_prompt_path"):
+                if path_key in redacted_v and isinstance(redacted_v[path_key], str):
+                    redacted_v[path_key] = redact_path(redacted_v[path_key], username=username)
+            # add_dirs is list[str]
+            if "add_dirs" in redacted_v and isinstance(redacted_v["add_dirs"], list):
+                redacted_v["add_dirs"] = [
+                    redact_path(p, username=username) if isinstance(p, str) else p
+                    for p in redacted_v["add_dirs"]
+                ]
+            out[k] = redacted_v
+        else:
+            out[k] = v
+    return out
+
+
+def redact_sessions_json(data: dict, *, username: str | None = None) -> dict:
+    """Walk a parsed ``sessions.json`` dict and redact paths + system prompt.
+
+    Schema: map of ``thread_id -> {session_id, project_path, ..., system_prompt?}``.
+    """
+    if username is None:
+        username = _current_username()
+    out: dict = {}
+    for k, v in data.items():
+        if isinstance(v, dict):
+            redacted_v = dict(v)
+            if "project_path" in redacted_v and isinstance(redacted_v["project_path"], str):
+                redacted_v["project_path"] = redact_path(redacted_v["project_path"], username=username)
+            # system_prompt is sensitive — replace verbatim text with provenance marker.
+            if "system_prompt" in redacted_v and isinstance(redacted_v["system_prompt"], str):
+                redacted_v["system_prompt"] = _digest_marker(redacted_v["system_prompt"])
+            out[k] = redacted_v
+        else:
+            out[k] = v
+    return out

--- a/src/clauded/diagnostics/redact.py
+++ b/src/clauded/diagnostics/redact.py
@@ -51,30 +51,52 @@ ENV_ALLOWLIST: frozenset[str] = frozenset({
 ENV_PREFIX_ALLOWLIST: tuple[str, ...] = ("LC_",)
 
 # Pattern matching var names that MUST be redacted (case-insensitive).
+# #224 R1 security: extended beyond the original TOKEN/SECRET/etc. to
+# include OAuth-era names (AUTH, OAUTH, BEARER, JWT, COOKIE, SIGNING)
+# as defense-in-depth. Default-deny on unknown keys still catches them,
+# but pattern-match wins early so any future allowlist addition can't
+# accidentally pass them through.
 ENV_SENSITIVE_PATTERN = re.compile(
-    r"TOKEN|SECRET|API_KEY|PASSWORD|PRIVATE_KEY|PASSPHRASE",
+    r"TOKEN|SECRET|API_KEY|PASSWORD|PRIVATE_KEY|PASSPHRASE"
+    r"|AUTH|OAUTH|BEARER|JWT|COOKIE|SIGNING|CREDENTIAL",
     re.IGNORECASE,
 )
 
 
 def _digest_marker(value: str) -> str:
-    """Return ``len=<N> sha256=<first8>`` provenance for a redacted value."""
+    """Return ``len=<N> sha256=<first8>`` provenance for a redacted value.
+
+    #224 R1 security: for short values (<= 12 chars), the
+    ``len=N sha256=<first8>`` envelope is brute-forceable via rainbow
+    tables (especially 4-digit PINs / short passphrases). Drop the
+    sha256 prefix for short values — length alone still helps PM
+    distinguish "empty" from "set" without leaking guessable hash.
+    """
     if not value:
-        return "len=0 sha256=empty"
+        return "len=0 empty"
+    n = len(value)
+    if n <= 12:
+        # Short — don't ship a hash a rainbow table could invert.
+        return f"len={n} <redacted-short>"
     digest = hashlib.sha256(value.encode("utf-8", errors="replace")).hexdigest()
-    return f"len={len(value)} sha256={digest[:8]}"
+    return f"len={n} sha256={digest[:8]}"
 
 
 def redact_env(env: dict[str, str] | None = None) -> dict[str, str]:
     """Return a copy of ``env`` ready to dump to the bundle.
 
-    - Allowlisted keys → verbatim value
+    - Allowlisted keys → verbatim value (with path redaction on path-shape vars)
     - Keys matching ``ENV_SENSITIVE_PATTERN`` → ``len=N sha256=...``
     - Everything else → omitted entirely (keep the bundle small, avoid
       leaking app-internal env we haven't audited)
+
+    #224 R1 security: ``HOME`` / ``USER`` / ``PWD`` carry the operator's
+    actual username ("/Users/alice", "alice"). Apply the same path-redact
+    treatment to their values so the bundle doesn't leak the account name.
     """
     if env is None:
         env = dict(os.environ)
+    username = _current_username()
     out: dict[str, str] = {}
     for key, value in env.items():
         # Sensitive override always wins (TOKEN-named keys never leak even
@@ -83,7 +105,14 @@ def redact_env(env: dict[str, str] | None = None) -> dict[str, str]:
             out[key] = _digest_marker(value)
             continue
         if key in ENV_ALLOWLIST:
-            out[key] = value
+            # #224 R1 security: path-redact the value for path-shape vars
+            # so the username doesn't leak via env-redacted.txt.
+            if key in ("HOME", "PWD"):
+                out[key] = redact_path(value, username=username)
+            elif key == "USER":
+                out[key] = "<user>" if value == username else value
+            else:
+                out[key] = value
             continue
         if any(key.startswith(p) for p in ENV_PREFIX_ALLOWLIST):
             out[key] = value

--- a/tests/test_log_dump_bundle.py
+++ b/tests/test_log_dump_bundle.py
@@ -1,0 +1,478 @@
+"""#224 — diagnostic bundle / log dump tests.
+
+Coverage:
+- redact_env: allowlist + sensitive-pattern + drop-unknown
+- redact_path: macOS + Linux home prefix rewrite
+- redact_text: multi-occurrence
+- redact_projects_json / redact_sessions_json: schema-aware redaction
+- generate_bundle: zip structure, manifest, no sensitive env leaks,
+  state file redaction, size budget truncation
+- log_dump cog: source-grep on the command shape
+- auto-crash dispatcher: rate-limit + bundle generation
+"""
+from __future__ import annotations
+
+import inspect
+import io
+import json
+import os
+import sys
+import zipfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from clauded.diagnostics import bundle as bundle_mod
+from clauded.diagnostics import redact
+
+
+# ---------------------------------------------------------------------------
+# redact_env
+# ---------------------------------------------------------------------------
+
+
+def test_redact_env_keeps_allowlisted():
+    env = {"PATH": "/usr/bin", "HOME": "/Users/test", "LANG": "en_US.UTF-8"}
+    out = redact.redact_env(env)
+    assert out["PATH"] == "/usr/bin"
+    assert out["HOME"] == "/Users/test"
+    assert out["LANG"] == "en_US.UTF-8"
+
+
+def test_redact_env_keeps_lc_prefix():
+    out = redact.redact_env({"LC_ALL": "C", "LC_CTYPE": "UTF-8"})
+    assert out["LC_ALL"] == "C"
+    assert out["LC_CTYPE"] == "UTF-8"
+
+
+def test_redact_env_drops_unknown_keys():
+    """Unknown keys are silently dropped — keeps bundle small + leak-safe."""
+    out = redact.redact_env({"MY_RANDOM_VAR": "value", "PATH": "/x"})
+    assert "MY_RANDOM_VAR" not in out
+    assert "PATH" in out
+
+
+@pytest.mark.parametrize("key,value", [
+    ("DISCORD_BOT_TOKEN", "actual-token-string-here-32chars"),
+    ("ANTHROPIC_API_KEY", "sk-ant-abc123"),
+    ("GITHUB_TOKEN", "ghp_xxx"),
+    ("MY_SECRET_KEY", "redacted"),
+    ("APP_PASSWORD", "redacted"),
+    ("PRIVATE_KEY_PEM", "-----BEGIN..."),
+])
+def test_redact_env_redacts_sensitive_pattern(key, value):
+    """Any key matching TOKEN/SECRET/API_KEY/PASSWORD/PRIVATE_KEY/PASSPHRASE
+    gets replaced with ``len=N sha256=...`` marker."""
+    out = redact.redact_env({key: value})
+    assert key in out
+    assert value not in out[key], f"actual value leaked for {key}: {out[key]!r}"
+    assert out[key].startswith("len=")
+    assert "sha256=" in out[key]
+
+
+def test_redact_env_sensitive_wins_over_allowlist():
+    """Even if a sensitive-pattern key were allowlisted, redaction wins.
+
+    Today the allowlist doesn't include anything matching the sensitive
+    pattern, but pin the precedence so a future allowlist addition can't
+    accidentally leak a token.
+    """
+    env = {"PATH_TOKEN": "totally-not-a-secret"}
+    out = redact.redact_env(env)
+    if "PATH_TOKEN" in out:
+        assert "totally-not-a-secret" not in out["PATH_TOKEN"]
+
+
+def test_redact_env_handles_empty():
+    assert redact.redact_env({}) == {}
+
+
+# ---------------------------------------------------------------------------
+# redact_path
+# ---------------------------------------------------------------------------
+
+
+def test_redact_path_macos():
+    out = redact.redact_path("/Users/alice/projects/foo", username="alice")
+    assert out == "/Users/<user>/projects/foo"
+
+
+def test_redact_path_linux():
+    out = redact.redact_path("/home/bob/src/main.py", username="bob")
+    assert out == "/home/<user>/src/main.py"
+
+
+def test_redact_path_no_match():
+    """Paths not under /Users/<user>/ or /home/<user>/ pass through."""
+    assert redact.redact_path("/tmp/foo", username="bob") == "/tmp/foo"
+    assert redact.redact_path("/var/log/x", username="bob") == "/var/log/x"
+    assert redact.redact_path("relative/path.png", username="bob") == "relative/path.png"
+
+
+def test_redact_path_only_target_username():
+    """Should NOT redact other users' paths (only the operator's)."""
+    out = redact.redact_path("/Users/somebody-else/secret", username="alice")
+    assert out == "/Users/somebody-else/secret"
+
+
+# ---------------------------------------------------------------------------
+# redact_text
+# ---------------------------------------------------------------------------
+
+
+def test_redact_text_multi_occurrence():
+    txt = (
+        "Working in /Users/alice/proj\n"
+        "Wrote to /Users/alice/proj/a.txt\n"
+        "Done.\n"
+    )
+    out = redact.redact_text(txt, username="alice")
+    assert "/Users/alice" not in out
+    assert out.count("/Users/<user>") == 2
+
+
+# ---------------------------------------------------------------------------
+# JSON-shape redactors
+# ---------------------------------------------------------------------------
+
+
+def test_redact_projects_json_rewrites_paths():
+    data = {
+        "1234": {
+            "path": "/Users/alice/repo",
+            "add_dirs": ["/Users/alice/extra", "/tmp/scratch"],
+        },
+    }
+    out = redact.redact_projects_json(data, username="alice")
+    assert out["1234"]["path"] == "/Users/<user>/repo"
+    assert out["1234"]["add_dirs"] == ["/Users/<user>/extra", "/tmp/scratch"]
+
+
+def test_redact_sessions_json_redacts_system_prompt():
+    data = {
+        "999": {
+            "session_id": "abc-123",
+            "project_path": "/Users/alice/repo",
+            "system_prompt": "secret instructions here",
+        },
+    }
+    out = redact.redact_sessions_json(data, username="alice")
+    assert out["999"]["project_path"] == "/Users/<user>/repo"
+    assert "secret instructions" not in out["999"]["system_prompt"]
+    assert out["999"]["system_prompt"].startswith("len=")
+    # session_id is verbatim (not sensitive — it's a server-side ID)
+    assert out["999"]["session_id"] == "abc-123"
+
+
+# ---------------------------------------------------------------------------
+# bundle.generate_bundle — pipeline integration
+# ---------------------------------------------------------------------------
+
+
+def _build_bot_stub(*, has_session_manager=False):
+    """Minimal duck-typed bot for bundle generation."""
+    import time
+    bot = MagicMock()
+    bot._start_time = time.time() - 60  # 60s uptime
+    bot._claude_version = "1.0.0-test"
+    bot._debug_logging = False
+    bot._pre_tool_notifications = True
+    bot._notify_enabled = {}
+    bot._allow_unbound_fallback = False
+    bot._stream_debug_enabled = False
+    if has_session_manager:
+        bridge = MagicMock()
+        bridge.project_path = "/Users/alice/repo"
+        bridge.session_id = "sess-xyz"
+        bridge.is_active = True
+        bridge.total_cost = 0.05
+        bridge.num_turns = 3
+        bridge._sdk_model = "claude-sonnet-4"
+        bridge._model_override = None
+        bridge._permission_mode_override = None
+        bridge.system_prompt = "you are a helpful assistant"
+        bot.session_manager.list_sessions = MagicMock(return_value={42: bridge})
+    else:
+        bot.session_manager = None
+    return bot
+
+
+def test_generate_bundle_produces_zip(tmp_path):
+    """Smoke: bundle is a parseable .zip with the expected entries."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    # Plant a state file so we have something to redact
+    (data_dir / "projects.json").write_text(
+        json.dumps({"1": {"path": "/Users/alice/repo"}})
+    )
+    out_path = bundle_mod.generate_bundle(
+        data_dir=data_dir,
+        out_dir=tmp_path,
+        log_dir=tmp_path / "fake-logs",  # missing → tail logs absent
+    )
+    assert out_path.exists()
+    with zipfile.ZipFile(out_path) as z:
+        names = set(z.namelist())
+    assert "manifest.json" in names
+    assert "env-redacted.txt" in names
+    assert "state/projects.json" in names
+    assert "diagnostics/info.json" in names
+
+
+def test_generate_bundle_manifest_shape(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    out_path = bundle_mod.generate_bundle(
+        data_dir=data_dir,
+        out_dir=tmp_path,
+        log_dir=tmp_path / "x",
+        generated_by="slash",
+    )
+    with zipfile.ZipFile(out_path) as z:
+        manifest = json.loads(z.read("manifest.json"))
+    assert manifest["bundle_version"] == 1
+    assert manifest["generated_by"] == "slash"
+    assert manifest["bot_pid"] == os.getpid()
+    assert isinstance(manifest["generated_at"], str)
+    assert manifest["generated_at"].endswith("Z")
+
+
+def test_generate_bundle_no_token_leaks(tmp_path, monkeypatch):
+    """#224 AC3: DISCORD_BOT_TOKEN / ANTHROPIC_API_KEY must NOT appear
+    anywhere in the bundle."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "supersecret-discord-bot-token-xxx")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-totally-secret")
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    out_path = bundle_mod.generate_bundle(
+        data_dir=data_dir,
+        out_dir=tmp_path,
+        log_dir=tmp_path / "x",
+    )
+
+    # Read every entry's bytes and grep for the secrets
+    with zipfile.ZipFile(out_path) as z:
+        for name in z.namelist():
+            data = z.read(name)
+            assert b"supersecret-discord-bot-token-xxx" not in data, (
+                f"#224 AC3: DISCORD_BOT_TOKEN leaked into {name}"
+            )
+            assert b"sk-ant-totally-secret" not in data, (
+                f"#224 AC3: ANTHROPIC_API_KEY leaked into {name}"
+            )
+
+
+def test_generate_bundle_redacts_user_paths(tmp_path, monkeypatch):
+    """#224 AC4: /Users/<actual> must not appear in state/runtime/."""
+    monkeypatch.setattr(redact, "_current_username", lambda: "alice")
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "projects.json").write_text(
+        json.dumps({"1": {"path": "/Users/alice/secret-project"}})
+    )
+    out_path = bundle_mod.generate_bundle(
+        data_dir=data_dir,
+        out_dir=tmp_path,
+        log_dir=tmp_path / "x",
+    )
+    with zipfile.ZipFile(out_path) as z:
+        proj = z.read("state/projects.json")
+    assert b"/Users/alice/" not in proj, (
+        "#224 AC4: /Users/<actual>/ leaked into state/projects.json"
+    )
+    assert b"/Users/<user>" in proj
+
+
+def test_generate_bundle_runtime_snapshot_when_bot_present(tmp_path):
+    bot = _build_bot_stub(has_session_manager=True)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    out_path = bundle_mod.generate_bundle(
+        bot=bot,
+        data_dir=data_dir,
+        out_dir=tmp_path,
+        log_dir=tmp_path / "x",
+    )
+    with zipfile.ZipFile(out_path) as z:
+        names = set(z.namelist())
+        sessions = json.loads(z.read("runtime/sessions-live.json"))
+        flags = json.loads(z.read("runtime/bot-flags.json"))
+    assert "runtime/sessions-live.json" in names
+    assert "runtime/bot-flags.json" in names
+    assert len(sessions) == 1
+    s = sessions[0]
+    assert s["session_id"] == "sess-xyz"
+    assert s["thread_id"] == 42
+    # system_prompt verbatim is sensitive — must be a digest marker, not the text
+    assert "you are a helpful assistant" not in json.dumps(s)
+    assert s["system_prompt_marker"].startswith("len=")
+    # Bot flags landed
+    assert flags["_pre_tool_notifications"] is True
+
+
+def test_generate_bundle_omits_missing_state_files(tmp_path):
+    """Missing state files don't produce phantom empty entries."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    # Only projects.json plant
+    (data_dir / "projects.json").write_text("{}")
+    out_path = bundle_mod.generate_bundle(
+        data_dir=data_dir,
+        out_dir=tmp_path,
+        log_dir=tmp_path / "x",
+    )
+    with zipfile.ZipFile(out_path) as z:
+        names = set(z.namelist())
+    assert "state/projects.json" in names
+    # Other state files absent (not phantom-empty)
+    assert "state/sessions.json" not in names
+    assert "state/costs.json" not in names
+
+
+def test_generate_bundle_tails_logs(tmp_path, monkeypatch):
+    """Logs are tailed (not full-copied) when present."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    big_log = log_dir / "clauded.log"
+    big_log.write_text("X" * 50)  # tiny — tail returns whole file
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    out_path = bundle_mod.generate_bundle(
+        data_dir=data_dir,
+        out_dir=tmp_path,
+        log_dir=log_dir,
+    )
+    with zipfile.ZipFile(out_path) as z:
+        names = set(z.namelist())
+        clauded_log_bytes = z.read("logs/clauded.log")
+    assert "logs/clauded.log" in names
+    assert len(clauded_log_bytes) <= 50
+
+
+# ---------------------------------------------------------------------------
+# /log dump cog
+# ---------------------------------------------------------------------------
+
+
+def test_log_dump_cog_registered_at_module_level():
+    """The cog exposes a Group named 'log' with a 'dump' subcommand."""
+    from clauded.cogs.log_dump import log_group
+
+    assert log_group.name == "log"
+    sub_names = {c.name for c in log_group.commands}
+    assert "dump" in sub_names
+
+
+def test_log_dump_uses_executor():
+    """Bundle generation runs in an executor (not the event loop)."""
+    from clauded.cogs import log_dump as cog
+    src = inspect.getsource(cog)
+    assert "run_in_executor" in src
+    assert "bundle_mod.generate_bundle" in src or "generate_bundle" in src
+
+
+def test_log_dump_defers_interaction():
+    """``response.defer`` is called (bundle gen takes >3s)."""
+    from clauded.cogs import log_dump as cog
+    src = inspect.getsource(cog)
+    assert "interaction.response.defer" in src
+
+
+# ---------------------------------------------------------------------------
+# Auto-crash dispatcher
+# ---------------------------------------------------------------------------
+
+
+def test_auto_crash_method_exists_on_bot():
+    """ClaudedBot._maybe_dispatch_auto_crash_bundle is defined."""
+    from clauded.bot import ClaudedBot
+    assert hasattr(ClaudedBot, "_maybe_dispatch_auto_crash_bundle")
+
+
+def test_auto_crash_called_from_render_with_retry():
+    """The crash branch of _render_with_retry calls the dispatcher."""
+    from clauded.bot import ClaudedBot
+    src = inspect.getsource(ClaudedBot._render_with_retry)
+    assert "_maybe_dispatch_auto_crash_bundle" in src, (
+        "#224: _render_with_retry must call _maybe_dispatch_auto_crash_bundle "
+        "on the crash branch"
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_crash_rate_limit():
+    """Same thread within cooldown → second call is skipped (no bundle)."""
+    from clauded.bot import ClaudedBot
+    import time as _time
+
+    bot = ClaudedBot.__new__(ClaudedBot)
+    bot._auto_crash_last_dispatch = {42: _time.time()}  # just dispatched
+
+    thread = MagicMock()
+    thread.id = 42
+    exc = RuntimeError("test")
+
+    # Patch generate_bundle to detect if it was called
+    called = {"n": 0}
+    from clauded.diagnostics import bundle as bundle_mod_ref
+    orig = bundle_mod_ref.generate_bundle
+    def _spy(*a, **kw):
+        called["n"] += 1
+        return Path("/dev/null")
+    bundle_mod_ref.generate_bundle = _spy
+    try:
+        await bot._maybe_dispatch_auto_crash_bundle(thread=thread, exc=exc, bridge=None)
+    finally:
+        bundle_mod_ref.generate_bundle = orig
+    assert called["n"] == 0, "rate-limited bundle must not be generated"
+
+
+@pytest.mark.asyncio
+async def test_auto_crash_dispatches_when_cooldown_expired(tmp_path, monkeypatch):
+    """When cooldown expired, bundle is generated + uploaded."""
+    from clauded.bot import ClaudedBot
+    bot = ClaudedBot.__new__(ClaudedBot)
+    # No prior dispatch
+    bot._auto_crash_last_dispatch = {}
+    bot.session_manager = None
+    bot._start_time = 0
+    bot._claude_version = "test"
+
+    # Stub generate_bundle to return a tmp file
+    fake_zip = tmp_path / "fake.zip"
+    fake_zip.write_bytes(b"PK\x03\x04fake")
+
+    from clauded.diagnostics import bundle as bundle_mod_ref
+    orig = bundle_mod_ref.generate_bundle
+    captured = {}
+    def _spy(*a, **kw):
+        captured["called"] = True
+        captured["kwargs"] = kw
+        return fake_zip
+    bundle_mod_ref.generate_bundle = _spy
+
+    # Stub safe_send_message
+    from clauded import bot as bot_mod
+    orig_send = bot_mod.safe_send_message
+    sent_args = []
+    async def _send_spy(target, **kwargs):
+        sent_args.append((target, kwargs))
+        return MagicMock()
+    bot_mod.safe_send_message = _send_spy
+
+    thread = MagicMock()
+    thread.id = 99
+    try:
+        await bot._maybe_dispatch_auto_crash_bundle(
+            thread=thread, exc=RuntimeError("planted"), bridge=None,
+        )
+    finally:
+        bundle_mod_ref.generate_bundle = orig
+        bot_mod.safe_send_message = orig_send
+
+    assert captured.get("called"), "generate_bundle must be called"
+    assert captured["kwargs"]["generated_by"] == "auto-crash"
+    assert sent_args, "bundle must be uploaded to the thread"
+    assert sent_args[0][0] is thread

--- a/tests/test_log_dump_bundle.py
+++ b/tests/test_log_dump_bundle.py
@@ -57,18 +57,21 @@ def test_redact_env_drops_unknown_keys():
     ("DISCORD_BOT_TOKEN", "actual-token-string-here-32chars"),
     ("ANTHROPIC_API_KEY", "sk-ant-abc123"),
     ("GITHUB_TOKEN", "ghp_xxx"),
-    ("MY_SECRET_KEY", "redacted"),
-    ("APP_PASSWORD", "redacted"),
-    ("PRIVATE_KEY_PEM", "-----BEGIN..."),
+    ("MY_SECRET_KEY", "hush-value-x"),
+    ("APP_PASSWORD", "hush-value-y"),
+    ("PRIVATE_KEY_PEM", "-----BEGIN-this-is-a-long-pem-string-here-32+chars"),
 ])
 def test_redact_env_redacts_sensitive_pattern(key, value):
     """Any key matching TOKEN/SECRET/API_KEY/PASSWORD/PRIVATE_KEY/PASSPHRASE
-    gets replaced with ``len=N sha256=...`` marker."""
+    gets replaced with a redaction marker (long values: ``len=N sha256=<first8>``;
+    short values: ``len=N <redacted-short>`` per R1 security finding).
+    """
     out = redact.redact_env({key: value})
     assert key in out
     assert value not in out[key], f"actual value leaked for {key}: {out[key]!r}"
     assert out[key].startswith("len=")
-    assert "sha256=" in out[key]
+    # Either a hash (long values) or the explicit short marker.
+    assert "sha256=" in out[key] or "<redacted-short>" in out[key]
 
 
 def test_redact_env_sensitive_wins_over_allowlist():
@@ -217,7 +220,9 @@ def test_generate_bundle_produces_zip(tmp_path):
     assert "manifest.json" in names
     assert "env-redacted.txt" in names
     assert "state/projects.json" in names
-    assert "diagnostics/info.json" in names
+    # #224 R1 simplicity: diagnostics/info.json merged into manifest;
+    # no separate diagnostics/ directory.
+    assert "diagnostics/info.json" not in names
 
 
 def test_generate_bundle_manifest_shape(tmp_path):
@@ -236,6 +241,9 @@ def test_generate_bundle_manifest_shape(tmp_path):
     assert manifest["bot_pid"] == os.getpid()
     assert isinstance(manifest["generated_at"], str)
     assert manifest["generated_at"].endswith("Z")
+    # #224 R1 simplicity: diagnostics/info.json merged into manifest.
+    assert "python_executable" in manifest
+    assert manifest["python_executable"] == sys.executable
 
 
 def test_generate_bundle_no_token_leaks(tmp_path, monkeypatch):
@@ -476,3 +484,238 @@ async def test_auto_crash_dispatches_when_cooldown_expired(tmp_path, monkeypatch
     assert captured["kwargs"]["generated_by"] == "auto-crash"
     assert sent_args, "bundle must be uploaded to the thread"
     assert sent_args[0][0] is thread
+
+
+# ---------------------------------------------------------------------------
+# R1 retrofits
+# ---------------------------------------------------------------------------
+
+
+def test_r1_env_redacts_home_value(monkeypatch):
+    """R1 security: HOME / PWD values get path-redacted so the operator's
+    username doesn't leak via env-redacted.txt."""
+    monkeypatch.setattr(redact, "_current_username", lambda: "alice")
+    out = redact.redact_env({
+        "HOME": "/Users/alice",
+        "PWD": "/Users/alice/proj",
+        "USER": "alice",
+        "PATH": "/usr/bin",
+    })
+    assert out["HOME"] == "/Users/<user>"
+    assert out["PWD"] == "/Users/<user>/proj"
+    assert out["USER"] == "<user>"
+    assert out["PATH"] == "/usr/bin"  # unchanged
+
+
+def test_r1_env_user_passes_other_users():
+    """If USER somehow equals an OTHER user (not the current process
+    owner), don't redact — it might be useful debug info."""
+    out = redact.redact_env({"USER": "claude-runner"})
+    assert out["USER"] == "claude-runner"
+
+
+def test_r1_env_extended_sensitive_pattern():
+    """R1 security: pattern extended to AUTH/OAUTH/BEARER/JWT/COOKIE/SIGNING/CREDENTIAL."""
+    for key, val in [
+        ("AUTH_TOKEN_X", "secret"),  # AUTH AND TOKEN — either should match
+        ("OAUTH_CLIENT", "secret"),
+        ("BEARER_TKN", "secret"),
+        ("JWT_KEY", "secret"),  # JWT AND KEY — either should match
+        ("COOKIE_VAL", "secret"),
+        ("SIGNING_KEY_PROD", "secret"),
+        ("CREDENTIALS_FILE", "secret"),
+    ]:
+        out = redact.redact_env({key: val})
+        assert key in out
+        assert "secret" not in out[key], f"{key} leaked: {out[key]!r}"
+
+
+def test_r1_digest_marker_short_value_no_hash():
+    """R1 security: short values get `<redacted-short>` instead of brute-forceable hash."""
+    out = redact._digest_marker("1234")  # 4-char PIN
+    assert "sha256" not in out
+    assert "<redacted-short>" in out
+    assert "len=4" in out
+
+
+def test_r1_digest_marker_long_value_keeps_hash():
+    """Long values keep the hash — useful for fingerprinting without brute-force risk."""
+    out = redact._digest_marker("this-is-a-very-long-token-string-32+chars")
+    assert "sha256=" in out
+    assert "len=" in out
+
+
+def test_r1_bundle_jsonl_tail_path_redacted(tmp_path, monkeypatch):
+    """R1 security: stream-debug.jsonl tail now also gets path-redacted.
+
+    Previous code skipped jsonl with wrong rationale ("would break parsing").
+    """
+    monkeypatch.setattr(redact, "_current_username", lambda: "alice")
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    jsonl = log_dir / "stream-debug.jsonl"
+    jsonl.write_text(
+        '{"type":"ControlPlane","path":"/Users/alice/repo/foo"}\n'
+        '{"type":"DiscordHTTPRetry","url":"/Users/alice/scratch"}\n'
+    )
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    out_path = bundle_mod.generate_bundle(
+        data_dir=data_dir,
+        out_dir=tmp_path,
+        log_dir=log_dir,
+    )
+    with zipfile.ZipFile(out_path) as z:
+        jsonl_data = z.read("logs/stream-debug.tail.jsonl")
+    assert b"/Users/alice" not in jsonl_data, (
+        "#224 R1 security: jsonl tail must be path-redacted"
+    )
+    assert b"/Users/<user>" in jsonl_data
+
+
+def test_r1_bundle_crash_context_traceback_redacted(tmp_path, monkeypatch):
+    """R1 security: crash traceback in manifest is path-redacted."""
+    monkeypatch.setattr(redact, "_current_username", lambda: "alice")
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    crash_context = {
+        "where": "render_response",
+        "thread_id": 42,
+        "exc_class": "RuntimeError",
+        "exc_message": "failed in /Users/alice/proj/foo.py line 99",
+        "traceback": [
+            'File "/Users/alice/.venv/lib/foo.py", line 1, in bar\n',
+            'File "/Users/alice/repo/main.py", line 2, in baz\n',
+        ],
+    }
+    out_path = bundle_mod.generate_bundle(
+        data_dir=data_dir,
+        out_dir=tmp_path,
+        log_dir=tmp_path / "x",
+        generated_by="auto-crash",
+        crash_context=crash_context,
+    )
+    with zipfile.ZipFile(out_path) as z:
+        manifest = json.loads(z.read("manifest.json"))
+    tb_text = " ".join(manifest["crash_context"]["traceback"])
+    assert "/Users/alice" not in tb_text
+    assert "/Users/<user>" in tb_text
+    assert "/Users/alice" not in manifest["crash_context"]["exc_message"]
+
+
+def test_r1_bundle_emergency_truncate_drops_logs(tmp_path):
+    """R1 tester: AC5 size budget overflow → logs/ dropped, manifest+state kept."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    # Plant a giant log of HIGH-ENTROPY data so DEFLATE can't compress it
+    # below the budget. 200 KB of compressed-resistant bytes.
+    import secrets
+    big = log_dir / "clauded.log"
+    big.write_bytes(secrets.token_bytes(200 * 1024))
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "projects.json").write_text(json.dumps({"1": {"path": "/x"}}))
+    # Force overrun with a tiny budget
+    out_path = bundle_mod.generate_bundle(
+        data_dir=data_dir,
+        out_dir=tmp_path,
+        log_dir=log_dir,
+        size_budget=5 * 1024,  # 5 KB
+    )
+    with zipfile.ZipFile(out_path) as z:
+        names = set(z.namelist())
+    assert "logs/clauded.log" not in names, (
+        "#224 R1 tester: emergency truncate must drop logs/ entries"
+    )
+    assert "logs/TRUNCATED.txt" in names
+    # Manifest + state preserved
+    assert "manifest.json" in names
+    assert "state/projects.json" in names
+
+
+def test_r1_bundle_no_diagnostics_directory(tmp_path):
+    """R1 simplicity: 4 dirs → 3 dirs (diagnostics/ merged into manifest)."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    out_path = bundle_mod.generate_bundle(
+        data_dir=data_dir,
+        out_dir=tmp_path,
+        log_dir=tmp_path / "x",
+    )
+    with zipfile.ZipFile(out_path) as z:
+        dirs = {n.split("/")[0] for n in z.namelist() if "/" in n}
+    assert "diagnostics" not in dirs
+
+
+def test_r1_module_level_auto_crash_cooldown():
+    """R1 simplicity: cooldown is now module-level, not class-attr."""
+    from clauded import bot as bot_mod
+    assert hasattr(bot_mod, "AUTO_CRASH_COOLDOWN_S")
+    assert bot_mod.AUTO_CRASH_COOLDOWN_S == 300
+
+
+def test_r1_stream_debug_jsonl_renamed_in_archive(tmp_path):
+    """R1 tester: stream-debug.jsonl is archived as stream-debug.tail.jsonl."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "stream-debug.jsonl").write_text('{"a":1}\n')
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    out_path = bundle_mod.generate_bundle(
+        data_dir=data_dir,
+        out_dir=tmp_path,
+        log_dir=log_dir,
+    )
+    with zipfile.ZipFile(out_path) as z:
+        names = set(z.namelist())
+    assert "logs/stream-debug.tail.jsonl" in names
+    assert "logs/stream-debug.jsonl" not in names
+
+
+def test_r1_bot_flags_includes_runtime_overrides():
+    """R1 tester: AC7 — runtime sessions snapshot must include model_override etc."""
+    bot = _build_bot_stub(has_session_manager=True)
+    snap = bundle_mod._snapshot_live_sessions(bot)
+    assert len(snap) == 1
+    s = snap[0]
+    # AC7 needs PM to see the override matrix
+    assert "model_override" in s
+    assert "sdk_model" in s
+    assert "permission_mode_override" in s
+
+
+@pytest.mark.asyncio
+async def test_r1_log_dump_cog_runtime_dispatch(tmp_path, monkeypatch):
+    """R1 tester: real-runtime test for the /log dump command.
+
+    Drive the callback with a mock interaction; assert (a) defer fires,
+    (b) generate_bundle invoked, (c) followup with file attachment.
+    """
+    from clauded.cogs.log_dump import log_dump
+
+    # Stub the underlying coroutine: log_dump is an app_commands.Command,
+    # find its callback (callback or _callback).
+    callback = getattr(log_dump, "callback", None) or log_dump._callback
+
+    # Patch bundle generation to a tmp file
+    fake_zip = tmp_path / "fake.zip"
+    fake_zip.write_bytes(b"PK\x03\x04")
+    from clauded.diagnostics import bundle as _bundle_mod
+    orig = _bundle_mod.generate_bundle
+    _bundle_mod.generate_bundle = lambda **kw: fake_zip
+    try:
+        interaction = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup.send = AsyncMock()
+        interaction.client = MagicMock()
+
+        await callback(interaction)
+
+        # AC1: defer fired
+        interaction.response.defer.assert_called_once()
+        # AC1: followup with file
+        interaction.followup.send.assert_called_once()
+        kwargs = interaction.followup.send.call_args.kwargs
+        assert "file" in kwargs
+    finally:
+        _bundle_mod.generate_bundle = orig


### PR DESCRIPTION
Closes #224 (P1 epic).

## What

One-click `/log dump` slash command + auto-crash bundle dispatcher. Produces a redacted `.zip` with manifest + env + logs + state + runtime snapshots + diagnostics — everything PM needs to triage a bug from a single attachment.

## 5 subtasks all in this PR (coupling is tight)

1. **Bundle pipeline** — `diagnostics/bundle.py` assembles 8MB-budgeted zip
2. **Redaction** — `diagnostics/redact.py` (env allowlist + sensitive-pattern + path rewrite + JSON-shape redactors)
3. **`/log dump` cog** — defer + executor + upload
4. **Auto-crash hook** — `_render_with_retry` crash branch dispatches bundle to thread (5-min cooldown per thread)
5. **Tests +32** — including grep-style "no token leak / no `/Users/<actual>/` leak" pins

## Security promise

DISCORD_BOT_TOKEN / ANTHROPIC_API_KEY / SECRET / API_KEY pattern keys → `len=N sha256=<first8>` digest markers. Unknown env vars dropped. `/Users/<actual>/` rewritten to `/Users/<user>/`. `system_prompt` verbatim → digest marker.

Mental-revert pins on AC3 + AC4 — removing redaction breaks tests.

## Companion to #223

PR-A (#230) + PR-B (#231) closed the diagnostic data sources. This epic consumes them.

**933 / 0** (was 901; +32).

## Status

🚧 Draft pending R1 (epic deserves security + simplicity + architect perspectives).
