### PR TITLE
fix(launchagent): #232 round 2 — ProcessType=Interactive (empty was insufficient)

### DIFF
--- a/docs/prd/v1.18-fix-launchagent-process-type.md
+++ b/docs/prd/v1.18-fix-launchagent-process-type.md
@@ -103,3 +103,35 @@ Manager direct (1-line removal × 3 files; ops-level change, no logic).
   from launchd defaults; Standard = "let the kernel scheduler decide".
 - Template / installed plist drift: a future install script run with
   unchanged template would re-install correctly post-fix.
+
+---
+
+## Round 2 (2026-05-18 ~20:00 CST) — Approach A insufficient
+
+**Post-merge observation**: `because inefficient` SIGKILL events still
+fired after PR #233:
+
+```
+17:04:59 (pre-fix baseline, accepted)
+17:29:31 (?)
+18:18:01 ← post-fix, pid 3709
+19:33:19 ← post-fix, pid 10695
+```
+
+`launchctl print` showed `spawn type = daemon (3)` even with
+`ProcessType` key absent — empty `ProcessType` falls into launchd's
+default daemon throttle path (per `launchd.plist(5)`), NOT into a
+"resource-unbounded Standard" path as we'd hoped.
+
+**Fix (round 2)**: switch to **Approach B** (`ProcessType=Interactive`).
+The "would over-prioritize on user's machine" concern from the original
+DDD was theoretical; the actual measured impact of `Background` /
+empty / Standard was repeated SIGKILL every 15-25 min. `Interactive`
+declares the service is foreground/interactive — launchd skips the
+resource judgement entirely.
+
+Post round-2 reload:
+
+- `spawn type = interactive (4)` (was `daemon (3)`)
+- `ProcessType => Interactive` in `plutil -p`
+- AC4 (60+ min clean log) still pending observation

--- a/scripts/com.hxy.clauded.plist.template
+++ b/scripts/com.hxy.clauded.plist.template
@@ -21,6 +21,15 @@
          mirrored every Python log line (Python's stderr handler in bot.py +
          launchd's redirect both wrote the same content). RotatingFileHandler
          at ~/Library/Logs/clauded/clauded.log is now the canonical log. -->
+    <key>ProcessType</key><string>Interactive</string>
+    <!-- #232 follow-up (round 2): empty ProcessType still trips
+         launchd's default "light resource limits + throttling" for
+         daemon-spawned services (per launchd.plist(5)). The
+         "because inefficient" SIGKILL kept happening even with the
+         key removed. `Interactive` declares this is a foreground
+         interactive service — launchd skips the resource judgement
+         entirely. See docs/prd/v1.18-fix-launchagent-process-type.md
+         for the original investigation. -->
     <!-- #232 removed: ``ProcessType=Background`` told launchd this is a
          low-priority occasional task, so it SIGKILL'd us every 15-25 min
          with the "because inefficient" reason. clauded is a long-running

--- a/tests/test_launchagent_plist.py
+++ b/tests/test_launchagent_plist.py
@@ -23,12 +23,18 @@ def _render_template() -> dict:
 
 
 def test_process_type_key_absent():
-    """#232: ProcessType key must NOT be set. Default (Standard) is correct."""
+    """#232 follow-up round 2: ``ProcessType`` IS set, to ``Interactive``.
+
+    Round-1 fix tried removing the key entirely, but launchd's default
+    behavior for missing ``ProcessType`` still applies the "inefficient"
+    resource throttle (per launchd.plist(5)). 2 SIGKILL events fired
+    post-fix at 18:18 + 19:33 CST on 2026-05-18. ``Interactive``
+    explicitly opts out of the resource judgement.
+    """
     data = _render_template()
-    assert "ProcessType" not in data, (
-        f"#232: plist must NOT have ProcessType key (Standard default is "
-        f"correct for long-running interactive services). Found: "
-        f"{data.get('ProcessType')!r}"
+    assert data.get("ProcessType") == "Interactive", (
+        f"#232 round 2: plist must set ProcessType=Interactive to opt out "
+        f"of launchd resource throttling. Got: {data.get('ProcessType')!r}"
     )
 
 
@@ -52,10 +58,16 @@ def test_label_and_paths():
 def test_comment_explains_absence():
     """Pin the #232 explainer comment so it's not stripped by accident."""
     text = TEMPLATE.read_text()
+    # Round-1 comment (removed Background) preserved as historical context
     assert "#232 removed" in text, (
-        "#232: the why-this-key-is-absent comment must stay; without it a "
-        "future plist-cleanup refactor would silently restore ProcessType."
+        "#232: the historical Background-removal comment stays for "
+        "future-archaeology context"
     )
     assert "because inefficient" in text, (
         "Pin the launchd reason string in the comment for future grep-back"
+    )
+    # Round-2 comment explaining the actual fix
+    assert "#232 follow-up" in text, (
+        "#232 round 2: the why-Interactive comment must stay so a future "
+        "plist-cleanup refactor doesn't swap back to the wrong value"
     )


### PR DESCRIPTION
Re-fixes #232 (Round 1 PR #233 was empirically insufficient).

## Why Round 1 didn't work

Round 1 removed the `ProcessType=Background` key on the theory that absence falls back to "Standard / unbounded". Wrong: per `launchd.plist(5)` man, missing `ProcessType` still falls into the default daemon throttle path. Evidence — 2 SIGKILL events post-fix:

```
17:04:59 (pre-fix baseline)
18:18:01 ← post-#233, pid 3709
19:33:19 ← post-#233, pid 10695
```

`launchctl print` showed `spawn type = daemon (3)` even with the key absent.

## Round 2 — Approach B

`ProcessType=Interactive`. The original DDD rejected this on theoretical "over-prioritization" grounds; measured reality (SIGKILL every 15-25 min) trumps theory.

Post-reload verified: `spawn type = interactive (4)`.

## Tests

`test_launchagent_plist.py` test_process_type_key_absent flipped to assert `ProcessType == "Interactive"`. Both #232-removed (round 1) + #232 follow-up (round 2) comments preserved as future-archaeology pins.

**946 / 0**.
