### PR TITLE
fix(renderer): footer 💰 shows per-turn cost (was cumulative)

### DIFF
--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -707,6 +707,13 @@ class DiscordRenderer:
         task_depth = 0                            # subtask nesting depth (#74)
         # Stats populated from ResultMessage
         stats: dict | None = None
+        # #v1.18-footer: snapshot the bridge's cumulative ``total_cost``
+        # BEFORE the turn starts so we can compute the per-turn delta when
+        # ``ResultMessage`` arrives. SDK only ships cumulative cost; we
+        # want the footer's 💰 to show the user what THIS turn cost (the
+        # 💰 cumulative used to mislead users into thinking a 6.9k-token
+        # turn cost $5.98 when really only a few cents of it was theirs).
+        cost_before: float = float(getattr(bridge, "total_cost", 0.0) or 0.0)
         _last_stop_reason: str | None = None
         # Rolling tool log (Issue #1: merge consecutive tool embeds)
         tool_log_msg: discord.Message | None = None
@@ -912,9 +919,16 @@ class DiscordRenderer:
                     continue
 
                 if isinstance(event, ResultMessage):
-                    # Capture stats from the result
+                    # Capture stats from the result.
+                    # #v1.18-footer: ``total_cost_usd`` on ResultMessage is
+                    # the CUMULATIVE conversation cost (per SDK contract /
+                    # claude_bridge._update_stats). For the footer's 💰
+                    # we want the per-turn delta = cumulative_after -
+                    # cost_before snapshot taken at render_response start.
+                    cumulative_cost = float(getattr(event, 'total_cost_usd', 0) or 0)
                     stats = {
-                        'cost': float(getattr(event, 'total_cost_usd', 0) or 0),
+                        'cost': max(0.0, cumulative_cost - cost_before),
+                        'cost_cumulative': cumulative_cost,
                         'input_tokens': int((getattr(event, 'usage', None) or {}).get('input_tokens', 0) or 0),
                         'output_tokens': int((getattr(event, 'usage', None) or {}).get('output_tokens', 0) or 0),
                         'duration_ms': (time.time() - stream_start) * 1000,

--- a/tests/test_renderer_footer.py
+++ b/tests/test_renderer_footer.py
@@ -277,3 +277,40 @@ def test_extract_subagent_stats_usage_dict_wins_over_flat():
 
 
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# v1.18 footer 💰 per-turn delta (user feedback 5/18)
+# ---------------------------------------------------------------------------
+
+
+def test_v118_footer_cost_is_per_turn_delta():
+    """v1.18 footer 💰: cost shown is `total_cost_usd - cost_before`,
+    NOT cumulative. User reported `💰 $5.98 │ 📥 6.9k │ 📤 4.4k` was
+    misleading because $5.98 was the whole session, but 6.9k/4.4k were
+    just this turn.
+
+    Source-grep on the renderer assignment.
+    """
+    import inspect
+    from clauded import discord_renderer
+
+    src = inspect.getsource(discord_renderer.DiscordRenderer.render_response)
+    # The snapshot must exist
+    assert 'cost_before' in src
+    assert 'getattr(bridge, "total_cost"' in src
+    # The stats dict must compute the delta (not just take cumulative)
+    assert 'cumulative_cost - cost_before' in src
+    # Both fields land in stats for future debug/display
+    assert "'cost'" in src and "'cost_cumulative'" in src
+
+
+def test_v118_footer_cost_clamped_to_zero():
+    """If cumulative cost regresses (shouldn't happen, but bridge reset
+    could in theory), max(0, ...) prevents negative cost display."""
+    import inspect
+    from clauded import discord_renderer
+
+    src = inspect.getsource(discord_renderer.DiscordRenderer.render_response)
+    # max(0.0, ...) clamp present
+    assert "max(0.0, cumulative_cost - cost_before)" in src


### PR DESCRIPTION
User feedback: footer 💰 was misleading.

`💰 $5.9837 │ 📥 6.9k │ 📤 4.4k │ ⏱️ 159.3s` mixed semantics — $5.98 was the whole session, 6.9k/4.4k/159.3s were just this turn.

## Fix

Snapshot `bridge.total_cost` at `render_response` start; compute `turn_cost = max(0, ResultMessage.total_cost_usd - cost_before)`. Footer 💰 now per-turn, consistent with 📥/📤/⏱️.

`stats['cost_cumulative']` kept for debug/future use; `cost_tracker` accumulation unchanged.

## Tests +2

**948 / 0** (was 946).

## Note on 🧠 0%

While digging, found 🧠 0% root cause: SDK's `get_context_usage()['percentage']` returns INT, rounds anything < 0.5% to 0. Opus-4 has 1M context window so even multi-turn conversations live at < 0.5%. Out of scope for this PR; user asked only for 💰 fix.
