### PR TITLE
fix(renderer): footer 🧠 precision — compute pct from totalTokens/maxTokens

### DIFF
--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -296,7 +296,7 @@ async def _fetch_context_pct_settled(
     settle_delay: float = 0.5,
     log_label: str = "footer",
 ) -> float | None:
-    """Fetch context_usage percentage with settle delay + retry-on-0 (#220).
+    """Fetch context-window usage percentage with settle delay + retry-on-0 (#220).
 
     The CLI control plane doesn't immediately reflect the just-finished
     turn's token state when ``ResultMessage`` is emitted. Calling
@@ -306,34 +306,63 @@ async def _fetch_context_pct_settled(
 
     Strategy:
       1. Sleep ``settle_delay`` (default 0.5s) — lets the CLI commit.
-      2. Call ``bridge.get_context_usage()``. If ``percentage > 0``, return.
-      3. If ``percentage == 0``, sleep ``settle_delay`` again and call once
-         more. Accept whatever the second call returns (including 0 —
+      2. Call ``bridge.get_context_usage()``. Compute precise percentage.
+      3. If precise percentage == 0, sleep ``settle_delay`` again and call
+         once more. Accept whatever the second call returns (including 0 —
          first message in a fresh session is legitimately 0%).
+
+    **#v1.18 precision fix**: the SDK's ``ContextUsageResponse.percentage``
+    is documented as float but the live wire format returns an INT —
+    anything ``< 0.5%`` rounds to ``0`` and the user sees ``🧠 0%``
+    forever on small conversations under wide context windows (Opus-4
+    at 1M tokens means a 28k-token turn rounds to ``0``). Compute the
+    percentage ourselves from ``totalTokens / maxTokens`` so a 2.8%
+    conversation renders as ``🧠 2.8%`` not ``🧠 0%``.
+
+    Falls back to the SDK-supplied ``percentage`` int when ``totalTokens``
+    or ``maxTokens`` is missing (old/different SDK versions).
 
     ``settle_delay`` is a single knob (R1 simplicity #225: pre-PR had
     separate ``initial_delay``/``retry_delay`` that were always set
     together). Tests pass ``settle_delay=0.0`` to skip actual sleep.
 
     Returns the percentage float, or ``None`` on any error / missing field.
-    Caller's :func:`_format_context_segment` already handles the
+    Caller's :func:`_format_context_segment` handles the
     ``None`` / ``0`` / ``0 < pct < 1`` cases.
     """
+    def _compute(cu: dict[str, Any] | None) -> float | None:
+        if cu is None:
+            return None
+        # Prefer self-computed ratio for precision (#v1.18: SDK rounds to int).
+        total = cu.get("totalTokens")
+        max_t = cu.get("maxTokens")
+        if (
+            isinstance(total, (int, float))
+            and isinstance(max_t, (int, float))
+            and max_t > 0
+        ):
+            return (float(total) / float(max_t)) * 100.0
+        # Fallback to SDK-provided percentage (legacy / unfamiliar shape).
+        if "percentage" not in cu:
+            return None
+        try:
+            return float(cu["percentage"])
+        except (TypeError, ValueError):
+            return None
+
     try:
         await asyncio.sleep(settle_delay)
         cu = await bridge.get_context_usage()
-        if cu is None or "percentage" not in cu:
-            log.debug("%s: get_context_usage returned no percentage", log_label)
+        pct = _compute(cu)
+        if pct is None:
+            log.debug("%s: get_context_usage returned no usable percentage", log_label)
             return None
-        pct = cu["percentage"]
         if pct > 0:
             return pct
         # Retry once — CLI likely hasn't fully committed turn state yet.
         await asyncio.sleep(settle_delay)
         cu = await bridge.get_context_usage()
-        if cu is None or "percentage" not in cu:
-            return None
-        return cu["percentage"]
+        return _compute(cu)
     except Exception:
         log.debug("%s: get_context_usage failed", log_label, exc_info=True)
         return None
@@ -378,6 +407,15 @@ def _format_context_segment(stats: dict[str, Any] | None) -> str | None:
     # Floor sub-1% to ``<1%`` so a 0.4% turn doesn't render as ``0%``.
     if 0 < pct_f < 1:
         return f" │ {emoji} <1%"
+    # #v1.18 precision tier: SDK's ``percentage`` field is int-rounded,
+    # so a 2.8% conversation showed as ``🧠 0%`` (or ``3%`` if SDK gave
+    # us the rounded value directly). We now compute pct ourselves from
+    # ``totalTokens / maxTokens`` for precision; honor that precision by
+    # showing 1 decimal in the 1–10% range where the difference matters
+    # most. ``0`` exact stays ``0%`` (no decimal noise on truly empty);
+    # values >= 10% stay int (🔥 92.4% reads no better than 🔥 92%).
+    if 0 < pct_f < 10:
+        return f" │ {emoji} {pct_f:.1f}%"
     return f" │ {emoji} {int(pct_f)}%"
 
 

--- a/tests/test_context_footer.py
+++ b/tests/test_context_footer.py
@@ -55,8 +55,14 @@ def test_format_context_sub_1_percent_floor():
     assert _format_context_segment({"context_percentage": 0.99}) == " │ 🧠 <1%"
     # 0% exact stays as 0% (haven't started the session)
     assert _format_context_segment({"context_percentage": 0}) == " │ 🧠 0%"
-    # 1.0% rounds to 1%
-    assert _format_context_segment({"context_percentage": 1.0}) == " │ 🧠 1%"
+    # #v1.18 precision tier: 1–10% range uses 1-decimal precision so
+    # users see movement (was `🧠 1%` flat regardless of 1.0 vs 9.9).
+    assert _format_context_segment({"context_percentage": 1.0}) == " │ 🧠 1.0%"
+    assert _format_context_segment({"context_percentage": 2.8}) == " │ 🧠 2.8%"
+    assert _format_context_segment({"context_percentage": 9.9}) == " │ 🧠 9.9%"
+    # >= 10% reverts to int (precision adds no value at scale).
+    assert _format_context_segment({"context_percentage": 10.0}) == " │ 🧠 10%"
+    assert _format_context_segment({"context_percentage": 73.4}) == " │ 🧠 73%"
 
 
 def test_format_context_shape():
@@ -95,10 +101,14 @@ async def test_footer_includes_context_segment_e2e():
     ]
     target = FakeTarget()
     renderer = DiscordRenderer(target)
-    # Realistic ContextUsageResponse shape from SDK 0.1.80
+    # Realistic ContextUsageResponse shape from SDK 0.1.80.
+    # #v1.18: footer now computes pct from totalTokens/maxTokens for
+    # precision (SDK's ``percentage`` is int-rounded; 0.0-0.5% shows as
+    # 0 even when real ratio is non-zero). Numbers chosen so the
+    # self-computed ratio is exactly 73.0% (146k/200k).
     ctx_response = {
-        "percentage": 73.4,
-        "totalTokens": 145000,
+        "percentage": 73,  # SDK-rounded int (now ignored by helper)
+        "totalTokens": 146000,
         "maxTokens": 200000,
         "rawMaxTokens": 200000,
         "model": "claude-sonnet-4-5",
@@ -108,7 +118,7 @@ async def test_footer_includes_context_segment_e2e():
 
     # Collect all message content
     all_content = " ".join(m.content for m in target._sent if m.content)
-    # The footer should contain 🧠 73%
+    # The footer should contain 🧠 73% (146000/200000 = 73.0%, int-tier)
     assert "🧠 73%" in all_content, (
         f"Expected '🧠 73%' in footer; got: {all_content!r}"
     )

--- a/tests/test_footer_context_race.py
+++ b/tests/test_footer_context_race.py
@@ -254,3 +254,80 @@ async def test_integration_footer_renders_sub_one_percent():
     assert "🧠 <1%" in all_content, (
         f"Sub-1% must render `<1%`, got: {all_content!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# v1.18 precision: use totalTokens / maxTokens, not SDK's int-rounded percentage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_v118_precision_self_computes_from_total_and_max():
+    """SDK ``percentage`` is int-rounded (28192/1000000 ≈ 2.82% → 3 or 0).
+    Helper now computes ``totalTokens / maxTokens`` itself for precision.
+    """
+    from clauded.discord_renderer import _fetch_context_pct_settled
+
+    class FakeBridge:
+        async def get_context_usage(self):
+            return {
+                "percentage": 3,   # SDK int-rounded (would lose precision)
+                "totalTokens": 28192,
+                "maxTokens": 1000000,
+            }
+
+    pct = await _fetch_context_pct_settled(FakeBridge(), settle_delay=0.0)
+    # 28192 / 1000000 * 100 = 2.8192 (not the SDK's int 3)
+    assert pct is not None
+    assert 2.8 <= pct <= 2.9, f"expected ~2.82%, got {pct}"
+
+
+@pytest.mark.asyncio
+async def test_v118_precision_falls_back_to_sdk_percentage_when_total_missing():
+    """If totalTokens/maxTokens absent, fall back to SDK's ``percentage`` field."""
+    from clauded.discord_renderer import _fetch_context_pct_settled
+
+    class FakeBridge:
+        async def get_context_usage(self):
+            return {"percentage": 47}  # only the legacy field
+
+    pct = await _fetch_context_pct_settled(FakeBridge(), settle_delay=0.0)
+    assert pct == 47.0
+
+
+@pytest.mark.asyncio
+async def test_v118_precision_handles_zero_max_tokens_gracefully():
+    """Defensive: maxTokens=0 → fall back to legacy percentage field."""
+    from clauded.discord_renderer import _fetch_context_pct_settled
+
+    class FakeBridge:
+        async def get_context_usage(self):
+            return {"percentage": 50, "totalTokens": 100, "maxTokens": 0}
+
+    pct = await _fetch_context_pct_settled(FakeBridge(), settle_delay=0.0)
+    # 0 maxTokens triggers the fallback path
+    assert pct == 50.0
+
+
+@pytest.mark.asyncio
+async def test_v118_user_reported_28k_in_1m_window_no_longer_zero():
+    """User-reported scenario (5/18): conversation at 28k tokens in 1M
+    Opus context window. Pre-fix SDK rounded to 0 → footer showed 🧠 0%
+    forever. Post-fix: 2.8% precision."""
+    from clauded.discord_renderer import _fetch_context_pct_settled, _format_context_segment
+
+    class OpusBridge:
+        async def get_context_usage(self):
+            return {
+                "percentage": 0,  # SDK rounded 28192/1000000 down
+                "totalTokens": 28192,
+                "maxTokens": 1000000,
+            }
+
+    pct = await _fetch_context_pct_settled(OpusBridge(), settle_delay=0.0)
+    assert pct is not None and pct > 0, (
+        f"#v1.18: 28k/1M must NOT round to 0; got {pct}"
+    )
+    # Threshold tier renders with 1-decimal precision in 1-10% range
+    seg = _format_context_segment({"context_percentage": pct})
+    assert seg == " │ 🧠 2.8%", f"expected ' │ 🧠 2.8%', got {seg!r}"


### PR DESCRIPTION
**Fixes 🧠 0% always-on bug** — finished the job #220 + #225 started.

## Root cause

Live SDK probe revealed `ContextUsageResponse.percentage` field is int-rounded — 0.0-0.5% → 0. Opus-4 has 1M context window so even 28k-token conversations round to 0 and footer is stuck at `🧠 0%`.

## Fix

Compute percentage from `totalTokens / maxTokens` ourselves for precision; fall back to SDK's percentage field when those are missing.

Plus precision-tier rendering:
- 0 → `🧠 0%`
- 0 < pct < 1 → `🧠 <1%`
- 1 ≤ pct < 10 → `🧠 N.N%` ← NEW (the user's 2.8% case)
- ≥ 10 → `🧠 N%`

## Tests +4

**952 / 0** (was 948).
