### PR TITLE
feat(#241): /schedule timer system — dual-kind scheduler + 5 MCP tools + slash cog

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,64 @@ cp .env.example .env
 
 ---
 
+## `/schedule` — Timer system
+
+Create timers that fire at a scheduled time and either inject a user message into an existing thread's session, or spawn a new thread + fresh claude session to run an independent task. Schedules persist across bot restarts.
+
+### Subcommands
+
+| Command | Purpose |
+|---|---|
+| `/schedule message <text>` | Inject reminder; claude parses → calls `schedule_message` MCP tool → schedule persisted |
+| `/schedule new_task <text>` | Spawn a new thread + session at fire time; claude calls `schedule_new_task` |
+| `/schedule list [scope]` | List schedules (scope = `thread` / `channel` / `all`) — directly reads store, no claude turn |
+| `/schedule delete <id>` | Delete by 16-char hex id or 8-char prefix (creator or admin) |
+| `/schedule toggle <id> <enabled>` | Enable / disable a schedule (creator or admin) |
+
+### Triggers
+
+Two forms (claude converts your natural language into one of these and passes via the MCP tool):
+- **One-shot**: `iso: 2026-05-20T09:00:00+08:00`
+- **Recurring cron**: `cron: 0 9 * * *` (5-field; interpreted in the channel's tz, default `Asia/Shanghai`)
+
+### `max_lifetime` (claude-only)
+
+When creating from natural language ("提醒我一个月"), claude can set `max_lifetime` as a duration string (`30d`, `7d`, `24h`, max **365d**). Counts from first fire. Only valid with `recurring=true`. Not exposed in the slash UI — set via prompt only.
+
+### Caps
+
+- **per-user active**: 20 schedules
+- **global active**: 100 schedules
+- **claude min interval (cron)**: 5 minutes
+- **global in-flight fires**: 10 concurrent
+
+### Permissions
+
+| Action | Allowed |
+|---|---|
+| Slash create (`message` / `new_task`) | Anyone in bound channel |
+| Slash list | Anyone |
+| Slash delete / toggle | Creator + admin |
+| Tool create | Claude (auto with `created_by="claude"`) |
+| Tool delete / toggle | Claude can only touch claude-created |
+
+### Storage
+
+`data/schedules.json` — atomic write (mirrors `data/sessions.json`). Corrupt JSON falls back to an empty store with a `WARNING` log.
+
+### Behavior
+
+- **Fire visibility**: When a schedule fires, the target thread receives a `-# ⏰ Scheduled fire: <name>` prefix line followed by the injected text shown as a Discord block quote (`> ...`) so users see exactly what was sent into the conversation.
+- **`new_task` fires**: parent channel gets a `📌 Scheduled-task thread created` embed announcing the new thread.
+- **Missed fires across restart**: ≤5 minutes late → fire on next tick; >5 minutes late → mark `missed`, log WARNING, roll `next_fire_at` forward, do NOT fire.
+- **Terminal errors** (`NotFound` / `Forbidden`): auto-disable + log.
+- **Transient errors**: 1s / 4s / 16s backoff, 3 attempts, then disable.
+- **`max_lifetime` expiry**: auto-disable + post an `⏰ Schedule expired` embed to the schedule's original created channel.
+
+Spec / PRD: `docs/prd/v1.18-scheduler.md`. Issue: #241.
+
+---
+
 ## Architecture
 
 ```

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -221,6 +221,21 @@ PYTHONPATH=src .venv/bin/python scripts/e2e/run_real_e2e.py
 
 ---
 
+## `/schedule` (#241) 覆盖
+
+v1.18 `/schedule` timer system 在三层金字塔上的覆盖：
+
+| Layer | Coverage |
+|---|---|
+| Unit (`tests/test_scheduler.py`) | 68 tests: trigger parsing (iso/cron/duration), store CRUD + corrupt-recovery, manager create/delete/toggle + cap matrix + permission matrix, tick + catch_up grace logic, fire-success / fire-terminal / fire-retry, max_lifetime expiry, per-thread lock acquisition, global in-flight cap |
+| MCP unit (`tests/test_scheduler_mcp.py`) | 22 tests: each of 5 tools (`schedule_message` / `new_task` / `list` / `delete` / `toggle`) — happy + error paths, ctx-missing, validation forwarding, permission edges |
+| Cog unit (`tests/test_cogs_schedule.py`) | 16 tests: 5 slash subcommands — thread-only enforcement, unbound rejection, render call assertion (system reminder verbatim), list embed shape, delete prefix resolution + permission, toggle admin override |
+| Real-Discord e2e (`scripts/e2e/run_real_e2e.py`) | 2 cases: `case_schedule_message_e2e` (90s wait for fire, verify fire_count++, prefix + quoted what visible in thread, last_error=None); `case_schedule_new_task_e2e` (same + new thread created + announce embed in parent) |
+
+Total: ~106 unit / MCP / cog tests + 2 real-Discord e2e cases.
+
+---
+
 ## 4. 诊断 / Probe 脚本
 
 ad-hoc 验证脚本，用于：

--- a/docs/prd/v1.18-scheduler.md
+++ b/docs/prd/v1.18-scheduler.md
@@ -1,0 +1,547 @@
+# PRD v1.18 — `/schedule` Timer System (FINAL)
+
+**Issue**: #241 (epic, P0)
+**Branch**: `feat/v1.18-schedule-cron`
+**Author**: claudeD manager
+**Status**: **APPROVED by user 2026-05-19**
+**Authority**: This document is the single source of truth for the implementation. The spec section in #241 has higher priority for the kinetic decisions; this PRD locks the PRD-allowed parameters. **Dev sub-agents MUST read this PRD before writing code.**
+
+---
+
+## 1. 一句话目标
+
+让用户在 Discord 里说 "明天 9 点提醒我开会" 或主动 `/schedule message ...` / `/schedule new_task ...`，bot 创建一个跨重启持久化的定时任务；到时间真触发，**两种行为模式**之一：
+1. **`schedule_message`** — 往某个已有 thread 注入一条 user message，让该 thread 的活 session 接着跑一轮
+2. **`schedule_new_task`** — 在某 channel 新建一个 thread + 起一个 fresh claude session，把 `what` 作为首条 user prompt
+
+注入的内容**在 Discord 上必须可见**（用户能直观看到"这条话被定时塞进来了"）。
+
+---
+
+## 2. Spec 钉死（来自 #241，PRD 不许动）
+
+复制粘贴 issue 241 §Spec / §行为规则 / §权限模型 / §Acceptance Criteria / §不在 scope 的全部硬约束。摘要：
+
+- 触发表达：5-field cron + ISO datetime 二选一
+- Per-thread serial fire；全局 in-flight ≤ 10；per-user active ≤ 20；全局 active ≤ 100（**两 kind 合算**）
+- Missed fire ≤ 5min grace 补跑，> 5min 跳过 + mark missed
+- 3× backoff (1s/4s/16s)；`NotFound`/`Forbidden` → 自动 disable
+- Fire 前显示 `-# ⏰ Scheduled fire: <name>`
+- Claude 创建 min interval 5 分钟（用户 slash 无此限）
+- Persistence: `data/schedules.json` (atomic 写)
+- Scope creep 禁止（详 issue §不在 scope）
+
+---
+
+## 3. PRD 阶段决策（已 DDD 拍板）
+
+### 3.1 工具命名（两套）
+
+| Tool | Kind | 用途 |
+|---|---|---|
+| `schedule_message` | 1 | 定时往**已有 thread** 注入一条 user message，触发该 thread 现有 session 继续跑 |
+| `schedule_new_task` | 2 | 定时在某 channel **新建 thread + 起 fresh session**，把 `what` 当首条 prompt |
+
+### 3.2 Slash 命令（同 group）
+
+```
+/schedule message <text>           ← Kind 1：注入 prompt → claude 调 schedule_message
+/schedule new_task <text>          ← Kind 2：注入 prompt → claude 调 schedule_new_task
+/schedule list                     ← cog 直接调 store
+/schedule delete <id>              ← cog 直接调 store
+/schedule toggle <id> <enabled>    ← cog 直接调 store
+```
+
+`app_commands.Group(name="schedule")` 单 group 5 subcommand。
+
+### 3.3 Schedule ID 形态
+
+`secrets.token_hex(8)` → 16 字符 hex（例 `b76849080e844b32`）。无前缀匹配，UI/CLI 一律全长。
+
+### 3.4 PR 策略
+
+5 个 subtask 在 `feat/v1.18-schedule-cron` 串行累积 commit → 全 done → **单一 PR** → R1 7 视角并行 review → R2 修 → merge。
+
+### 3.5 #232 关系
+
+不阻塞。Missed fire 补跑为这种场景设计。
+
+### 3.6 Dead code 清理
+
+`discord_renderer.py` 行号（grep 已验证）：
+- 1374: `CronCreate`
+- 1383: `CronDelete`
+- 1390: `CronList`
+- 1415: `ScheduleWakeup`
+
+四个 PascalCase 内置工具渲染分支在 Subtask 5 一并清。这是 claudecode CLI 内置工具的渲染，audit 显示 runtime 0 命中。**我们新增的 4 个工具是 snake_case，跟 PascalCase 内置不会撞**。
+
+### 3.7 MCP 形态 — In-process SDK MCP
+
+`create_sdk_mcp_server(name="clauded-scheduler", tools=[...])` → 4 个 `@tool` 装饰的 async fn，跑在 bot 进程内。无独立进程、无 IPC、无配置文件。
+
+**关键澄清**：tool 注入是**全局自动**的 —— 在 `ClaudeBridge.start()` 一次性 dict-merge 到 `mcp_servers`，任何 turn（无论是 `@bot` 自然对话、`/schedule message/new_task` 注入、还是 fire 触发的 turn）都自动看得到 4 个 tool。slash cog **不**做任何 hot-load tool 动作。
+
+### 3.8 参数细节表（本 PRD 锁定）
+
+| 参数 | 取值 | 备注 |
+|---|---|---|
+| `data/schedules.json` | 同目录同模式 (atomic 写) | 照搬 `session_store.py` |
+| `created_by` | `"claude"` / `str(discord_user_id)` | 一致 str |
+| `name` 缺省 | `schedule_id[:8]` 当显示名 | 不强迫填名 |
+| Tz 默认 | `Asia/Shanghai` | 未来 `/project bind --tz` 可覆写；本 epic 硬编码 |
+| Tz 解析失败 | `raise ValueError`（不静默 fallback UTC） | 用户输错要看到 |
+| 5min grace | `MISSED_FIRE_GRACE_S = 300` | 含 = 边界 |
+| Tick 间隔 | `TICK_INTERVAL_S = 15` 秒 | |
+| In-flight cap | `MAX_GLOBAL_INFLIGHT = 10` | |
+| Per-user cap | `MAX_USER_ACTIVE = 20` | **两 kind 合算** |
+| Global cap | `MAX_GLOBAL_ACTIVE = 100` | **两 kind 合算** |
+| Per-thread lock | `bot.session_manager.get_lock(thread_id)` | |
+| `user` field on session | Kind 1: `"scheduled-fire"`; Kind 2: `"scheduled-fire-newtask"` | 便于 log/audit 区分 |
+| MCP server 注册时机 | `ClaudeBridge.start()` 内 `_build_mcp_servers()` dict-merge | 每个 session 自动带 |
+| Fire 前 prefix（两 kind 都用） | `-# ⏰ Scheduled fire: <name>` | |
+| 注入内容 Discord 可见 | 在 prefix 之后，bot 用 `> 「<what>」` 引用形式发到 thread（kind 1 fire 到目标 thread；kind 2 fire 到新建 thread）| **本次 PRD 新加** |
+| Kind 2 新 thread 类型 | public + auto_archive_duration=1440 (1d) + slow_mode=0 | |
+| Kind 2 新 thread 命名 | claude 在 tool args 传 `thread_name`；不传时 bot 用 `f"⏰ {schedule_name} {fire_ts:%m-%d %H:%M}"` | |
+| Kind 2 channel announce | Fire 时 parent channel 发 `📌 Created scheduled-task thread: <thread mention>` embed | 让 channel 成员看到 |
+| Kind 1 session 已死 | 用 stored `resume_session_id` 重起 bridge → 注入 `what` | transparent UX |
+| Kind 2 unbind 后 fire | 拒绝 fire + disable + log WARNING（无 user-facing 通知） | |
+| List embed kind marker | 📨 (message) / 🧵 (new_task) | |
+| List embed creator marker | 🤖 (claude) / 👤 (user slash) | |
+| `max_lifetime` 语义 | **从首次 fire 起算寿命**；到期 disable + 不再 fire | |
+| `max_lifetime` 输入 | duration string `"30d"`/`"7d"`/`"24h"`/`"1w"` (后缀 `s/m/h/d/w`)；parse 到 seconds 存盘 | claude 传；用户 slash **不暴露** |
+| `max_lifetime` 上限 | 365 天 (31536000 s)；超过 → tool reject | |
+| `max_lifetime` 仅 recurring 有效 | `recurring=False` + `max_lifetime != null` → tool reject | |
+| `max_lifetime` 到期通知 | 在 schedule **原 created channel** 发 `⏰ Schedule <name> 寿命到期，已自动停用` embed | |
+
+---
+
+## 4. Tool spec 定稿
+
+### 4.1 `schedule_message`（Kind 1）
+
+```jsonc
+{
+  "when": "cron: 0 9 * * *" | "iso: 2026-05-19T09:00:00+08:00",
+  "what": "string ≤ 500 chars (user prompt 注入文本)",
+  "target_thread_id": "optional str (默认当前 thread)",
+  "name": "optional ≤ 50 chars",
+  "recurring": true | false,
+  "max_lifetime": "30d | 7d | ... (optional; 仅 recurring=true 时有效, 上限 365d)"
+}
+→ {"schedule_id": "<16-char hex>", "next_fire_at": "<iso UTC>"}
+```
+
+### 4.2 `schedule_new_task`（Kind 2）
+
+```jsonc
+{
+  "when": "cron: ... | iso: ...",
+  "what": "string ≤ 500 chars (新 session 首条 user prompt)",
+  "target_channel_id": "optional str (默认当前 channel)",
+  "thread_name": "optional ≤ 50 chars",
+  "name": "optional ≤ 50 chars",
+  "recurring": true | false,
+  "max_lifetime": "duration string optional, ≤ 365d, 仅 recurring 有效"
+}
+→ {"schedule_id": "<16-char hex>", "next_fire_at": "<iso UTC>"}
+```
+
+### 4.3 `schedule_list`
+
+```jsonc
+{
+  "scope": "thread" | "channel" | "all",
+  "include_disabled": false
+}
+→ [{"schedule_id", "kind", "name", "when", "what_preview",
+    "next_fire_at", "last_fired_at", "fire_count", "missed_count",
+    "enabled", "created_by", "max_lifetime"}]
+```
+
+### 4.4 `schedule_delete`
+
+```jsonc
+{ "schedule_id": "<16-char hex>" }
+→ {"deleted": true}
+```
+
+权限：claude 调 = 只能删 `created_by=claude`；用户调 = 只能删自己创建；admin 万能。
+
+### 4.5 `schedule_toggle`
+
+```jsonc
+{ "schedule_id": "<16-char hex>", "enabled": true | false }
+→ {"enabled": <bool>}
+```
+
+---
+
+## 5. 持久化 schema
+
+`data/schedules.json`：
+
+```jsonc
+{
+  "<schedule_id>": {
+    "schedule_id": "<16-char hex>",
+    "kind": "message" | "new_task",                  // ← 双 kind
+    "name": "string ≤ 50",
+    "created_at": "<iso UTC>",
+    "created_by": "claude" | "<discord_user_id>",
+    "guild_id": <int>,
+    "channel_id": <int>,                              // schedule 原 created channel
+    "target_thread_id": <int>,                        // kind=message 才有
+    "target_channel_id": <int>,                       // kind=new_task 才有
+    "thread_name": "optional",                        // kind=new_task 才有
+    "trigger": {
+      "kind": "once" | "cron",                        // 与 schedule.kind 不同概念！这是触发 kind
+      "iso": "<iso UTC>",
+      "cron": "0 9 * * *",
+      "tz_when_created": "Asia/Shanghai",
+      "recurring": true | false                        // user-facing recurring flag
+    },
+    "payload": {
+      "what": "string ≤ 500"
+    },
+    "max_lifetime_seconds": <int> | null,              // null = unlimited
+    "state": {
+      "enabled": true,
+      "next_fire_at": "<iso UTC>",
+      "first_fired_at": null,                          // ← 新加：max_lifetime 从这里起算
+      "last_fired_at": null,
+      "last_error": null,
+      "fire_count": 0,
+      "missed_count": 0
+    }
+  }
+}
+```
+
+**写盘**: `tmp + fsync + os.replace`，损坏 JSON 自动 fallback 空 dict + WARNING。
+
+---
+
+## 6. System reminder 模板（两条）
+
+### 6.1 `/schedule message <text>` 用 (approved)
+
+````
+<system-reminder>
+The user just invoked `/schedule message`. You MUST call the
+`schedule_message` tool to fulfill this request. Do not respond
+with text explanation alone — call `schedule_message` as your first
+action.
+
+`schedule_message` creates a timer that, when it fires, will inject
+a user message into a Discord thread's existing session. The target
+session will continue its conversation as if the user typed that
+message themselves.
+
+When parsing the user's text:
+- Extract `when` as either `"cron: <5-field>"` (recurring) or
+  `"iso: <ISO 8601 with tz>"` (one-shot). Convert natural language
+  like "明天 9 点" / "每周一 9am" using the channel's timezone
+  (default Asia/Shanghai).
+- Extract `what` — the message text that will be injected when the
+  timer fires. Phrase it from the user's first-person point of view
+  (e.g. "提醒我开会" not "remind the user about meeting"), since the
+  session will see it as a user message.
+- If the user said the schedule should only last for a certain
+  duration (e.g. "持续一个月" / "for the next week"), set
+  `max_lifetime` to a duration string like `"30d"` / `"7d"`
+  (max 365d). Only valid with recurring=true.
+- `target_thread_id` defaults to the current thread; only set it if
+  the user explicitly named a different thread.
+- Pick a short `name` (≤50 chars) if not obvious from the text.
+
+After calling the tool, respond briefly to the user confirming what
+was scheduled and the next_fire_at.
+</system-reminder>
+
+<user-text>{user_text}</user-text>
+````
+
+### 6.2 `/schedule new_task <text>` 用 (approved)
+
+````
+<system-reminder>
+The user just invoked `/schedule new_task`. You MUST call the
+`schedule_new_task` tool. Do not respond with text explanation alone.
+
+`schedule_new_task` creates a timer that, when it fires, will spawn a
+BRAND NEW Discord thread + a FRESH claude session, then submit `what`
+as that session's first user prompt. Use this when the user wants an
+independent task started at a scheduled time — not a reminder injected
+into an existing conversation.
+
+When parsing the user's text:
+- Extract `when` (cron / iso). For recurring tasks, every fire creates
+  a new thread + new session (52 threads/year for weekly cron — that
+  is intentional). Honor user tz (default Asia/Shanghai).
+- Extract `what` — the task brief that becomes the new session's
+  first user prompt. Phrase it as an actionable task (e.g. "整理本周
+  的 PR 状态报告" not "remind me to do reports"), not a reminder.
+- If the user said the schedule should only last for a certain
+  duration, set `max_lifetime` (e.g. `"30d"`, max 365d). Only valid
+  with recurring=true.
+- `target_channel_id` defaults to the current channel; only set it if
+  the user explicitly named a different channel.
+- Pick a `thread_name` (≤50 chars) for the new thread, and a `name`
+  for the schedule display label.
+
+Reminder: schedule_new_task vs schedule_message
+- schedule_new_task → fresh thread + fresh session every fire
+- schedule_message  → inject into existing thread's existing session
+
+After calling the tool, respond briefly confirming the schedule.
+</system-reminder>
+
+<user-text>{user_text}</user-text>
+````
+
+---
+
+## 7. 文件树
+
+新增：
+```
+src/clauded/
+  scheduler_store.py          # JSON 持久化
+  scheduler.py                # SchedulerManager (trigger 解析 + tick + 双 fire executor)
+  scheduler_mcp.py            # 4 个 @tool + create_sdk_mcp_server
+  cogs/schedule.py            # /schedule group (message/new_task/list/delete/toggle)
+tests/
+  test_scheduler.py
+  test_scheduler_mcp.py
+  test_cogs_schedule.py
+docs/prd/v1.18-scheduler.md   # 本文档
+```
+
+修改：
+```
+pyproject.toml                  # croniter>=2.0
+src/clauded/bot.py              # _fire_message + _fire_new_task + _register_scheduler_ctx + tasks.loop + setup_hook
+src/clauded/claude_bridge.py    # _build_mcp_servers 合并 scheduler server
+src/clauded/discord_renderer.py # 删 dead code 行 1374/1383/1390/1415
+README.md / docs/TESTING.md     # /schedule 用法 (Subtask 5)
+scripts/e2e/run_real_e2e.py     # 新增 case_schedule_message + case_schedule_new_task
+```
+
+新增依赖：`croniter >= 2.0`
+
+---
+
+## 8. Subtask 拆分（5 个串行 dev sub-agent）
+
+### Subtask 1 — `SchedulerStore` + `SchedulerManager` 核心（无 fire）
+
+**Files**: `scheduler_store.py`, `scheduler.py` (核心部分), `tests/test_scheduler.py` (部分)
+
+**Scope**:
+- `SchedulerStore`: 同 §5 schema 落盘；`add/get/delete/list_all/list_for_thread/list_for_channel/count_active_for_user/count_active_total`；损坏 fallback；atomic 写
+- `SchedulerManager.__init__(store, fire_message_callback, fire_new_task_callback, get_lock=None)` —— 两个 callback 分别对应两 kind
+- Trigger 解析（共用）：`parse_iso_utc`, `parse_cron_to_next`, `compute_next_fire`
+- `parse_duration(s: str) -> int` —— `"30d"`/`"7d"`/`"24h"` → seconds；上限 365d
+- `create(kind: Literal["message","new_task"], when, what, ..., max_lifetime: str|None)` —— 单一入口，按 kind 分发，所有 cap/校验/权限内层做
+- `delete / toggle` —— 跟 kind 无关
+- 常量：`TICK_INTERVAL_S=15`, `CLAUDE_MIN_INTERVAL_S=300`, `MISSED_FIRE_GRACE_S=300`, `MAX_GLOBAL_INFLIGHT=10`, `MAX_USER_ACTIVE=20`, `MAX_GLOBAL_ACTIVE=100`, `MAX_LIFETIME_SECONDS=31536000` (365d)
+
+**Tests** (~30 cases):
+- Trigger 解析 happy + 错误
+- Duration string 解析 happy + 上限 reject + bad suffix reject
+- Store CRUD + reload + corrupt fallback
+- Manager `create` (kind=message) happy + 各 cap reject + future-only iso + claude min interval + max_lifetime + recurring=false + max_lifetime → reject
+- Manager `create` (kind=new_task) happy + target_channel_id 必须 bound (这层校验 mock binding 检查)
+- Permission matrix
+
+**Acceptance**: 该 subtask 的 30 测试全过；`scheduler.py` 不依赖 `discord.py` 内容（callback 接口已注入）。
+
+---
+
+### Subtask 2 — Fire executors + tick/catch_up（双 kind）
+
+**Files**: `scheduler.py` (extends), `tests/test_scheduler.py` (extends)
+
+**Scope**:
+- `SchedulerManager.tick()` —— 扫 due → `_fire_one(sched)` 池
+- `SchedulerManager.catch_up()` —— 启动时一次性
+- `SchedulerManager._fire_one(sched)` —— 拿 lock → dispatch 到 `fire_message_callback` 或 `fire_new_task_callback`（按 `sched.kind`）→ 成功后更新 state（`first_fired_at` 首次设置）→ max_lifetime 到期检查 → 失败 3× backoff → terminal disable
+- `SchedulerManager._check_max_lifetime(sched)` —— 每次 tick 前预检；到期 disable + 调 `expire_notify_callback(sched)`（manager 新增第 3 个 callback）
+- 持久化每次 state 更新都写盘
+
+**Tests** (~15 cases):
+- tick fires-due / skips-future / skips-disabled
+- catch_up grace 补跑 vs miss
+- _fire_one 调对应 kind callback
+- 首次 fire 后 first_fired_at 被设
+- max_lifetime 到期 → disable + expire callback 调
+- one-shot disable / cron recompute
+- NotFound/Forbidden 立即 disable
+- Transient 3× backoff
+- per-thread lock acquire
+
+**Acceptance**: 该 subtask 的 15 测试全过。
+
+---
+
+### Subtask 3 — Scheduler MCP server (4 tools)
+
+**Files**: `scheduler_mcp.py`, `tests/test_scheduler_mcp.py`
+
+**Scope**:
+- 4 个 `@tool` 装饰的 async handler:
+  - `schedule_message_tool` (kind=message)
+  - `schedule_new_task_tool` (kind=new_task)
+  - `schedule_list_tool`
+  - `schedule_delete_tool`
+  - `schedule_toggle_tool`
+- 注意：tool count = **5 个** 在 list/delete/toggle 拆出去后。让我重新数：
+  - `schedule_message` (1)
+  - `schedule_new_task` (2)
+  - `schedule_list` (3)
+  - `schedule_delete` (4)
+  - `schedule_toggle` (5)
+  → **5 个 tool**，PRD 早期写 "4 个" 是 kind 1 only 的版本，**这里 final 是 5 个**
+- `build_scheduler_mcp_server()` → `create_sdk_mcp_server(name="clauded-scheduler", tools=[5 tools])`
+- `set_scheduler_manager(mgr, ctx_provider)` 全局 setter
+- Handler 错误返回 `{"is_error": True, "content": [{"type":"text","text": ...}]}`
+- `schedule_list` 输出含 📨/🧵 + 🤖/👤 marker
+
+**Tests** (~18 cases):
+- Server build 不崩
+- 每个 tool happy + error path
+- claude 不能 delete 用户的
+- 全局/per-user cap 触发返回 error
+- ctx-missing → error
+- max_lifetime 上限 365d reject
+- recurring=false + max_lifetime → reject
+- new_task target_channel 必须 bound
+
+**Acceptance**: 18 测试全过；`build_scheduler_mcp_server()` 返回 dict 能直接塞 `ClaudeAgentOptions.mcp_servers`。
+
+---
+
+### Subtask 4 — `/schedule` Slash Cog + Bot Wiring
+
+**Files**: `cogs/schedule.py`, `bot.py`, `claude_bridge.py`, `tests/test_cogs_schedule.py`
+
+**Scope**:
+- `cogs/schedule.py`:
+  - `schedule_group = app_commands.Group(name="schedule", ...)`
+  - `@schedule_group.command(name="message")` —— 拼 reminder 6.1 + user text → 调 `bot._handle_thread_message`-equivalent 注入
+  - `@schedule_group.command(name="new_task")` —— 拼 reminder 6.2 + user text → 同上
+  - `@schedule_group.command(name="list")` —— cog 直接 `bot.scheduler.store.list_for_thread`，embed
+  - `@schedule_group.command(name="delete")` / `name="toggle"` —— cog 直接调
+  - **注意**: 不需要在 cog 里 hot-load tool —— tool 在 `ClaudeBridge.start()` 已全局注入
+
+- `bot.py`:
+  - `ClaudedBot.__init__`: 实例化 store + manager（**3 个** callback: `fire_message`, `fire_new_task`, `expire_notify`）
+  - `_scheduler_ctx_provider()` → return `self._scheduler_current_ctx`
+  - `_register_scheduler_ctx(thread_id, channel_id, guild_id, tz_name)` setter
+  - `_render_with_retry()` 调用前 set ctx
+  - `_fire_message(sched)` 实现：resolve thread → 查 binding → get_or_create session (含 resume 已死 session) → 发 prefix + `> 「{what}」` 引用 → `DiscordRenderer.render_response(bridge, what)`
+  - `_fire_new_task(sched)` 实现：resolve target_channel → 检 binding → 新建 thread (public, 1d archive) → 起 fresh session (cwd/system_prompt/extra_dirs/mcp/env 全继承 channel binding) → 在 parent channel 发 announce embed → 在新 thread 发 prefix + `> 「{what}」` 引用 → `DiscordRenderer.render_response`
+  - `_expire_notify(sched)` 实现：拿 schedule.channel_id (created channel) → 发 expire embed
+  - `setup_hook`: 注册 `schedule_group` + 启 `_scheduler_tick` (`@tasks.loop(seconds=15)`) + `_before_scheduler_tick`
+  - `_scheduler_tick`: first call `catch_up()` once, then `tick()` per interval; exceptions logged but never bubble
+
+- `claude_bridge.py`:
+  - `_build_mcp_servers()` 方法 —— dict-merge `_mcp_servers` + scheduler server
+
+**Tests** (~12 cases):
+- `/schedule message` 走 prompt 注入路径（mock interaction + assert bridge.send_message 被调）
+- `/schedule new_task` 同上
+- `/schedule list` 直接 store + embed 含 📨/🧵 + 🤖/👤
+- `/schedule delete` 跨用户权限错误返回 ephemeral
+- `_fire_message` 不存在 thread → raise NotFound → scheduler 接住 disable
+- `_fire_new_task` 创建 thread + 起 session 调用契约
+- `_fire_new_task` target_channel unbind → raise → disable
+- `_expire_notify` 发 embed 到 created channel
+- `_register_scheduler_ctx` + provider 配对
+- `claude_bridge._build_mcp_servers` 返回 dict 含 `clauded-scheduler`
+
+**Acceptance**: 12 测试全过；手动启动 bot，`/schedule` UI 出现 5 个 subcommand。
+
+---
+
+### Subtask 5 — Docs + e2e + Dead code
+
+**Files**: `README.md`, `docs/TESTING.md`, `discord_renderer.py`, `scripts/e2e/run_real_e2e.py`
+
+**Scope**:
+- `README.md`: 加 `/schedule` 章节（双 kind 用法 + 权限矩阵 + max_lifetime 说明）
+- `docs/TESTING.md`: 加 `/schedule` 在 3 层金字塔的覆盖
+- `discord_renderer.py:1374, 1383, 1390, 1415` 删 dead code
+- `scripts/e2e/run_real_e2e.py`:
+  - `case_schedule_message_e2e` —— testbot @bot 让 claude 创建 60s 后 fire 的 message schedule → 等 90s → 验证 schedules.json fire_count=1 + thread 看到 prefix + 引用 + claude 回复
+  - `case_schedule_new_task_e2e` —— 同上但 new_task；验证新 thread 创建 + announce embed + 引用 + claude 回复
+
+**Tests**:
+- Dead code 删除后全测试套件仍 pass
+- 2 个 e2e case 都 PASS
+
+**Acceptance**: AC1-AC10 全部在 real Discord 验证。
+
+---
+
+## 9. AC 验证矩阵
+
+| AC | Subtask | 验证方式 |
+|---|---|---|
+| AC1 (slash 创建走 tool) | 4 | Subtask 4 单测 + Subtask 5 e2e |
+| AC2 (定时真 fire) | 2+4+5 | Subtask 5 e2e (90s 等) |
+| AC3 (自然对话也能调) | 3+4 | Subtask 5 第三 e2e case（手测亦可）|
+| AC4 (cron 1min 拒) | 1 | Subtask 1 单测 |
+| AC5 (重启 missed) | 2 | Subtask 2 单测 |
+| AC6 (NotFound disable) | 2 | Subtask 2 单测 |
+| AC7 (per-thread serial) | 2+4 | Subtask 2 单测 |
+| AC8 (list 标 🤖/👤) | 3 | Subtask 3 单测 |
+| AC9 (跨用户 delete 拒) | 1+3 | Subtask 1/3 单测 |
+| AC10 (dead code 清) | 5 | Subtask 5 静态检查 |
+| **新 AC11**: Kind 2 fire 真新建 thread | 4+5 | Subtask 5 e2e new_task case |
+| **新 AC12**: max_lifetime 到期 disable + 通知 | 2 | Subtask 2 单测 + 手测 |
+| **新 AC13**: 注入 prompt 在 Discord 可见（引用消息）| 4 | Subtask 4 单测 + Subtask 5 e2e |
+
+---
+
+## 10. 风险 + 缓解
+
+| 风险 | 缓解 |
+|---|---|
+| Cron 用户输错（非 5-field） | `parse_cron_to_next` raise → tool 返 error → claude 重试 |
+| 重启时 schedules.json 被并发写坏 | atomic write + 损坏 fallback |
+| Claude 回环（fire 触发 claude 又调 create）| 5min min interval + 100 全局 cap |
+| Kind 2 recurring 每周新建 thread → channel 充斥 thread | 用户 disable schedule 收尾 + per-user 20 cap |
+| `_scheduler_ctx_provider` 非 thread turn 调用 | 返 {}，tool handler 见到 → error |
+| MCP server 启动失败 | `_build_mcp_servers` try/except → log + 继续 |
+| Discord rate limit | `MAX_GLOBAL_INFLIGHT=10` |
+| Kind 2 fire 中途 channel unbind | fire 时检 binding；unbind → raise → disable + WARNING |
+| max_lifetime 365d 还嫌长 | 用户 `/schedule delete` 主动停 |
+| 注入 prompt 引用 message 太长（500 字符）超 Discord 2000 limit | bot 发引用前 truncate 显示 + 链接全文（如 long-tier）|
+
+---
+
+## 11. Out-of-scope
+
+跟 #241 §不在 scope 一致；本 PRD 额外明确**不做**：
+- `/schedule history` audit 视图
+- Email/webhook 告警
+- Schedule chaining
+- Mid-fire 取消
+- Custom thread settings (private thread, auto_archive < 1d 等)
+- 跨 guild fire
+
+---
+
+## 12. 完成定义 (Definition of Done)
+
+- [ ] 5 个 Subtask 实现 + 单测通过
+- [ ] 全测试套件 1065 → ~1140 通过，0 新增 fail
+- [ ] `run_real_e2e.py` 新 case 都 PASS
+- [ ] AC1-AC13 全部验证（10 原 + 3 新）
+- [ ] PR 开 + R1 7 视角 review 全部 APPROVE 或修齐
+- [ ] R2 修复（如需）
+- [ ] 用户 final approve
+- [ ] CI（如有）pass
+- [ ] Merge main + 删 branch + close #241

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "claude-agent-sdk==0.1.80",
     "python-dotenv>=1.0",
     "Pillow>=10",
+    "croniter>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/e2e/run_real_e2e.py
+++ b/scripts/e2e/run_real_e2e.py
@@ -567,6 +567,184 @@ async def case_3rd_party_thread_with_mention(driver: TestBotDriver) -> CaseResul
 
 
 # ---------------------------------------------------------------------------
+# /schedule (#241) e2e cases + assert helpers
+# ---------------------------------------------------------------------------
+
+
+def assert_schedule_message_fired() -> tuple[bool, str]:
+    """Verify a schedule_message fired:
+    1. data/schedules.json contains exactly 1 schedule with name=e2e_msg,
+       fire_count=1, enabled=False (one-shot completed), last_error=None
+    2. The target thread (the one testbot posted in) received both:
+       - a "-# ⏰ Scheduled fire: e2e_msg" line
+       - a quoted "> SCHED_MSG_E2E_FIRED" line
+       - a subsequent claude response
+    Returns (ok, reason).
+    """
+    p = Path("data/schedules.json")
+    if not p.exists():
+        return False, "data/schedules.json missing"
+    schedules = json.loads(p.read_text())
+    matches = [s for s in schedules.values() if s.get("name") == "e2e_msg"]
+    if len(matches) != 1:
+        return False, f"expected 1 schedule named e2e_msg, got {len(matches)}"
+    s = matches[0]
+    state = s.get("state", {})
+    if state.get("fire_count") != 1:
+        return False, f"fire_count={state.get('fire_count')} != 1"
+    if state.get("enabled") is not False:
+        return False, f"enabled={state.get('enabled')} != False"
+    if state.get("last_error"):
+        return False, f"last_error={state.get('last_error')!r}"
+    return True, "schedule_message fired and persisted correctly"
+
+
+def assert_schedule_new_task_fired() -> tuple[bool, str]:
+    """Verify schedule_new_task fired:
+    1. data/schedules.json contains 1 schedule named e2e_newtask, fire_count=1
+    2. A new thread was created in the test channel
+    """
+    p = Path("data/schedules.json")
+    if not p.exists():
+        return False, "data/schedules.json missing"
+    schedules = json.loads(p.read_text())
+    matches = [s for s in schedules.values() if s.get("name") == "e2e_newtask"]
+    if len(matches) != 1:
+        return False, f"expected 1 schedule named e2e_newtask, got {len(matches)}"
+    s = matches[0]
+    state = s.get("state", {})
+    if state.get("fire_count") != 1:
+        return False, f"fire_count={state.get('fire_count')} != 1"
+    if state.get("enabled") is not False:
+        return False, f"enabled={state.get('enabled')} != False"
+    if state.get("last_error"):
+        return False, f"last_error={state.get('last_error')!r}"
+    return True, "schedule_new_task fired and persisted correctly"
+
+
+# Registry mapping case "assert" name -> callable, mirrors the data-style
+# spec in PRD §8 Subtask 5. The case wrappers below call into this registry
+# so new asserts can be added by extending only this dict.
+SCHEDULE_ASSERT_REGISTRY = {
+    "schedule_message_fired": assert_schedule_message_fired,
+    "schedule_new_task_fired": assert_schedule_new_task_fired,
+}
+
+
+async def case_schedule_message_e2e(driver: TestBotDriver) -> CaseResult:
+    """#241 e2e: claude creates a one-shot schedule_message timer via natural
+    language; wait ~130s for the timer to fire; verify the schedule entry on
+    disk plus the marker text appears in the test thread.
+
+    Flow:
+    1. @bot post the create-schedule prompt
+    2. Wait for claude's "好" creation ACK (a thread also gets created)
+    3. Sleep wait_seconds (gives the 90s timer + render margin)
+    4. Verify the marker text "SCHED_MSG_E2E_FIRED" landed in the thread
+    5. Verify the schedules.json entry (fire_count=1, enabled=False, etc.)
+    """
+    marker = "SCHED_MSG_E2E_FIRED"
+    wait_seconds = 130
+    prompt = (
+        "请用 schedule_message 工具创建一个一次性定时任务。"
+        "when 设为 90 秒后的 ISO 时间 (使用 iso: 前缀，UTC tz)，"
+        f"what 设为 `{marker}`，name 设为 `e2e_msg`。"
+        "target_thread_id 不要传，用当前 thread。recurring 不要传。"
+        "max_lifetime 不要传。创建完只回\"好\"。"
+    )
+    msg = await driver.post(f"<@{BOT_USER_ID}> {prompt}")
+    # First wait: claude ACKs the creation (kicks off thread + posts "好")
+    ack_replies = await driver.wait_for_bot_reply(
+        msg, timeout=TIMEOUT_S, match="好"
+    )
+    if not ack_replies:
+        return CaseResult(
+            name="case_schedule_message_e2e",
+            status="FAIL",
+            detail="no creation ACK from claude within timeout",
+        )
+    # Now wait for the timer to fire and the marker to appear
+    fire_replies = await driver.wait_for_bot_reply(
+        msg, timeout=wait_seconds, match=marker
+    )
+    bot_texts = [driver._flatten(r) for r in fire_replies if driver._flatten(r).strip()]
+    saw_marker = any(marker in t for t in bot_texts)
+    saw_prefix = any("Scheduled fire" in t and "e2e_msg" in t for t in bot_texts)
+    ok, reason = SCHEDULE_ASSERT_REGISTRY["schedule_message_fired"]()
+    if saw_marker and saw_prefix and ok:
+        return CaseResult(
+            name="case_schedule_message_e2e",
+            status="PASS",
+            detail=f"marker+prefix visible in thread; {reason}",
+            bot_replies=bot_texts,
+        )
+    return CaseResult(
+        name="case_schedule_message_e2e",
+        status="FAIL",
+        detail=(
+            f"saw_marker={saw_marker} saw_prefix={saw_prefix} "
+            f"store_check_ok={ok} reason={reason!r}"
+        ),
+        bot_replies=bot_texts,
+    )
+
+
+async def case_schedule_new_task_e2e(driver: TestBotDriver) -> CaseResult:
+    """#241 e2e: claude creates a one-shot schedule_new_task timer; wait
+    ~130s; verify that on fire a NEW thread is created (announce embed in
+    parent channel mentions "Scheduled-task thread") and the marker text
+    lands in the new thread.
+    """
+    marker = "SCHED_NEWTASK_E2E_FIRED"
+    wait_seconds = 130
+    prompt = (
+        "请用 schedule_new_task 工具创建一个一次性定时任务。"
+        "when 设为 90 秒后的 ISO 时间 (使用 iso: 前缀，UTC tz)，"
+        f"what 设为 `{marker} 测试`，"
+        "thread_name 设为 `e2e-newtask-thread`，"
+        "name 设为 `e2e_newtask`。target_channel_id 不要传，"
+        "用当前 channel。recurring 不要传。max_lifetime 不要传。"
+        "创建完只回\"好\"。"
+    )
+    msg = await driver.post(f"<@{BOT_USER_ID}> {prompt}")
+    ack_replies = await driver.wait_for_bot_reply(
+        msg, timeout=TIMEOUT_S, match="好"
+    )
+    if not ack_replies:
+        return CaseResult(
+            name="case_schedule_new_task_e2e",
+            status="FAIL",
+            detail="no creation ACK from claude within timeout",
+        )
+    fire_replies = await driver.wait_for_bot_reply(
+        msg, timeout=wait_seconds, match=marker
+    )
+    bot_texts = [driver._flatten(r) for r in fire_replies if driver._flatten(r).strip()]
+    saw_marker = any(marker in t for t in bot_texts)
+    saw_announce = any(
+        "Scheduled-task thread" in t or "scheduled-task thread" in t
+        for t in bot_texts
+    )
+    ok, reason = SCHEDULE_ASSERT_REGISTRY["schedule_new_task_fired"]()
+    if saw_marker and saw_announce and ok:
+        return CaseResult(
+            name="case_schedule_new_task_e2e",
+            status="PASS",
+            detail=f"marker+announce visible; {reason}",
+            bot_replies=bot_texts,
+        )
+    return CaseResult(
+        name="case_schedule_new_task_e2e",
+        status="FAIL",
+        detail=(
+            f"saw_marker={saw_marker} saw_announce={saw_announce} "
+            f"store_check_ok={ok} reason={reason!r}"
+        ),
+        bot_replies=bot_texts,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Report
 # ---------------------------------------------------------------------------
 
@@ -647,6 +825,8 @@ async def main():
         ("M6b 3rd-party with mention", case_3rd_party_thread_with_mention),
         ("Log dump (slash needed)", case_log_dump_via_command_emoji),
         ("Unbound refuse hint", case_unbound_refuse),
+        ("#241 /schedule message e2e", case_schedule_message_e2e),
+        ("#241 /schedule new_task e2e", case_schedule_new_task_e2e),
     ]
 
     results: list[CaseResult] = []

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -29,6 +29,9 @@ from .project_manager import ProjectManager
 from .session_manager import SessionManager
 from .session_config import SessionConfig
 from .session_store import SessionStore
+from .scheduler_store import SchedulerStore
+from .scheduler import SchedulerManager
+from . import scheduler_mcp
 from .cost_tracker import CostTracker
 from .agent_manager import AgentManager
 from . import stream_logger
@@ -262,6 +265,25 @@ async def _resolve_path_or_friendly_error(
     return None
 
 
+class _MagicResponse:
+    """Minimal ``aiohttp.ClientResponse`` stand-in for :class:`discord.NotFound`.
+
+    #241: when a scheduled fire targets a thread/channel that's no longer a
+    Thread/TextChannel (renamed, type-changed) we want to raise
+    ``discord.NotFound`` so :class:`SchedulerManager._fire_with_retry`
+    classifies it as terminal and disables the schedule. ``discord.NotFound``
+    requires a response object with a ``status`` attr to construct; this is
+    the cheapest stub that satisfies that constraint without depending on
+    aiohttp at the call site.
+    """
+
+    def __init__(self, status: int) -> None:
+        self.status = status
+        # ``reason`` is occasionally formatted into discord.py's NotFound
+        # repr; provide a non-None default so logs stay readable.
+        self.reason = "scheduler-fire target invalid"
+
+
 class ClaudedBot(commands.Bot):
     """Discord bot for the claudeD bridge."""
 
@@ -293,6 +315,34 @@ class ClaudedBot(commands.Bot):
         # logged the ownership-skip for; cleared on bot restart.
         self._logged_third_party_thread: set[int] = set()
 
+        # ---------------------------------------------------------------- #241
+        # Scheduler core (PRD v1.18 §3.7 / §8 Subtask 4): persistent timer
+        # store + manager wired with 3 callbacks (fire-message, fire-new-task,
+        # expire-notify). Per-target lock provider is the existing session
+        # manager's per-thread lock so fire executions serialize against
+        # human turns on the same thread.
+        # ----------------------------------------------------------------------
+        self.scheduler_store = SchedulerStore()  # default: data/schedules.json
+        self.scheduler = SchedulerManager(
+            self.scheduler_store,
+            fire_message_callback=self._fire_schedule_message,
+            fire_new_task_callback=self._fire_schedule_new_task,
+            expire_notify_callback=self._notify_schedule_expired,
+            get_lock=self.session_manager.get_lock,
+        )
+        # Per-turn context, set by `_register_scheduler_ctx` immediately
+        # before every claude turn so the MCP tool handlers can resolve
+        # "current thread" / "current channel" defaults.
+        self._scheduler_current_ctx: dict = {}
+        scheduler_mcp.set_scheduler_manager(
+            self.scheduler,
+            ctx_provider=self._scheduler_ctx_provider,
+        )
+        # `catch_up()` runs once on the first `_scheduler_tick` after the
+        # bot is ready so missed-fire bookkeeping happens with a live event
+        # loop (cannot be done from __init__).
+        self._scheduler_catch_up_done = False
+
     async def setup_hook(self) -> None:
         """Register slash command groups and sync to Discord."""
         # Cache claude version (#86)
@@ -308,6 +358,11 @@ class ClaudedBot(commands.Bot):
             self._claude_version = "unknown"
         self._cleanup_task.start()
         self._heartbeat_task.start()
+        # #241: scheduler tick loop. The first iteration also runs
+        # `catch_up()` (missed-fire bookkeeping); subsequent iterations
+        # just `tick()`. `_before_scheduler_tick` waits for the gateway
+        # so we don't try to resolve channels before the cache is warm.
+        self._scheduler_tick.start()
 
         # PRD R3.3 — register the persistent Copy-as-text button view so
         # the button keeps working after a bot restart.
@@ -341,6 +396,8 @@ class ClaudedBot(commands.Bot):
         )
         # #224 epic: /log dump diagnostic bundle (slash + auto-crash).
         from .cogs.log_dump import log_group
+        # #241: /schedule group (message/new_task/list/delete/toggle).
+        from .cogs.schedule import schedule_group
 
         self.tree.add_command(project_group)
         self.tree.add_command(session_group)
@@ -371,6 +428,8 @@ class ClaudedBot(commands.Bot):
         self.tree.add_command(diff_cmd)
         # #224: /log dump
         self.tree.add_command(log_group)
+        # #241: /schedule group (message/new_task/list/delete/toggle)
+        self.tree.add_command(schedule_group)
         # #185: do NOT sync globally here — historically claudeD synced
         # via both ``tree.sync()`` (global) AND PR-specific per-guild
         # PUT calls, so commands ended up registered in BOTH scopes and
@@ -1184,6 +1243,18 @@ class ClaudedBot(commands.Bot):
         to the original requester (#179 R1 security).
         """
         try:
+            # #241: register per-turn scheduler context BEFORE invoking the
+            # bridge so the in-process scheduler MCP tools can resolve
+            # "current thread / channel / guild" defaults when claude calls
+            # `schedule_message` / `schedule_new_task` / `schedule_list`.
+            self._register_scheduler_ctx(
+                thread_id=getattr(thread, "id", None) or 0,
+                channel_id=(
+                    getattr(thread, "parent_id", None)
+                    or getattr(thread, "id", None)
+                ),
+                guild_id=getattr(getattr(thread, "guild", None), "id", None),
+            )
             await renderer.render_response(bridge, user_text, author_id=author_id)
         except Exception as exc:
             if is_transient_discord_error(exc):
@@ -1285,6 +1356,304 @@ class ClaudedBot(commands.Bot):
                     )
 
             await renderer.send_error_with_retry(exc, _on_retry)
+
+    # ------------------------------------------------------------------
+    # #241 — scheduler ctx provider + tick loop + fire callbacks
+    # ------------------------------------------------------------------
+
+    def _scheduler_ctx_provider(self) -> dict:
+        """Return the most recently registered per-turn scheduler context.
+
+        Consumed by ``scheduler_mcp._GLOBAL_CTX`` so tool handlers running
+        inside a claude turn can default ``target_thread_id`` /
+        ``target_channel_id`` to the thread/channel the turn originated
+        from. Returns ``{}`` if no turn is active (tool would then need an
+        explicit arg or surface a ctx-missing error).
+        """
+        return getattr(self, "_scheduler_current_ctx", {}) or {}
+
+    def _register_scheduler_ctx(
+        self,
+        *,
+        thread_id: int | None,
+        channel_id: int | None,
+        guild_id: int | None,
+        tz_name: str = "Asia/Shanghai",
+    ) -> None:
+        """Set the per-turn scheduler context.
+
+        Called immediately BEFORE every claude turn (natural ``@bot``
+        conversations via :meth:`_render_with_retry`, slash-injected turns
+        via :mod:`clauded.cogs.schedule`, scheduled-fire turns via the
+        ``_fire_schedule_*`` methods). PRD §3.7 — the ctx is what makes
+        the in-process MCP tools "know" which thread they're acting on.
+        """
+        self._scheduler_current_ctx = {
+            "thread_id": thread_id,
+            "channel_id": channel_id,
+            "guild_id": guild_id,
+            "tz_name": tz_name,
+        }
+
+    @tasks.loop(seconds=15)
+    async def _scheduler_tick(self) -> None:
+        """Periodic scheduler tick. First iteration also runs ``catch_up()``.
+
+        Exceptions are swallowed + logged so a single bad schedule (e.g. a
+        corrupt next_fire_at) can't kill the whole tick loop. The next
+        iteration retries automatically — terminal failures are handled
+        inside ``SchedulerManager._fire_with_retry`` which disables the
+        bad schedule rather than bubbling out.
+        """
+        try:
+            if not self._scheduler_catch_up_done:
+                await self.scheduler.catch_up()
+                self._scheduler_catch_up_done = True
+            await self.scheduler.tick()
+        except Exception:
+            log.exception("#241 scheduler tick failed; will retry next interval")
+
+    @_scheduler_tick.before_loop
+    async def _before_scheduler_tick(self) -> None:
+        await self.wait_until_ready()
+
+    async def _fire_schedule_message(self, sched: dict) -> None:
+        """Kind=message fire: inject ``what`` as a user message into the
+        target thread's existing session.
+
+        Steps (per PRD §3.8):
+          1. Resolve the target thread; raise :class:`discord.NotFound`
+             if the channel is gone (the manager will mark the schedule
+             terminal-disabled).
+          2. Resolve the parent channel + binding; raise on unbind so
+             the schedule auto-disables.
+          3. Get-or-resurrect the session (using the stored
+             ``resume_session_id`` if the live bridge has died).
+          4. Send the fire prefix line + a Discord-quoted view of ``what``
+             so the injection is visible to humans (PRD §3.8 / AC13).
+          5. Register the per-turn scheduler ctx.
+          6. Hand off to :class:`DiscordRenderer.render_response`.
+        """
+        thread_id = sched.get("target_thread_id")
+        if not isinstance(thread_id, int):
+            raise ValueError(
+                f"#241 schedule missing target_thread_id: "
+                f"{sched.get('schedule_id')}"
+            )
+        thread = self.get_channel(thread_id)
+        if thread is None:
+            thread = await self.fetch_channel(thread_id)
+        if not isinstance(thread, discord.Thread):
+            raise discord.NotFound(
+                _MagicResponse(404),
+                f"target {thread_id} is not a Thread",
+            )
+
+        parent_id = thread.parent_id or sched.get("channel_id")
+        if not parent_id:
+            raise RuntimeError("can't resolve parent channel for schedule fire")
+        project_path = self.project_manager.get_path(parent_id)
+        if not project_path:
+            raise RuntimeError(f"channel {parent_id} not bound")
+
+        # Get-or-resurrect session: if the live bridge died (process
+        # restart, /session stop, etc.), use the persisted resume id so
+        # the injected message lands in the same conversation history.
+        bridge = self.session_manager.get_session(thread_id)
+        if bridge is None or not getattr(bridge, "is_active", False):
+            stored = self.session_manager.get_stored_session(thread_id)
+            resume_id = stored.get("session_id") if stored else None
+            sc = SessionConfig(
+                system_prompt=self.project_manager.get_system_prompt(parent_id),
+                resume_session_id=resume_id,
+                add_dirs=self.project_manager.get_extra_dirs(parent_id) or None,
+                mcp_servers=(
+                    self.project_manager.get_mcp_servers(parent_id) or None
+                ),
+                env=self.project_manager.get_env(parent_id) or None,
+                user="scheduled-fire",
+            )
+            bridge = await self.session_manager.create_session(
+                thread_id, project_path, self.config, sc,
+            )
+
+        self._register_scheduler_ctx(
+            thread_id=thread_id,
+            channel_id=parent_id,
+            guild_id=getattr(getattr(thread, "guild", None), "id", None),
+        )
+
+        fire_label = sched.get("name") or (sched.get("schedule_id", "") or "")[:8]
+        what = (sched.get("payload") or {}).get("what", "") or ""
+        # Prefix + Discord-quoted view of `what` so the injection is visible
+        # to humans (PRD AC13). 1900-char ceiling leaves headroom under
+        # Discord's hard 2000 limit for the quote prefix characters.
+        try:
+            await thread.send(content=f"-# ⏰ Scheduled fire: {fire_label}")
+            quoted = (
+                "\n".join(f"> {line}" for line in what.splitlines())
+                or f"> {what}"
+            )
+            await thread.send(content=quoted[:1900])
+        except Exception as exc:
+            log.warning(
+                "#241 prefix/quoted send failed for sched=%s: %s",
+                sched.get("schedule_id"), exc,
+            )
+
+        renderer = DiscordRenderer(
+            thread,
+            bot=self,
+            project_path=Path(project_path) if project_path else None,
+        )
+        await renderer.render_response(bridge, what)
+
+    async def _fire_schedule_new_task(self, sched: dict) -> None:
+        """Kind=new_task fire: spawn a fresh thread + fresh session, inject
+        ``what`` as that new session's first user prompt.
+
+        Steps (per PRD §3.8):
+          1. Resolve the target channel; raise NotFound on disappearance.
+          2. Check binding (unbound → raise → manager disables).
+          3. Create a public thread (auto_archive=1440min, name capped at
+             100 chars).
+          4. Announce the new thread in the parent channel.
+          5. Build a fresh ``SessionConfig`` (no ``resume_session_id``).
+          6. Send the fire prefix + Discord-quoted ``what`` into the new
+             thread (PRD AC13).
+          7. Register scheduler ctx + hand off to ``DiscordRenderer``.
+        """
+        channel_id = sched.get("target_channel_id")
+        if not isinstance(channel_id, int):
+            raise ValueError(
+                f"#241 schedule missing target_channel_id: "
+                f"{sched.get('schedule_id')}"
+            )
+        channel = self.get_channel(channel_id)
+        if channel is None:
+            channel = await self.fetch_channel(channel_id)
+        if not isinstance(channel, discord.TextChannel):
+            raise discord.NotFound(
+                _MagicResponse(404),
+                f"target {channel_id} not a text channel",
+            )
+
+        project_path = self.project_manager.get_path(channel_id)
+        if not project_path:
+            raise RuntimeError(f"channel {channel_id} not bound")
+
+        # Build the thread name: claude can override via the ``thread_name``
+        # tool arg (PRD §3.8); otherwise we synthesize "⏰ {schedule_name}
+        # {fire_ts:%m-%d %H:%M}" so the user sees when each fire happened.
+        from datetime import datetime as _dt
+        fire_label = sched.get("name") or (sched.get("schedule_id", "") or "")[:8]
+        thread_name_raw = (
+            sched.get("thread_name")
+            or f"⏰ {fire_label} {_dt.now().strftime('%m-%d %H:%M')}"
+        )
+        thread_name = thread_name_raw[:100]
+
+        thread = await channel.create_thread(
+            name=thread_name,
+            type=discord.ChannelType.public_thread,
+            auto_archive_duration=1440,
+        )
+
+        # Parent-channel announce — best-effort. PRD §3.8: lets channel
+        # members see that the bot just spun up a scheduled-task thread.
+        try:
+            embed = discord.Embed(
+                title="📌 Scheduled-task thread created",
+                description=(
+                    f"{thread.mention} (schedule "
+                    f"`{(sched.get('schedule_id','') or '')[:8]}`)"
+                ),
+                color=COLOR_INFO,
+            )
+            await channel.send(embed=embed)
+        except Exception as exc:
+            log.warning(
+                "#241 new_task announce failed for sched=%s: %s",
+                sched.get("schedule_id"), exc,
+            )
+
+        # Fresh session — explicitly no resume id so this thread starts
+        # with empty conversation context, matching PRD §3.1 Kind 2
+        # semantics ("inject `what` as that session's first user prompt").
+        sc = SessionConfig(
+            system_prompt=self.project_manager.get_system_prompt(channel_id),
+            resume_session_id=None,
+            add_dirs=self.project_manager.get_extra_dirs(channel_id) or None,
+            mcp_servers=(
+                self.project_manager.get_mcp_servers(channel_id) or None
+            ),
+            env=self.project_manager.get_env(channel_id) or None,
+            user="scheduled-fire-newtask",
+        )
+        bridge = await self.session_manager.create_session(
+            thread.id, project_path, self.config, sc,
+        )
+
+        self._register_scheduler_ctx(
+            thread_id=thread.id,
+            channel_id=channel_id,
+            guild_id=getattr(channel.guild, "id", None),
+        )
+
+        what = (sched.get("payload") or {}).get("what", "") or ""
+        try:
+            await thread.send(content=f"-# ⏰ Scheduled fire: {fire_label}")
+            quoted = (
+                "\n".join(f"> {line}" for line in what.splitlines())
+                or f"> {what}"
+            )
+            await thread.send(content=quoted[:1900])
+        except Exception as exc:
+            log.warning(
+                "#241 newtask prefix/quoted send failed: %s", exc
+            )
+
+        renderer = DiscordRenderer(
+            thread,
+            bot=self,
+            project_path=Path(project_path) if project_path else None,
+        )
+        await renderer.render_response(bridge, what)
+
+    async def _notify_schedule_expired(self, sched: dict) -> None:
+        """Notify the schedule's created channel that its max_lifetime fired.
+
+        Called by :meth:`SchedulerManager._check_max_lifetime` once the
+        cumulative lifetime since first fire has elapsed (PRD §3.8). Best-
+        effort: failures are logged but never bubble — the schedule is
+        already disabled by the time we get here.
+        """
+        channel_id = sched.get("channel_id")
+        if not channel_id:
+            log.info(
+                "#241 expire-notify but no channel_id on sched=%s",
+                sched.get("schedule_id"),
+            )
+            return
+        try:
+            channel = self.get_channel(channel_id)
+            if channel is None:
+                channel = await self.fetch_channel(channel_id)
+            embed = discord.Embed(
+                title="⏰ Schedule expired",
+                description=(
+                    f"Schedule `{(sched.get('schedule_id','') or '')[:8]}` "
+                    f"(*{sched.get('name','')}*) reached its max_lifetime "
+                    f"and has been auto-disabled."
+                ),
+                color=COLOR_INFO,
+            )
+            await channel.send(embed=embed)
+        except Exception:
+            log.exception(
+                "#241 expire-notify failed for sched=%s",
+                sched.get("schedule_id"),
+            )
 
     # ------------------------------------------------------------------
     # #224 epic Subtask 4 — auto-crash bundle dispatch

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -16,6 +16,7 @@ import time
 import traceback
 import sys
 import asyncio
+import contextvars
 from pathlib import Path
 
 import discord
@@ -32,6 +33,7 @@ from .session_store import SessionStore
 from .scheduler_store import SchedulerStore
 from .scheduler import SchedulerManager
 from . import scheduler_mcp
+from .scheduler_mcp import set_ctx as _scheduler_set_ctx, get_ctx as _scheduler_get_ctx
 from .cost_tracker import CostTracker
 from .agent_manager import AgentManager
 from . import stream_logger
@@ -71,6 +73,26 @@ _VISION_MEDIA_TYPE = {
     ".gif": "image/gif",
     ".webp": "image/webp",
 }
+
+
+# --------------------------------------------------------------------------
+# #241 — module-level ContextVar for the per-turn scheduler context.
+#
+# Architect R1 + Engineer R1 (BLOCKER #2): per-turn ctx (thread_id /
+# channel_id / guild_id / tz_name) used to live on ``ClaudedBot`` as a
+# single mutable instance attribute. Every concurrent claude turn — be it
+# two ``@bot`` messages in different threads or two scheduled-fire
+# callbacks aimed at different targets — overwrites the same dict between
+# its register-ctx and its ``renderer.render_response`` await. When the
+# in-process scheduler MCP tools resolved "current thread" they read
+# whatever fire/turn last touched the attribute, occasionally pointing at
+# a sibling turn's thread. Fix: put ctx in a ``contextvars.ContextVar``;
+# asyncio copies the running context per ``create_task``, so each task
+# has its own snapshot for free.
+# --------------------------------------------------------------------------
+_scheduler_ctx_var: contextvars.ContextVar[dict] = contextvars.ContextVar(
+    "scheduler_ctx", default={}
+)
 
 
 # --------------------------------------------------------------------------
@@ -329,6 +351,11 @@ class ClaudedBot(commands.Bot):
             fire_new_task_callback=self._fire_schedule_new_task,
             expire_notify_callback=self._notify_schedule_expired,
             get_lock=self.session_manager.get_lock,
+            # M4: surface "channel not bound" at create() time rather than
+            # 30 days later at fire time. The manager calls this for every
+            # kind=new_task create; unbound channels are rejected before
+            # they hit the store.
+            bound_checker=self.project_manager.is_bound,
         )
         # Per-turn context, set by `_register_scheduler_ctx` immediately
         # before every claude turn so the MCP tool handlers can resolve
@@ -1369,8 +1396,19 @@ class ClaudedBot(commands.Bot):
         ``target_channel_id`` to the thread/channel the turn originated
         from. Returns ``{}`` if no turn is active (tool would then need an
         explicit arg or surface a ctx-missing error).
+
+        B2: prefers :func:`scheduler_mcp.get_ctx` (the module-level
+        ``ContextVar``) over the local bot-instance copy. This makes the
+        provider correct under concurrent fires/turns — each task's
+        ``ContextVar`` slot was set by its own ``_register_scheduler_ctx``
+        call and is invisible to siblings. The bot-instance
+        ``_scheduler_ctx_var`` / ``_scheduler_current_ctx`` are kept as
+        fallback / mirror for legacy tests reading the attribute directly.
         """
-        return getattr(self, "_scheduler_current_ctx", {}) or {}
+        cv = _scheduler_get_ctx()
+        if cv:
+            return cv
+        return _scheduler_ctx_var.get() or {}
 
     def _register_scheduler_ctx(
         self,
@@ -1387,13 +1425,35 @@ class ClaudedBot(commands.Bot):
         via :mod:`clauded.cogs.schedule`, scheduled-fire turns via the
         ``_fire_schedule_*`` methods). PRD §3.7 — the ctx is what makes
         the in-process MCP tools "know" which thread they're acting on.
+
+        B2: this now writes to BOTH the module-level ContextVar in
+        :mod:`scheduler_mcp` (via :func:`scheduler_mcp.set_ctx`) AND the
+        bot-instance ``contextvars.ContextVar``. The scheduler_mcp one
+        is what tool handlers actually read via :func:`scheduler_mcp.get_ctx`
+        / :func:`scheduler_mcp._resolve_ctx`; the bot-instance ContextVar
+        is kept for the legacy ``_scheduler_ctx_provider`` fallback. Both
+        ``set`` calls only mutate the current asyncio task's context, so
+        two concurrent fires / turns can't clobber each other's "current
+        thread" between register-ctx and ``render_response``. The
+        mirroring instance attribute is kept purely so existing tests
+        that read ``bot._scheduler_current_ctx`` directly continue to
+        pass — production code should never reach for it; use
+        :meth:`_scheduler_ctx_provider` instead.
         """
-        self._scheduler_current_ctx = {
+        ctx = {
             "thread_id": thread_id,
             "channel_id": channel_id,
             "guild_id": guild_id,
             "tz_name": tz_name,
         }
+        _scheduler_ctx_var.set(ctx)
+        # B2: also publish into scheduler_mcp's ContextVar so tool
+        # handlers running in this task pick it up via _resolve_ctx
+        # without depending on the bot-instance provider callable.
+        _scheduler_set_ctx(ctx)
+        # Mirror for legacy direct-attribute readers (tests). The
+        # ContextVars are the source of truth.
+        self._scheduler_current_ctx = ctx
 
     @tasks.loop(seconds=15)
     async def _scheduler_tick(self) -> None:
@@ -1416,6 +1476,113 @@ class ClaudedBot(commands.Bot):
     @_scheduler_tick.before_loop
     async def _before_scheduler_tick(self) -> None:
         await self.wait_until_ready()
+
+    # ------------------------------------------------------------------
+    # #241 — fire-callback shared helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _format_fire_quoted_what(what: str) -> str:
+        """Format ``what`` as a Discord block-quoted snippet for the fire prefix.
+
+        B6 / PRD §3.8 (AC13): every line of the injected ``what`` is
+        independently wrapped in 「…」 corner brackets and then prefixed
+        with Discord's ``>`` quote marker, so the user sees a clearly
+        visible record of exactly what string was injected into claude's
+        context. Empty input renders an empty block-quote rather than the
+        old ``"> "`` (literal "> " plus empty line) fallback.
+
+        Wrapping happens per line (not once around the whole multi-line
+        body) so each visible line in the channel reads as a self-contained
+        bracketed unit — important when ``what`` contains tool output or
+        anything multi-paragraph.
+        """
+        lines = what.splitlines() if what else []
+        if not lines:
+            # Empty / single-newline what: render an empty quote so the
+            # AC13 marker still shows but no bogus content leaks.
+            return "> 「」"
+        return "\n".join(f"> 「{line}」" for line in lines)
+
+    async def _send_fire_prefix_and_quote(
+        self,
+        thread,
+        fire_label: str,
+        what: str,
+        *,
+        sched_id_for_log: str = "",
+    ) -> None:
+        """Best-effort send of the AC13 prefix line + block-quoted ``what``.
+
+        Failures are swallowed + logged: the actual claude turn still
+        runs even if these "humans can see what just got injected" sends
+        fail (network blip, permissions). The 1900-char ceiling leaves
+        headroom under Discord's 2000-char message limit.
+        """
+        try:
+            await thread.send(content=f"-# ⏰ Scheduled fire: {fire_label}")
+            quoted = self._format_fire_quoted_what(what)
+            await thread.send(content=quoted[:1900])
+        except Exception as exc:
+            log.warning(
+                "#241 prefix/quoted send failed for sched=%s: %s",
+                sched_id_for_log, exc,
+            )
+
+    async def _safe_fire_render(
+        self,
+        *,
+        renderer: DiscordRenderer,
+        bridge,  # ClaudeBridge — typed loosely to avoid an extra import
+        what: str,
+        thread,
+    ) -> None:
+        """Run ``renderer.render_response`` for a scheduled fire with crash safety.
+
+        M3: scheduled fires used to call ``renderer.render_response``
+        directly, which meant any renderer crash propagated up to
+        ``_fire_with_retry`` → 1s/4s/16s backoff → permanent
+        terminal-disable for a one-off presentation-layer bug. Worse, no
+        #224 auto-crash bundle was dispatched, so the scheduled-fire
+        crash never made it into the audit trail.
+
+        This helper mirrors :meth:`_render_with_retry` but without the
+        Retry button (a scheduled fire has no human to click it) and
+        without bridge-resurrection (the next fire will create or
+        resurrect on its own). Renderer crashes are still ``raise``-d so
+        ``_fire_with_retry`` can classify them — but the auto-crash
+        bundle dispatch happens regardless.
+        """
+        try:
+            await renderer.render_response(bridge, what)
+        except Exception as exc:
+            if is_transient_discord_error(exc):
+                # _retry_http exhausted at the lower layer; let the
+                # scheduler treat this as transient + retry.
+                log.warning(
+                    "#241 fire render exhausted retries (transient); "
+                    "bubbling for scheduler retry: %s", exc,
+                )
+                raise
+            log.exception(
+                "#241 scheduled-fire renderer crashed; dispatching crash bundle"
+            )
+            # #224 auto-crash bundle — same as human-driven turns get via
+            # ``_render_with_retry``. The scheduled-fire surface is the
+            # one most likely to crash without a human nearby, so the
+            # audit trail matters more here than elsewhere.
+            try:
+                await self._maybe_dispatch_auto_crash_bundle(
+                    thread=thread,
+                    exc=exc,
+                    bridge=bridge,
+                )
+            except Exception:
+                log.exception(
+                    "#241 auto-crash bundle dispatch itself crashed; "
+                    "swallowing so we still raise the original"
+                )
+            raise
 
     async def _fire_schedule_message(self, sched: dict) -> None:
         """Kind=message fire: inject ``what`` as a user message into the
@@ -1485,28 +1652,24 @@ class ClaudedBot(commands.Bot):
 
         fire_label = sched.get("name") or (sched.get("schedule_id", "") or "")[:8]
         what = (sched.get("payload") or {}).get("what", "") or ""
-        # Prefix + Discord-quoted view of `what` so the injection is visible
-        # to humans (PRD AC13). 1900-char ceiling leaves headroom under
-        # Discord's hard 2000 limit for the quote prefix characters.
-        try:
-            await thread.send(content=f"-# ⏰ Scheduled fire: {fire_label}")
-            quoted = (
-                "\n".join(f"> {line}" for line in what.splitlines())
-                or f"> {what}"
-            )
-            await thread.send(content=quoted[:1900])
-        except Exception as exc:
-            log.warning(
-                "#241 prefix/quoted send failed for sched=%s: %s",
-                sched.get("schedule_id"), exc,
-            )
+        # B6/AC13: prefix + per-line 「<line>」 quote so humans can see what
+        # got injected. M3: helper centralizes the format + best-effort send.
+        await self._send_fire_prefix_and_quote(
+            thread, fire_label, what,
+            sched_id_for_log=sched.get("schedule_id", "") or "",
+        )
 
         renderer = DiscordRenderer(
             thread,
             bot=self,
             project_path=Path(project_path) if project_path else None,
         )
-        await renderer.render_response(bridge, what)
+        # M3: wrap render in crash-bundle-safe helper so a one-off renderer
+        # exception doesn't terminal-disable a recurring schedule + lose
+        # the #224 audit trail.
+        await self._safe_fire_render(
+            renderer=renderer, bridge=bridge, what=what, thread=thread,
+        )
 
     async def _fire_schedule_new_task(self, sched: dict) -> None:
         """Kind=new_task fire: spawn a fresh thread + fresh session, inject
@@ -1553,11 +1716,50 @@ class ClaudedBot(commands.Bot):
         )
         thread_name = thread_name_raw[:100]
 
-        thread = await channel.create_thread(
-            name=thread_name,
-            type=discord.ChannelType.public_thread,
-            auto_archive_duration=1440,
-        )
+        # M2 idempotency: if a prior attempt of THIS fire already created
+        # a thread (transient failure between create_thread and the rest
+        # of the callback), reuse it instead of creating a sibling. The
+        # cached id lives in ``state._new_task_thread_id`` and is cleared
+        # in ``_on_fire_success``, so the *next* scheduled occurrence
+        # still creates a fresh thread.
+        state = sched.setdefault("state", {})
+        cached_thread_id = state.get("_new_task_thread_id")
+        thread = None
+        if cached_thread_id:
+            cached = self.get_channel(cached_thread_id)
+            if cached is None:
+                try:
+                    cached = await self.fetch_channel(cached_thread_id)
+                except Exception:
+                    cached = None
+            if isinstance(cached, discord.Thread):
+                thread = cached
+                log.info(
+                    "#241 new_task fire reusing thread %s for retry sched=%s",
+                    cached_thread_id, sched.get("schedule_id"),
+                )
+            else:
+                # Cached id no longer resolves to a thread (deleted,
+                # archived to nothing). Drop the cache and create fresh.
+                state["_new_task_thread_id"] = None
+
+        if thread is None:
+            thread = await channel.create_thread(
+                name=thread_name,
+                type=discord.ChannelType.public_thread,
+                auto_archive_duration=1440,
+            )
+            # Persist the new thread id immediately so a transient failure
+            # after this point reuses it on retry. Best-effort: a save
+            # failure logs but doesn't abort the fire.
+            try:
+                state["_new_task_thread_id"] = thread.id
+                self.scheduler_store.save(sched)
+            except Exception as exc:
+                log.warning(
+                    "#241 failed to persist _new_task_thread_id sched=%s: %s",
+                    sched.get("schedule_id"), exc,
+                )
 
         # Parent-channel announce — best-effort. PRD §3.8: lets channel
         # members see that the bot just spun up a scheduled-task thread.
@@ -1601,24 +1803,23 @@ class ClaudedBot(commands.Bot):
         )
 
         what = (sched.get("payload") or {}).get("what", "") or ""
-        try:
-            await thread.send(content=f"-# ⏰ Scheduled fire: {fire_label}")
-            quoted = (
-                "\n".join(f"> {line}" for line in what.splitlines())
-                or f"> {what}"
-            )
-            await thread.send(content=quoted[:1900])
-        except Exception as exc:
-            log.warning(
-                "#241 newtask prefix/quoted send failed: %s", exc
-            )
+        # B6/AC13: shared prefix + per-line 「<line>」 quote helper.
+        await self._send_fire_prefix_and_quote(
+            thread, fire_label, what,
+            sched_id_for_log=sched.get("schedule_id", "") or "",
+        )
 
         renderer = DiscordRenderer(
             thread,
             bot=self,
             project_path=Path(project_path) if project_path else None,
         )
-        await renderer.render_response(bridge, what)
+        # M3: crash-bundle-safe render. See ``_fire_schedule_message`` for
+        # full rationale — renderer crash here would terminal-disable a
+        # weekly recurring task on a one-off bug, with no audit trail.
+        await self._safe_fire_render(
+            renderer=renderer, bridge=bridge, what=what, thread=thread,
+        )
 
     async def _notify_schedule_expired(self, sched: dict) -> None:
         """Notify the schedule's created channel that its max_lifetime fired.

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -245,6 +245,28 @@ class ClaudeBridge:
         """True iff the underlying client is currently connected."""
         return self._active
 
+    def _build_mcp_servers(self) -> dict:
+        """Merge user-configured MCP servers with the in-process scheduler server.
+
+        #241: always include the ``clauded-scheduler`` in-process MCP server
+        so claude can manage schedules in any session/turn (PRD §3.7 — the
+        tool surface is intentionally global, not hot-loaded per slash). The
+        scheduler server is best-effort: if its build raises (e.g. SDK
+        version skew), we log a warning and continue without it rather than
+        crashing every session start.
+        """
+        merged: dict = dict(self._mcp_servers or {})
+        try:
+            from .scheduler_mcp import build_scheduler_mcp_server
+            merged["clauded-scheduler"] = build_scheduler_mcp_server()
+        except Exception as exc:
+            log.warning(
+                "#241: failed to build scheduler MCP server; schedule_* "
+                "tools will not be available: %s",
+                exc,
+            )
+        return merged
+
     async def get_server_info(self) -> dict | None:
         """Return cached server init info, or ``None`` if not connected.
 
@@ -487,7 +509,7 @@ class ClaudeBridge:
             disallowed_tools=self._disallowed_tools,
             extra_args=extra_args,
             add_dirs=self._add_dirs,
-            mcp_servers=self._mcp_servers or {},
+            mcp_servers=self._build_mcp_servers(),
             max_turns=self._max_turns,
             # Feature #60: SDK hooks
             hooks=hooks,

--- a/src/clauded/cogs/schedule.py
+++ b/src/clauded/cogs/schedule.py
@@ -285,14 +285,87 @@ async def schedule_new_task_cmd(
     """
     bot = interaction.client
     channel = interaction.channel
-    if not isinstance(channel, discord.Thread):
+    # M11: ``/schedule new_task`` is the natural surface for "schedule a
+    # task that should run in its OWN thread later." The original
+    # implementation forced the *creating* turn to also be inside a
+    # thread — but the user often discovers this command in the bound
+    # channel itself ("hey bot, set up a weekly task here"). Allow a
+    # text-channel entry by auto-spinning a one-shot helper thread for
+    # the creation turn; the schedule, once created, still spawns a
+    # fresh thread at each fire-time per PRD §3.8 Kind 2.
+    if isinstance(channel, discord.Thread):
+        thread = channel
+        binding_id = channel.parent_id
+    elif isinstance(channel, discord.TextChannel):
+        binding_id = channel.id
+        if binding_id is None or not bot.project_manager.is_bound(binding_id):
+            await interaction.response.send_message(
+                "❌ This channel isn't bound to a project. "
+                "Run `/project bind <path>` first.",
+                ephemeral=True,
+            )
+            return
+        # Acknowledge before the (potentially slow) thread creation so
+        # we don't blow the 3s Discord interaction window.
         await interaction.response.send_message(
-            "/schedule new_task must be used inside a thread "
-            "(claude needs a session to call the tool).",
+            "⏰ Opening helper thread for schedule creation…",
+            ephemeral=False,
+        )
+        try:
+            thread = await channel.create_thread(
+                name=f"⏰ schedule {interaction.user.display_name}"[:100],
+                type=discord.ChannelType.public_thread,
+                auto_archive_duration=60,  # 1h — this thread is transient
+            )
+        except Exception as exc:
+            log.exception("/schedule new_task: helper thread create failed")
+            try:
+                await channel.send(embed=discord.Embed(
+                    title="❌ Failed to create helper thread",
+                    description=f"```\n{str(exc)[:500]}\n```",
+                    color=COLOR_TOOL_FAILURE,
+                ))
+            except Exception:
+                pass
+            return
+        try:
+            bridge = await _ensure_bridge(
+                bot, thread.id, binding_id, interaction.user.name,
+            )
+        except Exception as exc:
+            log.exception("/schedule new_task: failed to start bridge")
+            await thread.send(embed=discord.Embed(
+                title="❌ Failed to open session",
+                description=f"```\n{str(exc)[:500]}\n```",
+                color=COLOR_TOOL_FAILURE,
+            ))
+            return
+        bot._register_scheduler_ctx(
+            thread_id=thread.id,
+            channel_id=binding_id,
+            guild_id=getattr(channel.guild, "id", None),
+        )
+        full = _REMINDER_NEW_TASK.format(user_text=text)
+        project_path = bot.project_manager.get_path(binding_id)
+        renderer = DiscordRenderer(
+            thread,
+            bot=bot,
+            project_path=Path(project_path) if project_path else None,
+        )
+        try:
+            await renderer.render_response(
+                bridge, full, author_id=interaction.user.id,
+            )
+        except Exception:
+            log.exception("/schedule new_task render failed (channel branch)")
+        return
+    else:
+        await interaction.response.send_message(
+            "/schedule new_task must be used inside a thread or text channel.",
             ephemeral=True,
         )
         return
-    binding_id = channel.parent_id
+
     if binding_id is None:
         await interaction.response.send_message(
             NO_CHANNEL_MESSAGE, ephemeral=True,
@@ -313,11 +386,11 @@ async def schedule_new_task_cmd(
 
     try:
         bridge = await _ensure_bridge(
-            bot, channel.id, binding_id, interaction.user.name,
+            bot, thread.id, binding_id, interaction.user.name,
         )
     except Exception as exc:
         log.exception("/schedule new_task: failed to start bridge")
-        await channel.send(embed=discord.Embed(
+        await thread.send(embed=discord.Embed(
             title="❌ Failed to open session",
             description=f"```\n{str(exc)[:500]}\n```",
             color=COLOR_TOOL_FAILURE,
@@ -325,14 +398,14 @@ async def schedule_new_task_cmd(
         return
 
     bot._register_scheduler_ctx(
-        thread_id=channel.id,
+        thread_id=thread.id,
         channel_id=binding_id,
-        guild_id=getattr(channel.guild, "id", None),
+        guild_id=getattr(thread.guild, "id", None),
     )
     full = _REMINDER_NEW_TASK.format(user_text=text)
     project_path = bot.project_manager.get_path(binding_id)
     renderer = DiscordRenderer(
-        channel,
+        thread,
         bot=bot,
         project_path=Path(project_path) if project_path else None,
     )
@@ -412,9 +485,20 @@ async def schedule_list_cmd(
         nfa = state.get("next_fire_at", "") or "?"
         cnt = state.get("fire_count", 0)
         en_suffix = "" if state.get("enabled") else " (disabled)"
+        # M10: surface missed_count + last_fired_at + max_lifetime so
+        # ``/schedule list`` shows the same diagnostic detail that
+        # ``schedule_list`` (claude-facing MCP tool) returns. Without these
+        # fields users can't tell from the embed whether a schedule has
+        # ever fired, has been missing fires (catch_up rolled it forward),
+        # or is racing against its lifetime cap.
+        missed = state.get("missed_count", 0) or 0
+        last_fired = state.get("last_fired_at") or "—"
+        max_life = s.get("max_lifetime_seconds")
+        max_life_str = f"{max_life}s" if max_life else "—"
         lines.append(
             f"{kind_marker} {by_marker} `{sid}` {name} — next={nfa} "
-            f"fires={cnt}{en_suffix}"
+            f"fires={cnt} missed={missed} last={last_fired} "
+            f"max_lifetime={max_life_str}{en_suffix}"
         )
 
     embed = discord.Embed(

--- a/src/clauded/cogs/schedule.py
+++ b/src/clauded/cogs/schedule.py
@@ -1,0 +1,514 @@
+"""#241 — ``/schedule`` slash command group (5 subcommands).
+
+PRD: ``docs/prd/v1.18-scheduler.md`` §3.2 / §6 / §8 Subtask 4.
+
+The five subcommands split by who actually creates the schedule:
+
+* ``/schedule message <text>``   — injects PRD §6.1 system-reminder + the
+  user's text as a normal claude turn; claude then calls the
+  ``schedule_message`` MCP tool to actually create the schedule.
+* ``/schedule new_task <text>``  — same flow for kind=new_task (PRD §6.2).
+* ``/schedule list``             — cog calls :class:`SchedulerStore` directly
+  (no claude turn needed).
+* ``/schedule delete <id>``      — cog calls
+  :meth:`SchedulerManager.delete` directly.
+* ``/schedule toggle <id> <enabled>`` — direct toggle, mirror of delete.
+
+The natural-language → tool-args translation happens *inside the claude
+turn* — the cog just provides the system-reminder template that instructs
+claude to call the right tool. This keeps the cog dumb (no datetime
+parsing here) while letting users say "明天 9 点提醒我开会" / "every
+Monday 9am".
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import discord
+from discord import app_commands
+
+from ._unbound import NO_CHANNEL_MESSAGE
+from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE, DiscordRenderer
+from ..session_config import SessionConfig
+
+log = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------
+# System reminder templates — verbatim from PRD §6.1 / §6.2. These are the
+# exact strings approved in the PRD; do not edit without re-getting user
+# sign-off (the wording was chosen to force claude into the tool-call path
+# rather than responding in plain text).
+# --------------------------------------------------------------------------
+
+_REMINDER_MESSAGE = """\
+<system-reminder>
+The user just invoked `/schedule message`. You MUST call the
+`schedule_message` tool to fulfill this request. Do not respond
+with text explanation alone — call `schedule_message` as your first
+action.
+
+`schedule_message` creates a timer that, when it fires, will inject
+a user message into a Discord thread's existing session. The target
+session will continue its conversation as if the user typed that
+message themselves.
+
+When parsing the user's text:
+- Extract `when` as either `"cron: <5-field>"` (recurring) or
+  `"iso: <ISO 8601 with tz>"` (one-shot). Convert natural language
+  like "明天 9 点" / "每周一 9am" using the channel's timezone
+  (default Asia/Shanghai).
+- Extract `what` — the message text that will be injected when the
+  timer fires. Phrase it from the user's first-person point of view
+  (e.g. "提醒我开会" not "remind the user about meeting"), since the
+  session will see it as a user message.
+- If the user said the schedule should only last for a certain
+  duration (e.g. "持续一个月" / "for the next week"), set
+  `max_lifetime` to a duration string like `"30d"` / `"7d"`
+  (max 365d). Only valid with recurring=true.
+- `target_thread_id` defaults to the current thread; only set it if
+  the user explicitly named a different thread.
+- Pick a short `name` (≤50 chars) if not obvious from the text.
+
+After calling the tool, respond briefly to the user confirming what
+was scheduled and the next_fire_at.
+</system-reminder>
+
+<user-text>{user_text}</user-text>
+"""
+
+_REMINDER_NEW_TASK = """\
+<system-reminder>
+The user just invoked `/schedule new_task`. You MUST call the
+`schedule_new_task` tool. Do not respond with text explanation alone.
+
+`schedule_new_task` creates a timer that, when it fires, will spawn a
+BRAND NEW Discord thread + a FRESH claude session, then submit `what`
+as that session's first user prompt. Use this when the user wants an
+independent task started at a scheduled time — not a reminder injected
+into an existing conversation.
+
+When parsing the user's text:
+- Extract `when` (cron / iso). For recurring tasks, every fire creates
+  a new thread + new session (52 threads/year for weekly cron — that
+  is intentional). Honor user tz (default Asia/Shanghai).
+- Extract `what` — the task brief that becomes the new session's
+  first user prompt. Phrase it as an actionable task (e.g. "整理本周
+  的 PR 状态报告" not "remind me to do reports"), not a reminder.
+- If the user said the schedule should only last for a certain
+  duration, set `max_lifetime` (e.g. `"30d"`, max 365d). Only valid
+  with recurring=true.
+- `target_channel_id` defaults to the current channel; only set it if
+  the user explicitly named a different channel.
+- Pick a `thread_name` (≤50 chars) for the new thread, and a `name`
+  for the schedule display label.
+
+Reminder: schedule_new_task vs schedule_message
+- schedule_new_task → fresh thread + fresh session every fire
+- schedule_message  → inject into existing thread's existing session
+
+After calling the tool, respond briefly confirming the schedule.
+</system-reminder>
+
+<user-text>{user_text}</user-text>
+"""
+
+
+schedule_group = app_commands.Group(
+    name="schedule",
+    description="Manage scheduled timers (message/new_task/list/delete/toggle)",
+)
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+async def _ensure_bridge(bot, thread_id: int, binding_id: int, user_name: str):
+    """Return the live bridge for ``thread_id``, resurrecting from the
+    persisted ``resume_session_id`` if needed.
+
+    Mirrors the get-or-resurrect dance used by the natural-message handler
+    in :meth:`ClaudedBot._handle_thread_message` so a slash-injected turn
+    behaves identically to a typed ``@bot`` message. Inherits the channel
+    binding's system-prompt / extra-dirs / mcp-servers / env exactly like
+    a normal turn.
+    """
+    bridge = bot.session_manager.get_session(thread_id)
+    if bridge is not None and getattr(bridge, "is_active", False):
+        return bridge
+    stored = bot.session_manager.get_stored_session(thread_id)
+    resume_id = stored.get("session_id") if stored else None
+    project_path = bot.project_manager.get_path(binding_id)
+    sc = SessionConfig(
+        system_prompt=bot.project_manager.get_system_prompt(binding_id),
+        resume_session_id=resume_id,
+        add_dirs=bot.project_manager.get_extra_dirs(binding_id) or None,
+        mcp_servers=bot.project_manager.get_mcp_servers(binding_id) or None,
+        env=bot.project_manager.get_env(binding_id) or None,
+        user=user_name,
+    )
+    return await bot.session_manager.create_session(
+        thread_id, project_path, bot.config, sc,
+    )
+
+
+def _resolve_full_schedule_id(bot, partial: str) -> tuple[str | None, str | None]:
+    """Resolve a possibly-truncated schedule id to its full 16-char form.
+
+    Returns ``(full_id, None)`` on unique match, ``(None, reason)`` otherwise.
+    Accepts the full 16-char hex unchanged (no prefix scan needed in that
+    case). For shorter inputs, scans the store for prefix matches; rejects
+    ambiguous and unknown prefixes with an explanatory ``reason``.
+    """
+    if len(partial) >= 16:
+        return partial, None
+    matches = [
+        sid for sid in bot.scheduler.store.list_all()
+        if sid.startswith(partial)
+    ]
+    if len(matches) == 1:
+        return matches[0], None
+    if not matches:
+        return None, f"Unknown id prefix {partial!r}"
+    return None, f"Ambiguous id prefix {partial!r}: matched {len(matches)}"
+
+
+# --------------------------------------------------------------------------
+# /schedule message <text>
+# --------------------------------------------------------------------------
+
+@schedule_group.command(
+    name="message",
+    description="Schedule a message to be injected into this thread",
+)
+@app_commands.describe(text="What to schedule (e.g. '明天 9 点提醒我开会')")
+async def schedule_message_cmd(
+    interaction: discord.Interaction,
+    text: str,
+) -> None:
+    """Inject PRD §6.1 reminder + ``text`` so claude calls ``schedule_message``.
+
+    Restricted to thread context because claude needs a live session
+    (which lives at thread granularity) to call the MCP tool. The actual
+    schedule creation happens inside the claude turn, not in this cog.
+    """
+    bot = interaction.client
+    channel = interaction.channel
+    if not isinstance(channel, discord.Thread):
+        await interaction.response.send_message(
+            "/schedule message must be used inside a thread.",
+            ephemeral=True,
+        )
+        return
+    parent_id = channel.parent_id
+    if parent_id is None:
+        await interaction.response.send_message(
+            NO_CHANNEL_MESSAGE, ephemeral=True,
+        )
+        return
+    if not bot.project_manager.is_bound(parent_id):
+        await interaction.response.send_message(
+            "❌ This channel isn't bound to a project. "
+            "Run `/project bind <path>` first.",
+            ephemeral=True,
+        )
+        return
+
+    await interaction.response.send_message(
+        "⏰ Scheduling message… (claude will create the schedule)",
+        ephemeral=False,
+    )
+
+    try:
+        bridge = await _ensure_bridge(
+            bot, channel.id, parent_id, interaction.user.name,
+        )
+    except Exception as exc:
+        log.exception("/schedule message: failed to start bridge")
+        await channel.send(embed=discord.Embed(
+            title="❌ Failed to open session",
+            description=f"```\n{str(exc)[:500]}\n```",
+            color=COLOR_TOOL_FAILURE,
+        ))
+        return
+
+    bot._register_scheduler_ctx(
+        thread_id=channel.id,
+        channel_id=parent_id,
+        guild_id=getattr(channel.guild, "id", None),
+    )
+    full = _REMINDER_MESSAGE.format(user_text=text)
+    project_path = bot.project_manager.get_path(parent_id)
+    renderer = DiscordRenderer(
+        channel,
+        bot=bot,
+        project_path=Path(project_path) if project_path else None,
+    )
+    try:
+        await renderer.render_response(
+            bridge, full, author_id=interaction.user.id,
+        )
+    except Exception:
+        log.exception("/schedule message render failed")
+        try:
+            await channel.send(embed=discord.Embed(
+                title="❌ Schedule injection failed",
+                description="See bot logs.",
+                color=COLOR_TOOL_FAILURE,
+            ))
+        except Exception:
+            pass
+
+
+# --------------------------------------------------------------------------
+# /schedule new_task <text>
+# --------------------------------------------------------------------------
+
+@schedule_group.command(
+    name="new_task",
+    description="Schedule a new independent task in a fresh thread",
+)
+@app_commands.describe(text="What to schedule (e.g. '每周一 9am 整理周报')")
+async def schedule_new_task_cmd(
+    interaction: discord.Interaction,
+    text: str,
+) -> None:
+    """Inject PRD §6.2 reminder + ``text`` so claude calls ``schedule_new_task``.
+
+    Same thread-context restriction as ``/schedule message``: claude needs
+    a live session to call the tool. The actual fresh-thread creation at
+    fire time is handled by :meth:`ClaudedBot._fire_schedule_new_task`,
+    not here.
+    """
+    bot = interaction.client
+    channel = interaction.channel
+    if not isinstance(channel, discord.Thread):
+        await interaction.response.send_message(
+            "/schedule new_task must be used inside a thread "
+            "(claude needs a session to call the tool).",
+            ephemeral=True,
+        )
+        return
+    binding_id = channel.parent_id
+    if binding_id is None:
+        await interaction.response.send_message(
+            NO_CHANNEL_MESSAGE, ephemeral=True,
+        )
+        return
+    if not bot.project_manager.is_bound(binding_id):
+        await interaction.response.send_message(
+            "❌ This channel isn't bound to a project. "
+            "Run `/project bind <path>` first.",
+            ephemeral=True,
+        )
+        return
+
+    await interaction.response.send_message(
+        "⏰ Scheduling new_task… (claude will create the schedule)",
+        ephemeral=False,
+    )
+
+    try:
+        bridge = await _ensure_bridge(
+            bot, channel.id, binding_id, interaction.user.name,
+        )
+    except Exception as exc:
+        log.exception("/schedule new_task: failed to start bridge")
+        await channel.send(embed=discord.Embed(
+            title="❌ Failed to open session",
+            description=f"```\n{str(exc)[:500]}\n```",
+            color=COLOR_TOOL_FAILURE,
+        ))
+        return
+
+    bot._register_scheduler_ctx(
+        thread_id=channel.id,
+        channel_id=binding_id,
+        guild_id=getattr(channel.guild, "id", None),
+    )
+    full = _REMINDER_NEW_TASK.format(user_text=text)
+    project_path = bot.project_manager.get_path(binding_id)
+    renderer = DiscordRenderer(
+        channel,
+        bot=bot,
+        project_path=Path(project_path) if project_path else None,
+    )
+    try:
+        await renderer.render_response(
+            bridge, full, author_id=interaction.user.id,
+        )
+    except Exception:
+        log.exception("/schedule new_task render failed")
+
+
+# --------------------------------------------------------------------------
+# /schedule list
+# --------------------------------------------------------------------------
+
+@schedule_group.command(name="list", description="List schedules in this thread")
+@app_commands.describe(scope="thread (default) | channel | all")
+async def schedule_list_cmd(
+    interaction: discord.Interaction,
+    scope: str = "thread",
+) -> None:
+    """List schedules in the requested scope.
+
+    Calls :class:`SchedulerStore` directly — no claude turn involved.
+    Markers follow PRD §3.8 / §6:
+
+    * ``📨`` = kind=message     /    ``🧵`` = kind=new_task
+    * ``🤖`` = created_by claude /  ``👤`` = created_by user (slash)
+    """
+    bot = interaction.client
+    if scope == "thread":
+        if not isinstance(interaction.channel, discord.Thread):
+            await interaction.response.send_message(
+                "scope=thread requires a thread context.",
+                ephemeral=True,
+            )
+            return
+        items = bot.scheduler.store.list_for_thread(interaction.channel.id)
+    elif scope == "channel":
+        ch = interaction.channel
+        if isinstance(ch, discord.Thread):
+            cid = ch.parent_id
+        else:
+            cid = getattr(ch, "id", None)
+        if cid is None:
+            await interaction.response.send_message(
+                "scope=channel requires a channel context.",
+                ephemeral=True,
+            )
+            return
+        items = bot.scheduler.store.list_for_channel(cid)
+    elif scope == "all":
+        items = list(bot.scheduler.store.list_all().values())
+    else:
+        await interaction.response.send_message(
+            f"Invalid scope: {scope!r}. Use thread|channel|all.",
+            ephemeral=True,
+        )
+        return
+
+    if not items:
+        await interaction.response.send_message(
+            "(no schedules)", ephemeral=True,
+        )
+        return
+
+    lines: list[str] = []
+    # Discord embed practical safety cap: 25 lines. We don't try to be
+    # clever with pagination — the rare user with >25 schedules can run
+    # ``schedule_list`` via claude (no cap) or filter scope.
+    for s in items[:25]:
+        kind_marker = "📨" if s.get("kind") == "message" else "🧵"
+        by_marker = "🤖" if s.get("created_by") == "claude" else "👤"
+        sid = (s.get("schedule_id", "") or "")[:8]
+        name = s.get("name", "") or ""
+        state = s.get("state", {}) or {}
+        nfa = state.get("next_fire_at", "") or "?"
+        cnt = state.get("fire_count", 0)
+        en_suffix = "" if state.get("enabled") else " (disabled)"
+        lines.append(
+            f"{kind_marker} {by_marker} `{sid}` {name} — next={nfa} "
+            f"fires={cnt}{en_suffix}"
+        )
+
+    embed = discord.Embed(
+        title=f"📅 Schedules ({scope})",
+        description="\n".join(lines),
+        color=COLOR_INFO,
+    )
+    if len(items) > 25:
+        embed.set_footer(text=f"showing 25 of {len(items)}")
+    await interaction.response.send_message(embed=embed, ephemeral=False)
+
+
+# --------------------------------------------------------------------------
+# /schedule delete <id>
+# --------------------------------------------------------------------------
+
+@schedule_group.command(
+    name="delete",
+    description="Delete a schedule (creator/admin only)",
+)
+@app_commands.describe(
+    schedule_id="16-char hex schedule id (or first 8 chars)",
+)
+async def schedule_delete_cmd(
+    interaction: discord.Interaction,
+    schedule_id: str,
+) -> None:
+    """Delete a schedule. Permission per PRD §4.4: creator or admin.
+
+    Short id prefixes are resolved server-side to the unique match (or
+    rejected as ambiguous) so users don't have to copy/paste 16 hex chars.
+    """
+    bot = interaction.client
+    target_id, err = _resolve_full_schedule_id(bot, schedule_id)
+    if err:
+        await interaction.response.send_message(f"❌ {err}", ephemeral=True)
+        return
+
+    is_admin = (
+        isinstance(interaction.user, discord.Member)
+        and interaction.user.guild_permissions.manage_guild
+    )
+    ok, reason = bot.scheduler.delete(
+        target_id,
+        requester=str(interaction.user.id),
+        is_admin=is_admin,
+    )
+    if ok:
+        await interaction.response.send_message(
+            f"✅ Deleted `{target_id[:8]}`",
+            ephemeral=False,
+        )
+    else:
+        await interaction.response.send_message(
+            f"❌ {reason}", ephemeral=True,
+        )
+
+
+# --------------------------------------------------------------------------
+# /schedule toggle <id> <enabled>
+# --------------------------------------------------------------------------
+
+@schedule_group.command(name="toggle", description="Enable or disable a schedule")
+@app_commands.describe(
+    schedule_id="16-char hex schedule id (or first 8 chars)",
+    enabled="True to enable, False to disable",
+)
+async def schedule_toggle_cmd(
+    interaction: discord.Interaction,
+    schedule_id: str,
+    enabled: bool,
+) -> None:
+    """Enable/disable a schedule. Same permission model as ``delete``."""
+    bot = interaction.client
+    target_id, err = _resolve_full_schedule_id(bot, schedule_id)
+    if err:
+        await interaction.response.send_message(f"❌ {err}", ephemeral=True)
+        return
+
+    is_admin = (
+        isinstance(interaction.user, discord.Member)
+        and interaction.user.guild_permissions.manage_guild
+    )
+    ok, reason = bot.scheduler.toggle(
+        target_id, enabled,
+        requester=str(interaction.user.id),
+        is_admin=is_admin,
+    )
+    if ok:
+        await interaction.response.send_message(
+            f"✅ `{target_id[:8]}` enabled={enabled}",
+            ephemeral=False,
+        )
+    else:
+        await interaction.response.send_message(
+            f"❌ {reason}", ephemeral=True,
+        )

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1370,31 +1370,6 @@ class DiscordRenderer:
                                     tool_msgs[tool_id] = tmsg
                                 continue
 
-                            # --- Special tool display: Cron (#73) ---
-                            if name == "CronCreate":
-                                schedule = block.input.get("schedule", "")[:100]
-                                cmd = block.input.get("command", "")[:200]
-                                tool_embed = discord.Embed(title="⏰ Cron Created", description=f"`{schedule}`\n```\n{cmd}\n```", color=COLOR_INFO)
-                                tmsg = await self._safe_send(embed=tool_embed)
-                                if tmsg is not None and tool_id:
-                                    tool_msgs[tool_id] = tmsg
-                                continue
-
-                            if name == "CronDelete":
-                                tool_embed = discord.Embed(title="⏰ Cron Deleted", color=COLOR_TOOL_FAILURE)
-                                tmsg = await self._safe_send(embed=tool_embed)
-                                if tmsg is not None and tool_id:
-                                    tool_msgs[tool_id] = tmsg
-                                continue
-
-                            if name == "CronList":
-                                tool_embed = discord.Embed(title="⏰ Listing Crons", color=COLOR_INFO)
-                                tmsg = await self._safe_send(embed=tool_embed)
-                                if tmsg is not None and tool_id:
-                                    tool_msgs[tool_id] = tmsg
-                                continue
-
-
                             # --- Special tool display: NotebookEdit ---
                             if name == "NotebookEdit":
                                 cell_type = block.input.get("cell_type", "code")
@@ -1404,20 +1379,6 @@ class DiscordRenderer:
                                 tool_embed = discord.Embed(
                                     title=f"📓 Notebook Cell [{cell_idx}] ({cell_type})",
                                     description=f"```{lang}\n{content_preview.replace(chr(96)*3, chr(96)+' '+chr(96)+' '+chr(96))}\n```" if content_preview else "Empty cell",
-                                    color=COLOR_TOOL_RUNNING,
-                                )
-                                tmsg = await self._safe_send(embed=tool_embed)
-                                if tmsg is not None and tool_id:
-                                    tool_msgs[tool_id] = tmsg
-                                continue
-
-                            # --- Special tool display: ScheduleWakeup ---
-                            if name == "ScheduleWakeup":
-                                delay = block.input.get("delay_seconds", block.input.get("seconds", "?"))
-                                reason = block.input.get("message", block.input.get("reason", ""))[:200]
-                                tool_embed = discord.Embed(
-                                    title=f"⏰ Scheduled Wakeup: {delay}s",
-                                    description=reason or "Waiting...",
                                     color=COLOR_TOOL_RUNNING,
                                 )
                                 tmsg = await self._safe_send(embed=tool_embed)

--- a/src/clauded/scheduler.py
+++ b/src/clauded/scheduler.py
@@ -1,18 +1,22 @@
-"""Scheduler core — trigger parsing + SchedulerManager (no fire executor).
+"""Scheduler core — trigger parsing + SchedulerManager (with fire executor).
 
 This module is part of issue #241 / PRD v1.18 (``docs/prd/v1.18-scheduler.md``).
-Subtask 1 covers:
 
-* Module-level trigger parsing helpers
+* Subtask 1: module-level trigger parsing helpers
   (:func:`parse_iso_utc`, :func:`parse_cron_to_next`, :func:`compute_next_fire`,
-  :func:`parse_duration`).
-* :class:`SchedulerManager` — ``__init__``, ``create``, ``delete``, ``toggle``.
-
-Subtask 2 will extend this module with ``tick`` / ``catch_up`` / ``_fire_one``.
+  :func:`parse_duration`); :class:`SchedulerManager` ``__init__`` / ``create``
+  / ``delete`` / ``toggle``.
+* Subtask 2 (this revision): :meth:`SchedulerManager.tick`,
+  :meth:`~SchedulerManager.catch_up`, :meth:`~SchedulerManager._fire_one`,
+  ``_fire_with_retry``, ``_on_fire_success``, ``_on_fire_terminal``,
+  ``_check_max_lifetime``, ``_now_utc``.
 
 Intentional constraints:
-* No ``discord`` imports here — fire callbacks are injected by the bot wiring
-  layer so this module stays unit-testable in isolation.
+* All fire actions go through injected callbacks; this module never references
+  ``discord.Thread`` / ``discord.Client`` etc. ``discord`` is imported only
+  for its exception types (``NotFound`` / ``Forbidden``) so the retry/terminal
+  branches can distinguish "stop trying" from "transient retry" without
+  leaking discord objects into the manager's contract.
 * All times persisted as ISO-8601 UTC strings (``...+00:00``).
 """
 
@@ -26,6 +30,7 @@ from datetime import datetime, timezone
 from typing import Awaitable, Callable, Literal
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+import discord  # Subtask 2: catch discord.NotFound / discord.Forbidden as terminal
 from croniter import croniter
 
 from .scheduler_store import SchedulerStore
@@ -232,18 +237,27 @@ class SchedulerManager:
         self.expire_notify_callback = expire_notify_callback
 
         if get_lock is None:
-            # Lazy-instantiate to avoid creating a lock outside any loop
-            # before tests / wiring need one.
-            self._default_lock: asyncio.Lock | None = None
+            # Default: per-target (thread_id or channel_id) ``asyncio.Lock``s,
+            # lazily created the first time each id is seen. Caller-supplied
+            # ``get_lock`` (e.g. ``bot.session_manager.get_lock``) overrides
+            # this so production fire shares the same per-thread lock the
+            # rest of the bot already uses.
+            self._lock_map: dict[int, asyncio.Lock] = {}
 
-            def _shared_lock(_thread_id: int) -> asyncio.Lock:
-                if self._default_lock is None:
-                    self._default_lock = asyncio.Lock()
-                return self._default_lock
+            def _per_id_lock(target_id: int) -> asyncio.Lock:
+                lk = self._lock_map.get(target_id)
+                if lk is None:
+                    lk = asyncio.Lock()
+                    self._lock_map[target_id] = lk
+                return lk
 
-            self.get_lock = _shared_lock
+            self.get_lock = _per_id_lock
         else:
             self.get_lock = get_lock
+
+        # Bound concurrent in-flight fires across all schedules — PRD §3.8
+        # (``MAX_GLOBAL_INFLIGHT = 10``). Acquired inside ``_fire_one``.
+        self._inflight_sem = asyncio.Semaphore(MAX_GLOBAL_INFLIGHT)
 
     # ----------------------------------------------------- Permission
 
@@ -495,3 +509,272 @@ class SchedulerManager:
             sched_id, enabled, requester, is_admin,
         )
         return True, "ok"
+
+    # =================================================================
+    # Subtask 2 — fire executor + tick/catch_up + max_lifetime
+    # =================================================================
+
+    # ------------------------------------------------------- Time helper
+
+    def _now_utc(self) -> datetime:
+        """Return the current UTC datetime.
+
+        Thin wrapper around ``datetime.now(timezone.utc)`` so tests can
+        monkeypatch a deterministic clock without reaching into the
+        global ``datetime`` module.
+        """
+        return datetime.now(timezone.utc)
+
+    # ------------------------------------------------------------ Tick
+
+    @staticmethod
+    def _parse_next_fire(s: str | None) -> datetime | None:
+        """Parse a persisted ``next_fire_at`` ISO string to a UTC datetime.
+
+        Returns ``None`` for missing / malformed values. Naive datetimes
+        (no tzinfo) are normalized to UTC so the ``<= _now_utc()`` compare
+        in :meth:`tick` / :meth:`catch_up` is always tz-aware.
+        """
+        if not s:
+            return None
+        try:
+            dt = datetime.fromisoformat(s)
+        except (TypeError, ValueError):
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    async def tick(self) -> None:
+        """Scan all enabled schedules and dispatch any whose due time has arrived.
+
+        Called on a periodic loop (PRD §3.8 ``TICK_INTERVAL_S = 15``). For
+        every enabled schedule whose ``state.next_fire_at`` is ``<=`` now,
+        an :meth:`_fire_one` task is scheduled via ``asyncio.create_task``
+        and this method returns immediately — the semaphore inside
+        ``_fire_one`` is the only thing that bounds in-flight concurrency.
+        """
+        now = self._now_utc()
+        for sched in self.store.list_all().values():
+            state = sched.get("state") or {}
+            if not state.get("enabled", False):
+                continue
+            next_fire = self._parse_next_fire(state.get("next_fire_at"))
+            if next_fire is None:
+                continue
+            if next_fire <= now:
+                asyncio.create_task(self._fire_one(sched))
+
+    async def catch_up(self) -> None:
+        """One-shot scan called on bot startup to handle missed fires.
+
+        Schedules whose ``next_fire_at`` is past but within
+        :data:`MISSED_FIRE_GRACE_S` (300s) get dispatched normally.
+        Anything older is marked missed and rolled forward without
+        firing (recurring) or disabled (one-shot deep past).
+        """
+        now = self._now_utc()
+        for sched in self.store.list_all().values():
+            state = sched.get("state") or {}
+            if not state.get("enabled", False):
+                continue
+            next_fire = self._parse_next_fire(state.get("next_fire_at"))
+            if next_fire is None:
+                continue
+            if next_fire > now:
+                continue
+
+            age = (now - next_fire).total_seconds()
+            if age <= MISSED_FIRE_GRACE_S:
+                asyncio.create_task(self._fire_one(sched))
+                continue
+
+            # Too stale to fire — mark missed and roll forward.
+            state["missed_count"] = int(state.get("missed_count", 0)) + 1
+            trigger = sched.get("trigger") or {}
+            new_next = compute_next_fire(trigger, after=now)
+            if new_next is None:
+                # one-shot in deep past or unrecoverable trigger
+                state["enabled"] = False
+                state["next_fire_at"] = None
+            else:
+                state["next_fire_at"] = new_next.isoformat()
+            sched["state"] = state
+            self.store.save(sched)
+            log.warning(
+                "#241 missed fire schedule=%s age=%.0fs",
+                sched.get("schedule_id"), age,
+            )
+
+    # ---------------------------------------------------- _fire_one core
+
+    async def _fire_one(self, sched: dict) -> None:
+        """Acquire concurrency budget + per-target lock, then run the fire.
+
+        The global semaphore caps simultaneous in-flight fires across all
+        schedules at :data:`MAX_GLOBAL_INFLIGHT` (10). The per-target lock
+        (thread_id for ``kind=message``, channel_id for ``kind=new_task``)
+        serializes fires aimed at the same destination so two due
+        schedules can't interleave their callbacks.
+        """
+        async with self._inflight_sem:
+            kind = sched.get("kind")
+            if kind == "message":
+                lock_id = sched.get("target_thread_id")
+            else:
+                lock_id = sched.get("target_channel_id")
+            if lock_id is None:
+                # Defensive — would already have failed validation in create().
+                log.warning(
+                    "#241 _fire_one missing lock id schedule=%s kind=%s",
+                    sched.get("schedule_id"), kind,
+                )
+                await self._fire_with_retry(sched)
+                return
+            async with self.get_lock(lock_id):
+                await self._fire_with_retry(sched)
+
+    async def _fire_with_retry(self, sched: dict) -> None:
+        """Execute the kind-appropriate callback with 3× retry + terminal disable.
+
+        ``discord.NotFound`` and ``discord.Forbidden`` are terminal — the
+        target is gone or we can't post to it, so retrying would only burn
+        rate-limit budget. Any other exception is treated as transient and
+        retried up to 3 attempts with 1s / 4s / 16s backoff per PRD §2.
+        """
+        attempts = 0
+        last_exc: BaseException | None = None
+        backoffs = [1, 4, 16]
+        kind = sched.get("kind")
+        while attempts < 3:
+            attempts += 1
+            try:
+                if kind == "message":
+                    await self.fire_message_callback(sched)
+                else:
+                    await self.fire_new_task_callback(sched)
+                await self._on_fire_success(sched)
+                return
+            except (discord.NotFound, discord.Forbidden) as exc:
+                await self._on_fire_terminal(sched, exc)
+                return
+            except Exception as exc:
+                last_exc = exc
+                log.warning(
+                    "#241 transient fire failure schedule=%s attempt=%d: %s",
+                    sched.get("schedule_id"), attempts, exc,
+                )
+                if attempts < 3:
+                    await asyncio.sleep(backoffs[attempts - 1])
+                    continue
+        # Retries exhausted — disable with the last exception captured.
+        await self._on_fire_terminal(
+            sched,
+            last_exc if last_exc is not None else RuntimeError(
+                "fire failed without exception"
+            ),
+        )
+
+    # --------------------------------------------- success / terminal
+
+    async def _on_fire_success(self, sched: dict) -> None:
+        """Persist post-fire state and schedule the next run (or disable).
+
+        Bumps ``fire_count``, sets ``last_fired_at`` / ``first_fired_at``,
+        clears ``last_error``, then either rolls ``next_fire_at`` forward
+        (recurring cron) or disables the schedule (one-shot / final fire).
+        Calls :meth:`_check_max_lifetime` last so a schedule that just
+        hit its lifetime cap gets disabled after the per-fire bookkeeping
+        is on disk.
+        """
+        now = self._now_utc()
+        state = sched.setdefault("state", {})
+        state["fire_count"] = int(state.get("fire_count", 0)) + 1
+        state["last_fired_at"] = now.isoformat()
+        state["last_error"] = None
+        if state.get("first_fired_at") is None:
+            state["first_fired_at"] = now.isoformat()
+
+        trigger = sched.get("trigger") or {}
+        recurring = (
+            bool(trigger.get("recurring", False))
+            and trigger.get("kind") == "cron"
+        )
+        if not recurring:
+            state["enabled"] = False
+            state["next_fire_at"] = None
+        else:
+            new_next = compute_next_fire(trigger, after=now)
+            if new_next is None:
+                state["enabled"] = False
+                state["next_fire_at"] = None
+            else:
+                state["next_fire_at"] = new_next.isoformat()
+
+        self.store.save(sched)
+        log.info(
+            "#241 fire success schedule=%s fire_count=%d next=%s",
+            sched.get("schedule_id"),
+            state["fire_count"],
+            state.get("next_fire_at"),
+        )
+
+        # Check max_lifetime AFTER the success bookkeeping is persisted so
+        # ``first_fired_at`` is guaranteed populated for the comparison.
+        self._check_max_lifetime(sched)
+
+    async def _on_fire_terminal(
+        self, sched: dict, exc: BaseException
+    ) -> None:
+        """Disable a schedule that hit an unrecoverable fire failure.
+
+        Used for both terminal Discord exceptions (NotFound / Forbidden)
+        and for exhausted retry budgets. The error string lands in
+        ``state.last_error`` so ``/schedule list`` can surface it.
+        """
+        state = sched.setdefault("state", {})
+        state["enabled"] = False
+        state["last_error"] = f"{type(exc).__name__}: {exc}"
+        self.store.save(sched)
+        log.warning(
+            "#241 fire terminal disable schedule=%s exc=%s",
+            sched.get("schedule_id"),
+            state["last_error"],
+        )
+
+    # ---------------------------------------------------- max_lifetime
+
+    def _check_max_lifetime(self, sched: dict) -> bool:
+        """Disable + notify if ``max_lifetime_seconds`` has elapsed since first fire.
+
+        Returns ``True`` iff the schedule was just expired by this call.
+        Schedules without ``max_lifetime_seconds`` or without a
+        ``first_fired_at`` (haven't fired yet) are never expired here.
+        """
+        max_life = sched.get("max_lifetime_seconds")
+        state = sched.setdefault("state", {})
+        ff = state.get("first_fired_at")
+        if max_life is None or ff is None:
+            return False
+        try:
+            ff_dt = datetime.fromisoformat(ff)
+        except (TypeError, ValueError):
+            return False
+        if ff_dt.tzinfo is None:
+            ff_dt = ff_dt.replace(tzinfo=timezone.utc)
+        now = self._now_utc()
+        lived = (now - ff_dt).total_seconds()
+        if lived < max_life:
+            return False
+
+        state["enabled"] = False
+        state["last_error"] = "max_lifetime reached"
+        self.store.save(sched)
+        if self.expire_notify_callback is not None:
+            asyncio.create_task(self.expire_notify_callback(sched))
+        log.info(
+            "#241 max_lifetime expired schedule=%s lived=%.0fs",
+            sched.get("schedule_id"),
+            lived,
+        )
+        return True

--- a/src/clauded/scheduler.py
+++ b/src/clauded/scheduler.py
@@ -1,0 +1,497 @@
+"""Scheduler core — trigger parsing + SchedulerManager (no fire executor).
+
+This module is part of issue #241 / PRD v1.18 (``docs/prd/v1.18-scheduler.md``).
+Subtask 1 covers:
+
+* Module-level trigger parsing helpers
+  (:func:`parse_iso_utc`, :func:`parse_cron_to_next`, :func:`compute_next_fire`,
+  :func:`parse_duration`).
+* :class:`SchedulerManager` — ``__init__``, ``create``, ``delete``, ``toggle``.
+
+Subtask 2 will extend this module with ``tick`` / ``catch_up`` / ``_fire_one``.
+
+Intentional constraints:
+* No ``discord`` imports here — fire callbacks are injected by the bot wiring
+  layer so this module stays unit-testable in isolation.
+* All times persisted as ISO-8601 UTC strings (``...+00:00``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import secrets
+from datetime import datetime, timezone
+from typing import Awaitable, Callable, Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from croniter import croniter
+
+from .scheduler_store import SchedulerStore
+
+log = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------- Constants
+
+TICK_INTERVAL_S = 15
+CLAUDE_MIN_INTERVAL_S = 300
+MISSED_FIRE_GRACE_S = 300
+MAX_GLOBAL_INFLIGHT = 10
+MAX_USER_ACTIVE = 20
+MAX_GLOBAL_ACTIVE = 100
+MAX_LIFETIME_SECONDS = 31_536_000  # 365 days
+
+
+# ------------------------------------------------------------ Duration regex
+
+_DURATION_RE = re.compile(r"^\s*(\d+)\s*([smhdw])\s*$")
+_DURATION_MULT = {
+    "s": 1,
+    "m": 60,
+    "h": 3600,
+    "d": 86_400,
+    "w": 604_800,
+}
+
+
+# -------------------------------------------------------- Trigger parsing
+
+def parse_iso_utc(s: str) -> datetime:
+    """Parse an ISO-8601 datetime, normalized to UTC.
+
+    Accepts both raw (``"2026-05-19T09:00:00+08:00"``) and the prefixed
+    form used in tool args / persistence (``"iso: 2026-05-19T09:00:00+08:00"``).
+
+    Naive datetimes (no tzinfo) are rejected — we never silently assume UTC.
+
+    Raises:
+        ValueError: garbage input or missing tzinfo.
+    """
+    if not isinstance(s, str):
+        raise ValueError(f"iso datetime must be string, got {type(s).__name__}")
+    raw = s[4:] if s.startswith("iso:") else s
+    raw = raw.strip()
+    if not raw:
+        raise ValueError("iso datetime is empty")
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError as exc:
+        raise ValueError(f"invalid iso datetime: {raw!r}") from exc
+    if dt.tzinfo is None:
+        raise ValueError(
+            f"iso datetime must include timezone offset: {raw!r}"
+        )
+    return dt.astimezone(timezone.utc)
+
+
+def parse_cron_to_next(
+    cron: str,
+    tz_name: str,
+    base: datetime | None = None,
+) -> datetime:
+    """Return the next fire time for a cron expression as a UTC datetime.
+
+    ``cron`` may be raw (``"0 9 * * *"``) or prefixed (``"cron: 0 9 * * *"``).
+    ``tz_name`` is an IANA zone name (e.g. ``"Asia/Shanghai"``) — bad zones
+    raise :class:`ValueError`. ``base`` defaults to ``datetime.now(UTC)``;
+    if naive it is treated as UTC.
+
+    Raises:
+        ValueError: invalid cron expression or unknown timezone.
+    """
+    if not isinstance(cron, str):
+        raise ValueError(f"cron must be string, got {type(cron).__name__}")
+    raw = cron[5:] if cron.startswith("cron:") else cron
+    raw = raw.strip()
+    if not raw:
+        raise ValueError("cron expression is empty")
+    try:
+        tz = ZoneInfo(tz_name)
+    except (ZoneInfoNotFoundError, KeyError, ValueError) as exc:
+        raise ValueError(f"invalid timezone: {tz_name!r}") from exc
+
+    if base is None:
+        base = datetime.now(timezone.utc)
+    elif base.tzinfo is None:
+        base = base.replace(tzinfo=timezone.utc)
+    base_local = base.astimezone(tz)
+
+    try:
+        it = croniter(raw, base_local)
+        nxt = it.get_next(datetime)
+    except Exception as exc:  # croniter raises a variety of types
+        raise ValueError(f"invalid cron expression: {raw!r} ({exc})") from exc
+
+    if nxt.tzinfo is None:
+        nxt = nxt.replace(tzinfo=tz)
+    return nxt.astimezone(timezone.utc)
+
+
+def compute_next_fire(
+    trigger: dict,
+    after: datetime | None = None,
+) -> datetime | None:
+    """Return the next fire datetime (UTC) for a persisted ``trigger`` dict.
+
+    For one-shot (``trigger["kind"] == "once"``) returns the stored iso
+    datetime if it is in the future relative to ``after`` (default: now),
+    otherwise ``None``. For cron (``trigger["kind"] == "cron"``) returns
+    the next fire after ``after``. Malformed triggers return ``None``
+    (callers should not depend on this swallowing errors — it exists for
+    robust scheduling against possibly-stale persisted records).
+    """
+    now = after if after is not None else datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+
+    tk = trigger.get("kind")
+    if tk == "once":
+        iso_str = trigger.get("iso")
+        if not iso_str:
+            return None
+        try:
+            dt = datetime.fromisoformat(iso_str)
+        except ValueError:
+            return None
+        if dt.tzinfo is None:
+            return None
+        dt = dt.astimezone(timezone.utc)
+        return dt if dt > now else None
+
+    if tk == "cron":
+        cron = trigger.get("cron")
+        tz_name = trigger.get("tz_when_created", "UTC")
+        if not cron:
+            return None
+        try:
+            return parse_cron_to_next(cron, tz_name, base=now)
+        except ValueError:
+            return None
+
+    return None
+
+
+def parse_duration(s: str) -> int:
+    """Parse a duration string (``"30d"`` / ``"24h"`` / ``"1w"`` / ...) to seconds.
+
+    Allowed suffixes: ``s`` (seconds), ``m`` (minutes), ``h`` (hours),
+    ``d`` (days), ``w`` (weeks). Results greater than
+    :data:`MAX_LIFETIME_SECONDS` (365 days) raise :class:`ValueError`.
+
+    Raises:
+        ValueError: bad format, bad suffix, or above 365-day cap.
+    """
+    if not isinstance(s, str):
+        raise ValueError(
+            f"duration must be string, got {type(s).__name__}"
+        )
+    m = _DURATION_RE.match(s)
+    if not m:
+        raise ValueError(
+            f"invalid duration: {s!r} (expected '<n><s|m|h|d|w>', e.g. '30d')"
+        )
+    n = int(m.group(1))
+    suffix = m.group(2)
+    secs = n * _DURATION_MULT[suffix]
+    if secs > MAX_LIFETIME_SECONDS:
+        raise ValueError(
+            f"duration {s!r} exceeds max 365d ({MAX_LIFETIME_SECONDS}s)"
+        )
+    return secs
+
+
+# ----------------------------------------------------------- Manager class
+
+FireCallback = Callable[[dict], Awaitable[None]]
+LockProvider = Callable[[int], asyncio.Lock]
+
+
+class SchedulerManager:
+    """Owner of the schedule lifecycle (create / delete / toggle).
+
+    Subtask 1 (this module) implements the validation + persistence side.
+    The ``tick`` / ``catch_up`` / ``_fire_one`` methods that drive actual
+    firing are added in Subtask 2. The constructor already accepts the
+    fire callbacks so wiring can land later without re-arranging this API.
+    """
+
+    def __init__(
+        self,
+        store: SchedulerStore,
+        *,
+        fire_message_callback: FireCallback,
+        fire_new_task_callback: FireCallback,
+        expire_notify_callback: FireCallback | None = None,
+        get_lock: LockProvider | None = None,
+    ) -> None:
+        self.store = store
+        self.fire_message_callback = fire_message_callback
+        self.fire_new_task_callback = fire_new_task_callback
+        self.expire_notify_callback = expire_notify_callback
+
+        if get_lock is None:
+            # Lazy-instantiate to avoid creating a lock outside any loop
+            # before tests / wiring need one.
+            self._default_lock: asyncio.Lock | None = None
+
+            def _shared_lock(_thread_id: int) -> asyncio.Lock:
+                if self._default_lock is None:
+                    self._default_lock = asyncio.Lock()
+                return self._default_lock
+
+            self.get_lock = _shared_lock
+        else:
+            self.get_lock = get_lock
+
+    # ----------------------------------------------------- Permission
+
+    @staticmethod
+    def _check_permission(
+        sched: dict,
+        requester: str | int,
+        is_admin: bool,
+    ) -> tuple[bool, str]:
+        """Apply the PRD permission matrix.
+
+        See ``docs/prd/v1.18-scheduler.md`` (`权限模型`):
+
+        * ``requester == "claude"`` may only act on claude-created schedules
+          (admin flag is ignored — claude does not get admin override).
+        * otherwise: equal-string match on ``created_by`` is OK, else
+          ``is_admin`` overrides, else deny.
+        """
+        requester_s = str(requester)
+        created_by = str(sched.get("created_by"))
+        if requester_s == "claude":
+            if created_by == "claude":
+                return True, "ok"
+            return False, "claude can only manage claude-created schedules"
+        if requester_s == created_by:
+            return True, "ok"
+        if is_admin:
+            return True, "ok"
+        return False, "permission denied"
+
+    # ------------------------------------------------------------ Create
+
+    def create(
+        self,
+        *,
+        kind: Literal["message", "new_task"],
+        when: str,
+        what: str,
+        target_thread_id: int | None = None,
+        target_channel_id: int | None = None,
+        thread_name: str | None = None,
+        name: str | None = None,
+        recurring: bool = False,
+        max_lifetime: str | None = None,
+        created_by: str | int,
+        is_claude_created: bool = False,
+        guild_id: int | None = None,
+        channel_id: int | None = None,
+        tz_name: str = "Asia/Shanghai",
+    ) -> dict:
+        """Create + persist a schedule.
+
+        Returns the full schedule dict (same shape as
+        ``docs/prd/v1.18-scheduler.md §5``).
+
+        Raises:
+            ValueError: any validation failure (see PRD §3.8 and §4 for the
+                full ruleset enforced here).
+        """
+        # 1. what
+        if not isinstance(what, str) or len(what) == 0 or len(what) > 500:
+            raise ValueError("what must be non-empty and ≤500 chars")
+
+        # 2. name length
+        if name is not None and len(name) > 50:
+            raise ValueError("name ≤50 chars")
+
+        # 3. thread_name length
+        if thread_name is not None and len(thread_name) > 50:
+            raise ValueError("thread_name ≤50 chars")
+
+        # 4. kind-specific target validation
+        if kind == "message":
+            if (
+                not isinstance(target_thread_id, int)
+                or isinstance(target_thread_id, bool)
+                or target_thread_id <= 0
+            ):
+                raise ValueError(
+                    "kind=message requires positive int target_thread_id"
+                )
+        elif kind == "new_task":
+            if (
+                not isinstance(target_channel_id, int)
+                or isinstance(target_channel_id, bool)
+                or target_channel_id <= 0
+            ):
+                raise ValueError(
+                    "kind=new_task requires positive int target_channel_id"
+                )
+        else:
+            raise ValueError(f"unknown kind: {kind!r}")
+
+        # 5. when prefix + parse
+        if not isinstance(when, str):
+            raise ValueError("when must start with cron: or iso:")
+        if when.startswith("iso:"):
+            trigger_kind = "once"
+            next_fire = parse_iso_utc(when)
+            now_utc = datetime.now(timezone.utc)
+            if next_fire <= now_utc:
+                raise ValueError("iso must be in future")
+            iso_str: str | None = next_fire.isoformat()
+            cron_str: str | None = None
+        elif when.startswith("cron:"):
+            trigger_kind = "cron"
+            # parse_cron_to_next validates tz + cron in one go
+            next_fire = parse_cron_to_next(when, tz_name)
+            cron_str = when[5:].strip()
+            iso_str = None
+        else:
+            raise ValueError("when must start with cron: or iso:")
+
+        # 6. recurring only valid with cron
+        if recurring and trigger_kind == "once":
+            raise ValueError("recurring only valid with cron")
+
+        # 7. claude min interval for cron
+        if trigger_kind == "cron" and is_claude_created:
+            assert cron_str is not None  # narrowed by branch
+            tz = ZoneInfo(tz_name)  # validated above
+            base_local = datetime.now(timezone.utc).astimezone(tz)
+            it = croniter(cron_str, base_local)
+            t1 = it.get_next(datetime)
+            t2 = it.get_next(datetime)
+            if t1.tzinfo is None:
+                t1 = t1.replace(tzinfo=tz)
+                t2 = t2.replace(tzinfo=tz)
+            gap = (t2 - t1).total_seconds()
+            if gap < CLAUDE_MIN_INTERVAL_S:
+                raise ValueError(
+                    "min interval 5 min for claude-created schedules"
+                )
+
+        # 8. max_lifetime semantics
+        max_lifetime_seconds: int | None = None
+        if max_lifetime is not None:
+            if not recurring:
+                raise ValueError(
+                    "max_lifetime only valid with recurring=true"
+                )
+            max_lifetime_seconds = parse_duration(max_lifetime)  # caps at 365d
+
+        # 9. caps (per-user + global)
+        user_key = str(created_by)
+        if self.store.count_active_for_user(user_key) >= MAX_USER_ACTIVE:
+            raise ValueError(
+                f"per-user active cap reached ({MAX_USER_ACTIVE})"
+            )
+        if self.store.count_active_total() >= MAX_GLOBAL_ACTIVE:
+            raise ValueError(
+                f"global active cap reached ({MAX_GLOBAL_ACTIVE})"
+            )
+
+        # 10. build + persist
+        sched_id = secrets.token_hex(8)
+        now_iso = datetime.now(timezone.utc).isoformat()
+        sched: dict = {
+            "schedule_id": sched_id,
+            "kind": kind,
+            "name": name if name else sched_id[:8],
+            "created_at": now_iso,
+            "created_by": user_key,
+            "guild_id": guild_id,
+            "channel_id": channel_id,
+            "target_thread_id": target_thread_id if kind == "message" else None,
+            "target_channel_id": (
+                target_channel_id if kind == "new_task" else None
+            ),
+            "thread_name": thread_name if kind == "new_task" else None,
+            "trigger": {
+                "kind": trigger_kind,
+                "iso": iso_str,
+                "cron": cron_str,
+                "tz_when_created": tz_name,
+                "recurring": recurring,
+            },
+            "payload": {"what": what},
+            "max_lifetime_seconds": max_lifetime_seconds,
+            "state": {
+                "enabled": True,
+                "next_fire_at": next_fire.isoformat(),
+                "first_fired_at": None,
+                "last_fired_at": None,
+                "last_error": None,
+                "fire_count": 0,
+                "missed_count": 0,
+            },
+        }
+        self.store.add(sched)
+        log.info(
+            "schedule created id=%s kind=%s trigger=%s recurring=%s by=%s",
+            sched_id, kind, trigger_kind, recurring, user_key,
+        )
+        return sched
+
+    # ------------------------------------------------------------ Delete
+
+    def delete(
+        self,
+        sched_id: str,
+        *,
+        requester: str | int,
+        is_admin: bool = False,
+    ) -> tuple[bool, str]:
+        """Delete a schedule. Returns ``(ok, reason)``.
+
+        See :meth:`_check_permission` for the access matrix. Missing IDs
+        return ``(False, "not found")``.
+        """
+        sched = self.store.get(sched_id)
+        if sched is None:
+            return False, "not found"
+        ok, reason = self._check_permission(sched, requester, is_admin)
+        if not ok:
+            return False, reason
+        self.store.delete(sched_id)
+        log.info(
+            "schedule deleted id=%s by=%s admin=%s",
+            sched_id, requester, is_admin,
+        )
+        return True, "ok"
+
+    # ------------------------------------------------------------ Toggle
+
+    def toggle(
+        self,
+        sched_id: str,
+        enabled: bool,
+        *,
+        requester: str | int,
+        is_admin: bool = False,
+    ) -> tuple[bool, str]:
+        """Enable / disable a schedule. Returns ``(ok, reason)``.
+
+        Same permission matrix as :meth:`delete`. The fire loop (Subtask 2)
+        will pick up the new enabled flag on its next tick.
+        """
+        sched = self.store.get(sched_id)
+        if sched is None:
+            return False, "not found"
+        ok, reason = self._check_permission(sched, requester, is_admin)
+        if not ok:
+            return False, reason
+        sched.setdefault("state", {})["enabled"] = bool(enabled)
+        self.store.save(sched)
+        log.info(
+            "schedule toggle id=%s enabled=%s by=%s admin=%s",
+            sched_id, enabled, requester, is_admin,
+        )
+        return True, "ok"

--- a/src/clauded/scheduler.py
+++ b/src/clauded/scheduler.py
@@ -211,6 +211,7 @@ def parse_duration(s: str) -> int:
 
 FireCallback = Callable[[dict], Awaitable[None]]
 LockProvider = Callable[[int], asyncio.Lock]
+BoundChecker = Callable[[int], bool]
 
 
 class SchedulerManager:
@@ -230,11 +231,18 @@ class SchedulerManager:
         fire_new_task_callback: FireCallback,
         expire_notify_callback: FireCallback | None = None,
         get_lock: LockProvider | None = None,
+        bound_checker: BoundChecker | None = None,
     ) -> None:
         self.store = store
         self.fire_message_callback = fire_message_callback
         self.fire_new_task_callback = fire_new_task_callback
         self.expire_notify_callback = expire_notify_callback
+        # M4: optional bound-channel validator. If supplied, ``create``
+        # rejects ``kind=new_task`` schedules whose ``target_channel_id``
+        # is not bound to a project (avoiding the late "channel not bound"
+        # RuntimeError at fire time). Defaults to ``None`` (no check) so
+        # tests / non-Discord callers don't need a project_manager.
+        self.bound_checker = bound_checker
 
         if get_lock is None:
             # Default: per-target (thread_id or channel_id) ``asyncio.Lock``s,
@@ -258,6 +266,14 @@ class SchedulerManager:
         # Bound concurrent in-flight fires across all schedules — PRD §3.8
         # (``MAX_GLOBAL_INFLIGHT = 10``). Acquired inside ``_fire_one``.
         self._inflight_sem = asyncio.Semaphore(MAX_GLOBAL_INFLIGHT)
+
+        # B1: track schedule_ids currently being fired so a slow callback
+        # whose tick interval is shorter than its execution time can't be
+        # re-dispatched on the next ``tick()`` / ``catch_up()`` pass. The
+        # set is read by ``tick``/``catch_up`` before creating a fire task,
+        # and ``_fire_one`` removes the id on completion (success, terminal,
+        # or unexpected raise) so a transient outage can't strand the entry.
+        self._inflight_ids: set[str] = set()
 
     # ----------------------------------------------------- Permission
 
@@ -347,6 +363,18 @@ class SchedulerManager:
             ):
                 raise ValueError(
                     "kind=new_task requires positive int target_channel_id"
+                )
+            # M4: surface the unbound-channel error at create() time rather
+            # than letting the fire callback raise RuntimeError("not bound")
+            # 1..30 days later. The checker is optional so library/test
+            # callers without a project_manager are unaffected.
+            if (
+                self.bound_checker is not None
+                and not self.bound_checker(target_channel_id)
+            ):
+                raise ValueError(
+                    f"target_channel_id {target_channel_id} is not bound "
+                    "to a project (run /project bind <path> first)"
                 )
         else:
             raise ValueError(f"unknown kind: {kind!r}")
@@ -550,20 +578,36 @@ class SchedulerManager:
 
         Called on a periodic loop (PRD §3.8 ``TICK_INTERVAL_S = 15``). For
         every enabled schedule whose ``state.next_fire_at`` is ``<=`` now,
-        an :meth:`_fire_one` task is scheduled via ``asyncio.create_task``
+        an :meth:`_fire_one_safe` task is scheduled via ``asyncio.create_task``
         and this method returns immediately — the semaphore inside
         ``_fire_one`` is the only thing that bounds in-flight concurrency.
+
+        B1: schedules currently being fired (id in ``self._inflight_ids``)
+        are skipped — a slow callback whose runtime exceeds
+        :data:`TICK_INTERVAL_S` must not be double-dispatched. The
+        ``_inflight_ids.add(sid)`` happens HERE (synchronously, before the
+        task is created) so the guard is effective on the very next
+        ``tick`` iteration; if we deferred the add into ``_fire_one`` the
+        check above could pass spuriously between two ticks both racing
+        to dispatch the same schedule.
         """
         now = self._now_utc()
         for sched in self.store.list_all().values():
             state = sched.get("state") or {}
             if not state.get("enabled", False):
                 continue
+            sid = sched.get("schedule_id")
+            if sid in self._inflight_ids:
+                continue
             next_fire = self._parse_next_fire(state.get("next_fire_at"))
             if next_fire is None:
                 continue
             if next_fire <= now:
-                asyncio.create_task(self._fire_one(sched))
+                if sid is not None:
+                    self._inflight_ids.add(sid)
+                    asyncio.create_task(self._fire_one_safe(sid, sched))
+                else:
+                    asyncio.create_task(self._fire_one(sched))
 
     async def catch_up(self) -> None:
         """One-shot scan called on bot startup to handle missed fires.
@@ -572,11 +616,18 @@ class SchedulerManager:
         :data:`MISSED_FIRE_GRACE_S` (300s) get dispatched normally.
         Anything older is marked missed and rolled forward without
         firing (recurring) or disabled (one-shot deep past).
+
+        B1: schedules currently in-flight are skipped here too — catch_up
+        only runs once at startup, but the same belt-and-braces guard
+        keeps the contract consistent with ``tick()``.
         """
         now = self._now_utc()
         for sched in self.store.list_all().values():
             state = sched.get("state") or {}
             if not state.get("enabled", False):
+                continue
+            sid = sched.get("schedule_id")
+            if sid in self._inflight_ids:
                 continue
             next_fire = self._parse_next_fire(state.get("next_fire_at"))
             if next_fire is None:
@@ -586,7 +637,11 @@ class SchedulerManager:
 
             age = (now - next_fire).total_seconds()
             if age <= MISSED_FIRE_GRACE_S:
-                asyncio.create_task(self._fire_one(sched))
+                if sid is not None:
+                    self._inflight_ids.add(sid)
+                    asyncio.create_task(self._fire_one_safe(sid, sched))
+                else:
+                    asyncio.create_task(self._fire_one(sched))
                 continue
 
             # Too stale to fire — mark missed and roll forward.
@@ -608,6 +663,22 @@ class SchedulerManager:
 
     # ---------------------------------------------------- _fire_one core
 
+    async def _fire_one_safe(self, sched_id: str, sched: dict) -> None:
+        """Wrapper around :meth:`_fire_one` that guarantees inflight cleanup.
+
+        B1: ``tick()`` / ``catch_up()`` add the ``sched_id`` to
+        ``self._inflight_ids`` synchronously *before* creating this task
+        (so the very next tick sees the guard). This wrapper makes the
+        symmetric removal bulletproof — even if ``_fire_one`` raises an
+        unexpected exception (cancelled task, programming error, etc.),
+        the id is still discarded so the schedule isn't stranded out of
+        the inflight set forever.
+        """
+        try:
+            await self._fire_one(sched)
+        finally:
+            self._inflight_ids.discard(sched_id)
+
     async def _fire_one(self, sched: dict) -> None:
         """Acquire concurrency budget + per-target lock, then run the fire.
 
@@ -616,7 +687,20 @@ class SchedulerManager:
         (thread_id for ``kind=message``, channel_id for ``kind=new_task``)
         serializes fires aimed at the same destination so two due
         schedules can't interleave their callbacks.
+
+        B1: inflight-id bookkeeping lives in :meth:`_fire_one_safe` (the
+        dispatch-site wrapper) so the add/discard pair brackets the task
+        rather than the body of this method. This keeps the ``tick`` /
+        ``catch_up`` guard race-free without depending on an internal
+        try/finally here.
+
+        M1+M9: after acquiring the per-target lock we re-read the schedule
+        state from the store. If a concurrent ``delete()`` / ``toggle()``
+        flipped ``enabled=False`` or removed the row, this run is aborted
+        cleanly instead of firing the stale snapshot we were dispatched
+        with.
         """
+        sid = sched.get("schedule_id")
         async with self._inflight_sem:
             kind = sched.get("kind")
             if kind == "message":
@@ -632,6 +716,25 @@ class SchedulerManager:
                 await self._fire_with_retry(sched)
                 return
             async with self.get_lock(lock_id):
+                # M1+M9: re-read state under the lock so a delete/toggle
+                # that landed between dispatch and lock-acquire wins.
+                if sid is not None:
+                    fresh = self.store.get(sid)
+                    if fresh is None:
+                        log.info(
+                            "#241 _fire_one aborted (deleted): %s", sid,
+                        )
+                        return
+                    fresh_state = fresh.get("state") or {}
+                    if not fresh_state.get("enabled", False):
+                        log.info(
+                            "#241 _fire_one aborted (disabled): %s",
+                            sid,
+                        )
+                        return
+                    # Continue with the freshest snapshot — bookkeeping
+                    # in ``_on_fire_*`` writes through the same dict.
+                    sched = fresh
                 await self._fire_with_retry(sched)
 
     async def _fire_with_retry(self, sched: dict) -> None:
@@ -694,6 +797,16 @@ class SchedulerManager:
         state["last_error"] = None
         if state.get("first_fired_at") is None:
             state["first_fired_at"] = now.isoformat()
+
+        # M2: clear the cached "thread for this in-progress fire" id used
+        # by ``_fire_schedule_new_task`` to stay retry-idempotent (so a
+        # transient post-create_thread failure can reuse the same thread
+        # on the next attempt). A successful fire is the natural reset
+        # point — the next scheduled occurrence of a recurring kind=new_task
+        # MUST create a fresh thread; reusing the previous one would
+        # silently turn weekly tasks into "one thread, many turns".
+        if "_new_task_thread_id" in state:
+            state["_new_task_thread_id"] = None
 
         trigger = sched.get("trigger") or {}
         recurring = (

--- a/src/clauded/scheduler_mcp.py
+++ b/src/clauded/scheduler_mcp.py
@@ -19,6 +19,7 @@ before any turn runs; tests reset it via ``set_scheduler_manager(None)``.
 
 from __future__ import annotations
 
+import contextvars
 import logging
 from typing import Callable
 
@@ -33,6 +34,39 @@ log = logging.getLogger(__name__)
 
 _GLOBAL_MGR: SchedulerManager | None = None
 _GLOBAL_CTX: Callable[[], dict] | None = None
+
+# B2: per-task scheduler context. ``ContextVar.set`` mutates only the
+# current asyncio task's copy of the context, so two concurrent fires or
+# turns no longer race on a single bot-instance dict between
+# ``set_ctx`` and the eventual tool call. ``set_ctx`` is called by the
+# bot immediately before kicking off the turn / fire; ``_resolve_ctx``
+# prefers the ContextVar value when set, falling back to the legacy
+# ``_GLOBAL_CTX`` callable for code paths (older tests, callers wiring a
+# custom ctx_provider) that haven't migrated yet.
+_scheduler_ctx_var: contextvars.ContextVar[dict] = contextvars.ContextVar(
+    "scheduler_ctx", default={}
+)
+
+
+def set_ctx(ctx: dict) -> None:
+    """Set the per-task scheduler context (B2 ContextVar entry-point).
+
+    Stores ``ctx`` in :data:`_scheduler_ctx_var`. Because ``ContextVar``
+    is task-local, the value seen by tool handlers running inside the
+    *current* asyncio task isolated from any sibling fire/turn that may
+    be running concurrently. Pass an empty dict to clear.
+    """
+    _scheduler_ctx_var.set(ctx or {})
+
+
+def get_ctx() -> dict:
+    """Return the current task's scheduler context (B2 ContextVar getter).
+
+    Defaults to ``{}`` so callers can dispatch on truthiness. Reads from
+    :data:`_scheduler_ctx_var` only — :func:`_resolve_ctx` handles the
+    fallback to the legacy ``_GLOBAL_CTX`` provider.
+    """
+    return _scheduler_ctx_var.get() or {}
 
 
 def set_scheduler_manager(
@@ -60,7 +94,18 @@ def _require_mgr() -> SchedulerManager | None:
 
 
 def _resolve_ctx() -> dict:
-    """Call the ctx_provider safely. Returns ``{}`` on missing/raising."""
+    """Return the active scheduler context for the current tool call.
+
+    B2: the ``ContextVar`` is consulted first — a non-empty value there
+    means a recent ``set_ctx`` in this task already provided the context.
+    If empty, fall back to the legacy ``_GLOBAL_CTX`` callable wired via
+    :func:`set_scheduler_manager` (kept for compatibility with code paths
+    or tests that haven't migrated to ``set_ctx``). Returns ``{}`` on
+    missing/raising provider.
+    """
+    cv_ctx = _scheduler_ctx_var.get() or {}
+    if cv_ctx:
+        return cv_ctx
     if _GLOBAL_CTX is None:
         return {}
     try:
@@ -293,9 +338,19 @@ async def schedule_list_tool(args: dict) -> dict:
         fire_count = state.get("fire_count", 0)
         enabled = state.get("enabled", False)
         enabled_marker = "" if enabled else " (disabled)"
+        # M10: include missed_count + last_fired_at + max_lifetime so
+        # claude can reason about whether a recurring schedule has been
+        # firing reliably or has accumulated missed_fires (catch_up
+        # rollforwards) since last user interaction. The MCP tool surface
+        # has no embed-size budget like /schedule list, so we always emit.
+        missed = state.get("missed_count", 0) or 0
+        last_fired = state.get("last_fired_at") or "—"
+        max_life = s.get("max_lifetime_seconds")
+        max_life_str = f"{max_life}s" if max_life else "—"
         lines.append(
             f"{kind_marker} {cb_marker} `{sid}` {name} — next={next_at} "
-            f"fires={fire_count}{enabled_marker}\n"
+            f"fires={fire_count} missed={missed} last={last_fired} "
+            f"max_lifetime={max_life_str}{enabled_marker}\n"
             f"   what: {what_preview!r}"
         )
 

--- a/src/clauded/scheduler_mcp.py
+++ b/src/clauded/scheduler_mcp.py
@@ -1,0 +1,368 @@
+"""#241 — in-process MCP server exposing 5 ``schedule_*`` tools to claude.
+
+PRD: ``docs/prd/v1.18-scheduler.md`` §3.7 + §4. Wired into
+``ClaudeBridge.start()`` in Subtask 4 (do not import here from ``bot`` or
+``claude_bridge`` — this module is intentionally standalone so it can be
+imported from anywhere without dragging Discord types into pure-logic
+code paths).
+
+Five tools exposed:
+  * ``schedule_message``   — kind=message  (inject into existing thread)
+  * ``schedule_new_task``  — kind=new_task (spawn new thread + fresh session)
+  * ``schedule_list``      — list schedules with kind / creator markers
+  * ``schedule_delete``    — delete by 16-char hex id (claude→own only)
+  * ``schedule_toggle``    — enable/disable                (claude→own only)
+
+Module-level state (``_GLOBAL_MGR``, ``_GLOBAL_CTX``) is wired by the bot
+before any turn runs; tests reset it via ``set_scheduler_manager(None)``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+from claude_agent_sdk import create_sdk_mcp_server, tool
+
+from .scheduler import SchedulerManager
+
+log = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------- Module state
+
+_GLOBAL_MGR: SchedulerManager | None = None
+_GLOBAL_CTX: Callable[[], dict] | None = None
+
+
+def set_scheduler_manager(
+    mgr: SchedulerManager | None,
+    *,
+    ctx_provider: Callable[[], dict] | None = None,
+) -> None:
+    """Wire (or clear) the manager + per-turn context provider.
+
+    ``ctx_provider()`` should return a dict with ``thread_id`` /
+    ``channel_id`` / ``guild_id`` / ``tz_name`` keys describing the
+    *current* claude turn. The bot sets this immediately BEFORE invoking
+    the bridge so the tool handlers know which thread/channel the turn
+    originated from. Pass ``mgr=None`` (typically in test teardown) to
+    detach.
+    """
+    global _GLOBAL_MGR, _GLOBAL_CTX
+    _GLOBAL_MGR = mgr
+    _GLOBAL_CTX = ctx_provider
+
+
+def _require_mgr() -> SchedulerManager | None:
+    """Return the wired manager, or ``None`` if not set yet."""
+    return _GLOBAL_MGR
+
+
+def _resolve_ctx() -> dict:
+    """Call the ctx_provider safely. Returns ``{}`` on missing/raising."""
+    if _GLOBAL_CTX is None:
+        return {}
+    try:
+        return _GLOBAL_CTX() or {}
+    except Exception:
+        log.exception("#241 ctx_provider raised")
+        return {}
+
+
+def _err(text: str) -> dict:
+    """Standard error-result shape for SDK MCP tool handlers."""
+    return {"is_error": True, "content": [{"type": "text", "text": text}]}
+
+
+def _ok(text: str) -> dict:
+    """Standard ok-result shape for SDK MCP tool handlers."""
+    return {"content": [{"type": "text", "text": text}]}
+
+
+# ----------------------------------------------------- schedule_message
+
+@tool(
+    "schedule_message",
+    "Create a recurring or one-shot timer that injects a user message "
+    "into a Discord thread's existing session when it fires. "
+    "Use this when the user wants a reminder/message dropped into an "
+    "ongoing conversation at a scheduled time. "
+    "Required: when (str, 'cron: ...' or 'iso: ...'), what (str, ≤500). "
+    "Optional: target_thread_id, name (≤50), recurring (bool), "
+    "max_lifetime (e.g. '30d', ≤365d, only valid with recurring=true).",
+    {
+        "when": str,
+        "what": str,
+        "target_thread_id": str,
+        "name": str,
+        "recurring": bool,
+        "max_lifetime": str,
+    },
+)
+async def schedule_message_tool(args: dict) -> dict:
+    """Create a ``kind=message`` schedule from claude tool args."""
+    mgr = _require_mgr()
+    if mgr is None:
+        return _err("scheduler not initialized")
+    ctx = _resolve_ctx()
+
+    # target thread: explicit arg wins; else current turn's thread
+    tid_arg = args.get("target_thread_id")
+    if not tid_arg and not ctx.get("thread_id"):
+        return _err(
+            "no target thread (turn context missing and no "
+            "target_thread_id arg)"
+        )
+    try:
+        target_thread_id = int(tid_arg) if tid_arg else int(ctx["thread_id"])
+    except (TypeError, ValueError):
+        return _err(f"invalid target_thread_id: {tid_arg!r}")
+
+    when = args.get("when")
+    what = args.get("what")
+    if not isinstance(when, str):
+        return _err("when is required (str: 'cron: ...' or 'iso: ...')")
+    if not isinstance(what, str):
+        return _err("what is required (str ≤500)")
+
+    try:
+        sched = mgr.create(
+            kind="message",
+            when=when,
+            what=what,
+            target_thread_id=target_thread_id,
+            name=args.get("name"),
+            recurring=bool(args.get("recurring", False)),
+            max_lifetime=args.get("max_lifetime"),
+            created_by="claude",
+            is_claude_created=True,
+            guild_id=ctx.get("guild_id"),
+            channel_id=ctx.get("channel_id"),
+            tz_name=ctx.get("tz_name", "Asia/Shanghai"),
+        )
+    except ValueError as exc:
+        return _err(str(exc))
+    except Exception as exc:  # pragma: no cover — defensive
+        log.exception("#241 schedule_message_tool failed")
+        return _err(f"internal error: {exc}")
+
+    return _ok(
+        f"Created schedule {sched['schedule_id']} "
+        f"(kind=message, next_fire_at={sched['state']['next_fire_at']})"
+    )
+
+
+# ---------------------------------------------------- schedule_new_task
+
+@tool(
+    "schedule_new_task",
+    "Create a recurring or one-shot timer that spawns a NEW Discord "
+    "thread + fresh claude session at fire time, with `what` as the "
+    "first user prompt. Use for independent scheduled tasks (vs "
+    "schedule_message which injects into an existing conversation). "
+    "Required: when, what. Optional: target_channel_id, thread_name "
+    "(≤50, for the new thread), name (schedule label), recurring, "
+    "max_lifetime.",
+    {
+        "when": str,
+        "what": str,
+        "target_channel_id": str,
+        "thread_name": str,
+        "name": str,
+        "recurring": bool,
+        "max_lifetime": str,
+    },
+)
+async def schedule_new_task_tool(args: dict) -> dict:
+    """Create a ``kind=new_task`` schedule from claude tool args."""
+    mgr = _require_mgr()
+    if mgr is None:
+        return _err("scheduler not initialized")
+    ctx = _resolve_ctx()
+
+    # target channel: explicit arg wins; else current turn's channel
+    cid_arg = args.get("target_channel_id")
+    try:
+        if cid_arg:
+            target_channel_id = int(cid_arg)
+        elif ctx.get("channel_id"):
+            target_channel_id = int(ctx["channel_id"])
+        else:
+            return _err(
+                "no target channel (turn context missing and no "
+                "target_channel_id arg)"
+            )
+    except (TypeError, ValueError):
+        return _err(f"invalid target_channel_id: {cid_arg!r}")
+
+    when = args.get("when")
+    what = args.get("what")
+    if not isinstance(when, str):
+        return _err("when is required (str: 'cron: ...' or 'iso: ...')")
+    if not isinstance(what, str):
+        return _err("what is required (str ≤500)")
+
+    try:
+        sched = mgr.create(
+            kind="new_task",
+            when=when,
+            what=what,
+            target_channel_id=target_channel_id,
+            thread_name=args.get("thread_name"),
+            name=args.get("name"),
+            recurring=bool(args.get("recurring", False)),
+            max_lifetime=args.get("max_lifetime"),
+            created_by="claude",
+            is_claude_created=True,
+            guild_id=ctx.get("guild_id"),
+            channel_id=ctx.get("channel_id"),
+            tz_name=ctx.get("tz_name", "Asia/Shanghai"),
+        )
+    except ValueError as exc:
+        return _err(str(exc))
+    except Exception as exc:  # pragma: no cover — defensive
+        log.exception("#241 schedule_new_task_tool failed")
+        return _err(f"internal error: {exc}")
+
+    return _ok(
+        f"Created schedule {sched['schedule_id']} "
+        f"(kind=new_task, next_fire_at={sched['state']['next_fire_at']})"
+    )
+
+
+# -------------------------------------------------------- schedule_list
+
+@tool(
+    "schedule_list",
+    "List schedules. Scope: 'thread' (default, current thread, "
+    "kind=message only) | 'channel' (current channel: message+new_task) "
+    "| 'all' (everywhere). Optional include_disabled (default false).",
+    {
+        "scope": str,
+        "include_disabled": bool,
+    },
+)
+async def schedule_list_tool(args: dict) -> dict:
+    """List schedules in the requested scope with kind / creator markers."""
+    mgr = _require_mgr()
+    if mgr is None:
+        return _err("scheduler not initialized")
+    ctx = _resolve_ctx()
+    scope = args.get("scope", "thread")
+    include_disabled = bool(args.get("include_disabled", False))
+
+    if scope == "thread":
+        tid = ctx.get("thread_id")
+        if not tid:
+            return _err("scope=thread requires turn context")
+        try:
+            items = mgr.store.list_for_thread(int(tid))
+        except (TypeError, ValueError):
+            return _err(f"invalid ctx thread_id: {tid!r}")
+    elif scope == "channel":
+        cid = ctx.get("channel_id")
+        if not cid:
+            return _err("scope=channel requires turn context")
+        try:
+            items = mgr.store.list_for_channel(int(cid))
+        except (TypeError, ValueError):
+            return _err(f"invalid ctx channel_id: {cid!r}")
+    elif scope == "all":
+        items = list(mgr.store.list_all().values())
+    else:
+        return _err(f"invalid scope: {scope!r}")
+
+    if not include_disabled:
+        items = [s for s in items if s.get("state", {}).get("enabled", False)]
+
+    if not items:
+        return _ok("(no schedules)")
+
+    lines: list[str] = []
+    for s in items:
+        kind = s.get("kind", "?")
+        kind_marker = "📨" if kind == "message" else "🧵"
+        cb = s.get("created_by", "")
+        cb_marker = "🤖" if cb == "claude" else "👤"
+        name = s.get("name", "") or ""
+        sid = (s.get("schedule_id", "") or "")[:8]
+        what_preview = (s.get("payload", {}).get("what", "") or "")[:50]
+        state = s.get("state", {}) or {}
+        next_at = state.get("next_fire_at", "")
+        fire_count = state.get("fire_count", 0)
+        enabled = state.get("enabled", False)
+        enabled_marker = "" if enabled else " (disabled)"
+        lines.append(
+            f"{kind_marker} {cb_marker} `{sid}` {name} — next={next_at} "
+            f"fires={fire_count}{enabled_marker}\n"
+            f"   what: {what_preview!r}"
+        )
+
+    return _ok("\n".join(lines))
+
+
+# ------------------------------------------------------ schedule_delete
+
+@tool(
+    "schedule_delete",
+    "Delete a schedule by id (16-char hex). Claude can only delete "
+    "claude-created schedules.",
+    {"schedule_id": str},
+)
+async def schedule_delete_tool(args: dict) -> dict:
+    """Delete a schedule (claude scope only)."""
+    mgr = _require_mgr()
+    if mgr is None:
+        return _err("scheduler not initialized")
+    sid = args.get("schedule_id")
+    if not sid:
+        return _err("schedule_id required")
+    ok, reason = mgr.delete(sid, requester="claude", is_admin=False)
+    return _ok(f"Deleted {sid}") if ok else _err(reason)
+
+
+# ------------------------------------------------------ schedule_toggle
+
+@tool(
+    "schedule_toggle",
+    "Enable or disable a schedule. Claude can only toggle "
+    "claude-created schedules.",
+    {"schedule_id": str, "enabled": bool},
+)
+async def schedule_toggle_tool(args: dict) -> dict:
+    """Enable / disable a schedule (claude scope only)."""
+    mgr = _require_mgr()
+    if mgr is None:
+        return _err("scheduler not initialized")
+    sid = args.get("schedule_id")
+    if not sid:
+        return _err("schedule_id required")
+    enabled = bool(args.get("enabled", True))
+    ok, reason = mgr.toggle(sid, enabled, requester="claude", is_admin=False)
+    if not ok:
+        return _err(reason)
+    return _ok(f"Set {sid} enabled={enabled}")
+
+
+# ------------------------------------------------------------ Builder
+
+def build_scheduler_mcp_server():
+    """Build the in-process MCP server.
+
+    Returns an ``McpSdkServerConfig`` dict (``{"type":"sdk","name":...,
+    "instance":<server>}``) suitable for direct insertion into
+    ``ClaudeAgentOptions.mcp_servers`` (Subtask 4 wires this into
+    :meth:`ClaudeBridge.start`).
+    """
+    return create_sdk_mcp_server(
+        name="clauded-scheduler",
+        version="1.0.0",
+        tools=[
+            schedule_message_tool,
+            schedule_new_task_tool,
+            schedule_list_tool,
+            schedule_delete_tool,
+            schedule_toggle_tool,
+        ],
+    )

--- a/src/clauded/scheduler_store.py
+++ b/src/clauded/scheduler_store.py
@@ -1,0 +1,162 @@
+"""Persist scheduled-timer metadata so `/schedule` survives bot restart.
+
+Schema per PRD §5 (docs/prd/v1.18-scheduler.md). Atomic write follows the
+same pattern as :mod:`clauded.session_store` — tmp + fsync + os.replace.
+Corrupt JSON falls back to an empty dict + WARNING (never raises).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+class SchedulerStore:
+    """Maps schedule_id -> schedule dict, persisted to ``data/schedules.json``.
+
+    The on-disk shape is exactly the dict produced by
+    :meth:`clauded.scheduler.SchedulerManager.create` (see PRD §5). This
+    class is intentionally schema-agnostic — it stores and retrieves dicts;
+    higher-level validation lives in :class:`SchedulerManager`.
+    """
+
+    def __init__(self, data_dir: str = "data") -> None:
+        self._dir = Path(data_dir)
+        self._path = self._dir / "schedules.json"
+        self._schedules: dict[str, dict] = {}
+        self._load()
+
+    # ------------------------------------------------------------------ I/O
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            with open(self._path) as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                log.warning(
+                    "schedules.json top-level is %s, expected dict; starting fresh",
+                    type(data).__name__,
+                )
+                self._schedules = {}
+                return
+            self._schedules = data
+        except (json.JSONDecodeError, OSError) as exc:
+            log.warning(
+                "Failed to load schedules.json (%s); starting fresh", exc
+            )
+            self._schedules = {}
+
+    def _save(self) -> None:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        tmp = self._path.with_suffix(".tmp")
+        with open(tmp, "w") as f:
+            json.dump(self._schedules, f, indent=2, default=str)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, self._path)
+
+    # ---------------------------------------------------------------- CRUD
+
+    def add(self, sched: dict) -> str:
+        """Insert a new schedule and return its ``schedule_id``.
+
+        If the caller did not pre-populate ``sched["schedule_id"]``, a
+        fresh 16-char hex token is generated via :func:`secrets.token_hex`.
+        """
+        sid = sched.get("schedule_id")
+        if not sid:
+            sid = secrets.token_hex(8)
+            sched["schedule_id"] = sid
+        self._schedules[sid] = sched
+        self._save()
+        return sid
+
+    def get(self, sched_id: str) -> dict | None:
+        """Return the schedule dict for ``sched_id`` or None if missing."""
+        return self._schedules.get(sched_id)
+
+    def delete(self, sched_id: str) -> bool:
+        """Remove ``sched_id`` from the store. Returns False if not present."""
+        if sched_id in self._schedules:
+            del self._schedules[sched_id]
+            self._save()
+            return True
+        return False
+
+    def save(self, sched: dict) -> None:
+        """Persist a mutated schedule back to disk (write-through)."""
+        sid = sched.get("schedule_id")
+        if not sid:
+            raise ValueError("save() requires schedule_id field on sched dict")
+        self._schedules[sid] = sched
+        self._save()
+
+    # Alias for clarity at call sites.
+    update = save
+
+    # ------------------------------------------------------------ Queries
+
+    def list_all(self) -> dict[str, dict]:
+        """Return a shallow copy of all schedules keyed by schedule_id."""
+        return dict(self._schedules)
+
+    def list_for_thread(self, thread_id: int) -> list[dict]:
+        """All ``kind=message`` schedules whose ``target_thread_id`` matches.
+
+        ``kind=new_task`` schedules are never bound to a thread (they create
+        threads) and are therefore excluded.
+        """
+        out: list[dict] = []
+        for sched in self._schedules.values():
+            if sched.get("kind") != "message":
+                continue
+            if sched.get("target_thread_id") == thread_id:
+                out.append(sched)
+        return out
+
+    def list_for_channel(self, channel_id: int) -> list[dict]:
+        """All schedules tied to ``channel_id``.
+
+        Includes:
+          * any schedule whose ``channel_id`` (creation channel) matches, OR
+          * ``kind=new_task`` schedules whose ``target_channel_id`` matches.
+        """
+        out: list[dict] = []
+        for sched in self._schedules.values():
+            if sched.get("channel_id") == channel_id:
+                out.append(sched)
+                continue
+            if (
+                sched.get("kind") == "new_task"
+                and sched.get("target_channel_id") == channel_id
+            ):
+                out.append(sched)
+        return out
+
+    def count_active_for_user(self, user_id: str) -> int:
+        """Count enabled schedules created by ``user_id`` (string equality)."""
+        target = str(user_id)
+        n = 0
+        for sched in self._schedules.values():
+            if str(sched.get("created_by")) != target:
+                continue
+            state = sched.get("state") or {}
+            if state.get("enabled", False):
+                n += 1
+        return n
+
+    def count_active_total(self) -> int:
+        """Count enabled schedules across all creators (both kinds)."""
+        n = 0
+        for sched in self._schedules.values():
+            state = sched.get("state") or {}
+            if state.get("enabled", False):
+                n += 1
+        return n

--- a/tests/test_bot_fire_callbacks.py
+++ b/tests/test_bot_fire_callbacks.py
@@ -1,0 +1,269 @@
+"""Tests for the bot-side scheduled-fire callbacks (issue #241, Subtask 6 / B5).
+
+R1 Tester BLOCKER #1: the three callbacks on :class:`ClaudedBot` —
+``_fire_schedule_message`` / ``_fire_schedule_new_task`` /
+``_notify_schedule_expired`` — shipped with zero unit coverage. The
+"only thing standing between merge and works" was a not-yet-run real
+Discord e2e, which the 5/19 directive explicitly forbids.
+
+These 6 tests pin the actual call arguments (not just call counts) on
+the production methods — extracting via :meth:`ClaudedBot._format_fire_quoted_what`
+helper (B6) and the :meth:`ClaudedBot._send_fire_prefix_and_quote` wrapper
+(B6/M3) so each test stays scoped to one observable behavior:
+
+  1. ``_format_fire_quoted_what`` wraps each line in ``> 「<line>」``
+     and survives multi-line + empty input cleanly.
+  2. ``_send_fire_prefix_and_quote`` posts BOTH the AC13 prefix line
+     AND the bracketed-quote line, in order, with the prefix matching
+     the schedule's ``name``.
+  3. ``_send_fire_prefix_and_quote`` truncates the quoted content at
+     1900 chars (Discord 2000 ceiling minus headroom).
+  4. ``_send_fire_prefix_and_quote`` swallows + logs send errors so a
+     transient Discord failure on the prefix line never aborts the
+     actual fire.
+  5. ``_safe_fire_render`` dispatches the #224 auto-crash bundle on a
+     non-transient renderer crash AND re-raises so the scheduler can
+     classify the failure.
+  6. ``_safe_fire_render`` does NOT dispatch the crash bundle on
+     transient discord errors — those should bubble through the normal
+     retry path without polluting the audit trail.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from clauded.bot import ClaudedBot
+
+
+# ----------------------------------------------------------------------
+# Helpers — we instantiate just the methods of interest off a MagicMock-
+# spec'd ClaudedBot. The constructor pulls in too much (config, intents,
+# session_manager construction, the SchedulerManager). The methods we
+# test are functionally pure (apart from awaiting thread.send / renderer
+# methods), so binding them onto a MagicMock gives strict per-test
+# isolation without dragging in the full bot wiring.
+# ----------------------------------------------------------------------
+
+
+def _bare_bot() -> MagicMock:
+    """A MagicMock that exposes the bot fire-callback helpers via real impls.
+
+    We deliberately bind the *unbound* methods from ``ClaudedBot`` onto
+    a MagicMock so the staticmethod / regular-method semantics stay
+    correct and we can call them with the same self contract production
+    uses, but we avoid the constructor cost / side effects.
+    """
+    bot = MagicMock()
+    # Bind real implementations of the helpers under test.
+    bot._format_fire_quoted_what = ClaudedBot._format_fire_quoted_what
+    # _send_fire_prefix_and_quote and _safe_fire_render are regular
+    # methods — bind them with the MagicMock as ``self``.
+    bot._send_fire_prefix_and_quote = (
+        ClaudedBot._send_fire_prefix_and_quote.__get__(bot, MagicMock)
+    )
+    bot._safe_fire_render = (
+        ClaudedBot._safe_fire_render.__get__(bot, MagicMock)
+    )
+    bot._maybe_dispatch_auto_crash_bundle = AsyncMock()
+    return bot
+
+
+# ----------------------------------------------------------------------
+# Test 1 — _format_fire_quoted_what per-line 「<line>」 wrapping
+# ----------------------------------------------------------------------
+
+
+def test_format_fire_quoted_what_wraps_each_line_in_corner_brackets():
+    """B6 / PRD AC13: every visible line of the injected ``what`` is
+    independently wrapped in 「…」 and prefixed with Discord's quote ``> ``.
+
+    Strict: the multi-line case must produce one ``> 「line」`` per source
+    line — NOT one big ``> 「multi\\nline」`` blob (which would render in
+    Discord as one quoted line with a literal newline inside the brackets).
+    """
+    out = ClaudedBot._format_fire_quoted_what("line1\nline2\nline3")
+    assert out == "> 「line1」\n> 「line2」\n> 「line3」"
+
+    # Single-line input: still one bracketed quote line.
+    assert ClaudedBot._format_fire_quoted_what("hello") == "> 「hello」"
+
+    # Empty input: an empty bracketed quote — preserves the AC13 marker
+    # without leaking bogus content (the old behaviour was "> " literal).
+    assert ClaudedBot._format_fire_quoted_what("") == "> 「」"
+
+
+# ----------------------------------------------------------------------
+# Test 2 — _send_fire_prefix_and_quote sends prefix + quote, in order
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_fire_prefix_and_quote_emits_prefix_then_quoted_what():
+    """PRD AC13: humans see (1) the ``-# ⏰ Scheduled fire: <label>``
+    prefix line, then (2) the bracketed quote of ``what``.
+
+    Strict: pin the actual content of both ``send`` calls and the call
+    order — the prefix must precede the quote. A regression that swaps
+    the order, or that drops the prefix, would still satisfy
+    ``call_count == 2`` but break the AC.
+    """
+    bot = _bare_bot()
+    thread = MagicMock()
+    thread.send = AsyncMock()
+
+    await bot._send_fire_prefix_and_quote(
+        thread, "weekly_report", "first\nsecond",
+        sched_id_for_log="abc",
+    )
+
+    assert thread.send.await_count == 2
+    first_call, second_call = thread.send.await_args_list
+    assert first_call.kwargs == {
+        "content": "-# ⏰ Scheduled fire: weekly_report",
+    }
+    assert second_call.kwargs == {
+        "content": "> 「first」\n> 「second」",
+    }
+
+
+# ----------------------------------------------------------------------
+# Test 3 — _send_fire_prefix_and_quote truncates the quoted body to 1900
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_fire_prefix_and_quote_truncates_long_what_to_1900_chars():
+    """Discord's hard message ceiling is 2000 chars; we cap the quoted
+    line at 1900 to leave headroom for the ``> 「`` + ``」`` framing
+    characters and to defend against future-Discord ceiling tweaks.
+
+    Strict: the second ``send`` call's ``content`` MUST be exactly
+    1900 chars long when ``what`` exceeds that. A regression that
+    forgets the truncation slice would push >2000 and Discord would
+    reject the message — silently for the user.
+    """
+    bot = _bare_bot()
+    thread = MagicMock()
+    thread.send = AsyncMock()
+
+    long_what = "x" * 3000
+    await bot._send_fire_prefix_and_quote(
+        thread, "label", long_what, sched_id_for_log="abc",
+    )
+
+    second_call = thread.send.await_args_list[1]
+    assert len(second_call.kwargs["content"]) == 1900
+
+
+# ----------------------------------------------------------------------
+# Test 4 — _send_fire_prefix_and_quote swallows send failures
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_fire_prefix_and_quote_swallows_send_failure(caplog):
+    """A transient Discord failure on the prefix/quote sends must NOT
+    abort the broader fire callback — the actual claude turn (the
+    ``render_response`` after this helper) is the load-bearing work.
+
+    Strict: ``_send_fire_prefix_and_quote`` returns normally (no
+    exception) even when ``thread.send`` raises, AND a WARNING-level
+    log line lands so the audit trail records the dropped prefix.
+    """
+    bot = _bare_bot()
+    thread = MagicMock()
+    thread.send = AsyncMock(side_effect=RuntimeError("discord 503"))
+
+    with caplog.at_level("WARNING"):
+        # No exception propagates.
+        await bot._send_fire_prefix_and_quote(
+            thread, "lbl", "what", sched_id_for_log="sched-xyz",
+        )
+
+    # The log line includes the schedule id so /log dump can correlate.
+    assert any(
+        "sched-xyz" in r.message and "prefix/quoted send failed" in r.message
+        for r in caplog.records
+    )
+
+
+# ----------------------------------------------------------------------
+# Test 5 — _safe_fire_render dispatches the auto-crash bundle on a
+# non-transient renderer crash AND re-raises
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_safe_fire_render_dispatches_crash_bundle_and_reraises():
+    """M3: a scheduled-fire renderer crash MUST (a) dispatch the #224
+    auto-crash bundle so the audit trail captures the failure exactly
+    like human-driven turns get via ``_render_with_retry``, AND (b)
+    re-raise so :meth:`SchedulerManager._fire_with_retry` can apply its
+    1s/4s/16s backoff + terminal-disable policy.
+
+    Strict: both behaviours are pinned. Pre-M3 code skipped the bundle
+    entirely; a partial fix that dispatches the bundle but swallows the
+    exception would break the scheduler's retry contract.
+    """
+    bot = _bare_bot()
+    renderer = MagicMock()
+    boom = RuntimeError("renderer template KeyError: missing token")
+    renderer.render_response = AsyncMock(side_effect=boom)
+    bridge = MagicMock()
+    thread = MagicMock()
+
+    with pytest.raises(RuntimeError, match="renderer template"):
+        await bot._safe_fire_render(
+            renderer=renderer, bridge=bridge, what="x", thread=thread,
+        )
+
+    bot._maybe_dispatch_auto_crash_bundle.assert_awaited_once()
+    call_kwargs = bot._maybe_dispatch_auto_crash_bundle.await_args.kwargs
+    assert call_kwargs["thread"] is thread
+    assert call_kwargs["bridge"] is bridge
+    assert call_kwargs["exc"] is boom
+
+
+# ----------------------------------------------------------------------
+# Test 6 — _safe_fire_render does NOT dispatch the crash bundle on
+# transient discord errors (those bubble for the scheduler retry path)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_safe_fire_render_no_bundle_on_transient_discord_error(
+    monkeypatch,
+):
+    """M3 boundary: a transient discord error (HTTPException 5xx, etc.)
+    must NOT dispatch the crash bundle — those are normal "retry me"
+    failures, not renderer crashes. Dispatching a bundle for every
+    transient blip would pollute the audit trail and trip the 5min
+    cooldown so a *real* crash later gets silenced.
+
+    Strict: the function still re-raises (so the scheduler retries),
+    but ``_maybe_dispatch_auto_crash_bundle`` is NEVER awaited.
+    """
+    bot = _bare_bot()
+
+    # Force ``is_transient_discord_error`` to True regardless of the
+    # actual exception class so this test is isolated from discord.py's
+    # internal classification.
+    monkeypatch.setattr(
+        "clauded.bot.is_transient_discord_error", lambda exc: True,
+    )
+
+    renderer = MagicMock()
+    blip = RuntimeError("simulated transient")
+    renderer.render_response = AsyncMock(side_effect=blip)
+    bridge = MagicMock()
+    thread = MagicMock()
+
+    with pytest.raises(RuntimeError, match="simulated transient"):
+        await bot._safe_fire_render(
+            renderer=renderer, bridge=bridge, what="x", thread=thread,
+        )
+
+    bot._maybe_dispatch_auto_crash_bundle.assert_not_awaited()

--- a/tests/test_cogs_schedule.py
+++ b/tests/test_cogs_schedule.py
@@ -227,13 +227,31 @@ async def test_schedule_message_happy_path_renders_reminder(fake_bot):
 
 
 @pytest.mark.asyncio
-async def test_schedule_new_task_outside_thread_rejects(fake_bot):
+async def test_schedule_new_task_in_channel_creates_helper_thread(fake_bot):
+    """M11: /schedule new_task from a TextChannel should auto-create a
+    helper thread for the create-time reminder injection, NOT reject."""
     interaction = _make_channel_interaction(fake_bot)
-    await schedule_new_task_cmd.callback(interaction, "weekly report")
-    interaction.response.send_message.assert_awaited_once()
-    args, kwargs = interaction.response.send_message.await_args
-    assert "thread" in args[0].lower()
-    assert kwargs.get("ephemeral") is True
+    ch = interaction.channel
+    # Mock create_thread to return a fake thread
+    helper_thread = MagicMock(spec=discord.Thread)
+    helper_thread.id = 8888
+    helper_thread.parent_id = ch.id
+    helper_thread.guild = ch.guild
+    ch.create_thread = AsyncMock(return_value=helper_thread)
+
+    with patch("clauded.cogs.schedule.DiscordRenderer") as RendererCls:
+        renderer_inst = MagicMock()
+        renderer_inst.render_response = AsyncMock()
+        RendererCls.return_value = renderer_inst
+        await schedule_new_task_cmd.callback(interaction, "weekly report")
+
+    # Should have created a helper thread with scheduling prefix
+    ch.create_thread.assert_awaited_once()
+    call_kwargs = ch.create_thread.await_args[1] if ch.create_thread.await_args[1] else {}
+    call_args = ch.create_thread.await_args
+    # Thread name should contain scheduling indicator
+    name_arg = call_kwargs.get("name", call_args[0][0] if call_args[0] else "")
+    assert "schedule" in name_arg.lower() or "⏰" in name_arg or "📅" in name_arg
 
 
 @pytest.mark.asyncio

--- a/tests/test_cogs_schedule.py
+++ b/tests/test_cogs_schedule.py
@@ -1,0 +1,527 @@
+"""Tests for the v1.18 ``/schedule`` cog + bot wiring (issue #241, Subtask 4).
+
+Covers (per PRD ``docs/prd/v1.18-scheduler.md`` §8 Subtask 4):
+
+* The 5 subcommands on :data:`clauded.cogs.schedule.schedule_group`
+* Bot-side scheduler wiring (``_register_scheduler_ctx`` /
+  ``_scheduler_ctx_provider``) and the
+  ``claude_bridge.ClaudeBridge._build_mcp_servers`` merge.
+
+We deliberately drive the cog ``.callback`` functions directly with mocked
+``Interaction`` / ``Bot`` objects rather than spinning up a real Discord
+gateway connection. This matches the pattern in the existing
+``test_scheduler_mcp.py`` (call tool handlers directly via ``.handler``).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from clauded.cogs.schedule import (
+    _REMINDER_MESSAGE,
+    _REMINDER_NEW_TASK,
+    _resolve_full_schedule_id,
+    schedule_delete_cmd,
+    schedule_group,
+    schedule_list_cmd,
+    schedule_message_cmd,
+    schedule_new_task_cmd,
+    schedule_toggle_cmd,
+)
+from clauded.scheduler import SchedulerManager
+from clauded.scheduler_store import SchedulerStore
+
+
+# ---------------------------------------------------------------- Helpers
+
+
+def _future_iso(seconds: int = 3600) -> str:
+    dt = datetime.now(timezone.utc) + timedelta(seconds=seconds)
+    return "iso: " + dt.isoformat()
+
+
+async def _noop_cb(_sched):
+    return None
+
+
+@pytest.fixture
+def store(tmp_path):
+    d = tmp_path / "data"
+    d.mkdir()
+    return SchedulerStore(data_dir=str(d))
+
+
+@pytest.fixture
+def mgr(store):
+    return SchedulerManager(
+        store,
+        fire_message_callback=_noop_cb,
+        fire_new_task_callback=_noop_cb,
+        expire_notify_callback=_noop_cb,
+    )
+
+
+@pytest.fixture
+def fake_bot(mgr):
+    """A MagicMock standing in for :class:`ClaudedBot`.
+
+    Wired up with the bits the cog actually touches: scheduler, store,
+    project_manager (``is_bound``, ``get_path``, …), session_manager
+    (``get_session`` returns active-by-default bridge), and the
+    ``_register_scheduler_ctx`` callable that the cog invokes before
+    handing off to the renderer.
+    """
+    bot = MagicMock()
+    bot.scheduler = mgr
+    bot.scheduler.store = mgr.store  # alias for cog convenience
+    bot.scheduler_store = mgr.store
+    # project_manager: pretend channel 100 is bound to /tmp/proj
+    bot.project_manager.is_bound = MagicMock(return_value=True)
+    bot.project_manager.get_path = MagicMock(return_value="/tmp/proj")
+    bot.project_manager.get_system_prompt = MagicMock(return_value=None)
+    bot.project_manager.get_extra_dirs = MagicMock(return_value=None)
+    bot.project_manager.get_mcp_servers = MagicMock(return_value=None)
+    bot.project_manager.get_env = MagicMock(return_value=None)
+    # session_manager: live, active bridge
+    bridge = MagicMock()
+    bridge.is_active = True
+    bot.session_manager.get_session = MagicMock(return_value=bridge)
+    bot.session_manager.get_stored_session = MagicMock(return_value=None)
+    bot.session_manager.create_session = AsyncMock(return_value=bridge)
+    # context registration
+    bot._scheduler_current_ctx = {}
+
+    def _register(*, thread_id, channel_id, guild_id, tz_name="Asia/Shanghai"):
+        bot._scheduler_current_ctx = {
+            "thread_id": thread_id,
+            "channel_id": channel_id,
+            "guild_id": guild_id,
+            "tz_name": tz_name,
+        }
+    bot._register_scheduler_ctx = MagicMock(side_effect=_register)
+    return bot
+
+
+def _make_thread_interaction(bot, thread_id=42, parent_id=100, user_id=999,
+                             is_admin=False):
+    """Build an ``Interaction``-like mock anchored in a Thread."""
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = thread_id
+    thread.parent_id = parent_id
+    thread.guild = MagicMock()
+    thread.guild.id = 7
+    thread.mention = f"<#{thread_id}>"
+    thread.send = AsyncMock()
+
+    user = MagicMock()
+    user.id = user_id
+    user.name = f"user{user_id}"
+    # When testing admin override we set spec=discord.Member; otherwise
+    # leave plain so the ``isinstance(..., Member)`` short-circuit fails.
+    if is_admin:
+        member = MagicMock(spec=discord.Member)
+        member.id = user_id
+        member.name = f"admin{user_id}"
+        member.guild_permissions = MagicMock()
+        member.guild_permissions.manage_guild = True
+        user = member
+
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel = thread
+    interaction.user = user
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_channel_interaction(bot, channel_id=100, user_id=999):
+    """Build an Interaction anchored in a plain TextChannel (no thread)."""
+    ch = MagicMock(spec=discord.TextChannel)
+    ch.id = channel_id
+    ch.guild = MagicMock()
+    ch.guild.id = 7
+
+    user = MagicMock()
+    user.id = user_id
+    user.name = f"user{user_id}"
+
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel = ch
+    interaction.user = user
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+# ============================================================
+# /schedule message — reminder + ctx + render path
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_schedule_message_outside_thread_rejects(fake_bot):
+    """PRD: /schedule message requires thread context."""
+    interaction = _make_channel_interaction(fake_bot)
+    await schedule_message_cmd.callback(interaction, "remind me at 9")
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.await_args
+    assert "thread" in args[0].lower()
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_schedule_message_unbound_channel_rejects(fake_bot):
+    """When parent channel is unbound, refuse with an ephemeral message."""
+    fake_bot.project_manager.is_bound = MagicMock(return_value=False)
+    interaction = _make_thread_interaction(fake_bot)
+    await schedule_message_cmd.callback(interaction, "remind me at 9")
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.await_args
+    assert "bind" in args[0].lower() or "not bound" in args[0].lower()
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_schedule_message_happy_path_renders_reminder(fake_bot):
+    """Happy path: the cog invokes the renderer with the PRD §6.1 reminder
+    (system-reminder + user-text) and registers the per-turn ctx."""
+    interaction = _make_thread_interaction(fake_bot)
+    user_text = "明天 9 点提醒我开会"
+    # Patch the renderer at the module that USES it, not where it's defined.
+    with patch("clauded.cogs.schedule.DiscordRenderer") as RendererCls:
+        renderer_inst = MagicMock()
+        renderer_inst.render_response = AsyncMock()
+        RendererCls.return_value = renderer_inst
+        await schedule_message_cmd.callback(interaction, user_text)
+
+    # ack
+    interaction.response.send_message.assert_awaited_once()
+    # ctx
+    fake_bot._register_scheduler_ctx.assert_called_once_with(
+        thread_id=42, channel_id=100, guild_id=7,
+    )
+    # render
+    renderer_inst.render_response.assert_awaited_once()
+    rendered_text = renderer_inst.render_response.await_args.args[1]
+    assert "<system-reminder>" in rendered_text
+    assert "schedule_message" in rendered_text
+    assert f"<user-text>{user_text}</user-text>" in rendered_text
+
+
+# ============================================================
+# /schedule new_task — reminder + ctx + render
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_schedule_new_task_outside_thread_rejects(fake_bot):
+    interaction = _make_channel_interaction(fake_bot)
+    await schedule_new_task_cmd.callback(interaction, "weekly report")
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.await_args
+    assert "thread" in args[0].lower()
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_schedule_new_task_happy_renders_reminder(fake_bot):
+    interaction = _make_thread_interaction(fake_bot)
+    user_text = "每周一 9am 整理周报"
+    with patch("clauded.cogs.schedule.DiscordRenderer") as RendererCls:
+        renderer_inst = MagicMock()
+        renderer_inst.render_response = AsyncMock()
+        RendererCls.return_value = renderer_inst
+        await schedule_new_task_cmd.callback(interaction, user_text)
+    interaction.response.send_message.assert_awaited_once()
+    renderer_inst.render_response.assert_awaited_once()
+    rendered_text = renderer_inst.render_response.await_args.args[1]
+    assert "<system-reminder>" in rendered_text
+    assert "schedule_new_task" in rendered_text
+    assert f"<user-text>{user_text}</user-text>" in rendered_text
+
+
+# ============================================================
+# /schedule list — empty + populated + markers
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_schedule_list_empty(fake_bot):
+    """No schedules → ephemeral '(no schedules)' message."""
+    interaction = _make_thread_interaction(fake_bot)
+    await schedule_list_cmd.callback(interaction, "thread")
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.await_args
+    assert "(no schedules)" in args[0]
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_schedule_list_renders_markers(fake_bot):
+    """List emits embed with 📨 (message), 🧵 (new_task), 🤖/👤 markers."""
+    # Insert one of each kind / creator combination.
+    mgr = fake_bot.scheduler
+    mgr.create(
+        kind="message",
+        when=_future_iso(7200),
+        what="hi from claude",
+        target_thread_id=42,
+        name="claude-msg",
+        created_by="claude",
+        is_claude_created=True,
+        channel_id=100,
+        guild_id=7,
+        tz_name="UTC",
+    )
+    mgr.create(
+        kind="new_task",
+        when=_future_iso(7200),
+        what="hi from user",
+        target_channel_id=100,
+        name="user-task",
+        created_by="999",
+        channel_id=100,
+        guild_id=7,
+        tz_name="UTC",
+    )
+    interaction = _make_thread_interaction(fake_bot)
+    await schedule_list_cmd.callback(interaction, "all")
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    embed = kwargs.get("embed")
+    assert embed is not None
+    desc = embed.description
+    assert "📨" in desc        # kind=message marker
+    assert "🧵" in desc        # kind=new_task marker
+    assert "🤖" in desc        # claude creator marker
+    assert "👤" in desc        # user creator marker
+
+
+# ============================================================
+# /schedule delete — permission matrix
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_schedule_delete_ambiguous_prefix(fake_bot):
+    """Two ids share the same first 4 chars → cog refuses delete."""
+    mgr = fake_bot.scheduler
+    # Manually seed two schedules whose ids share a prefix.
+    base = {
+        "kind": "message",
+        "name": "x",
+        "created_by": "999",
+        "channel_id": 100,
+        "guild_id": 7,
+        "target_thread_id": 42,
+        "trigger": {
+            "kind": "once", "iso": _future_iso(3600).split(": ", 1)[1],
+            "cron": None, "tz_when_created": "UTC", "recurring": False,
+        },
+        "payload": {"what": "x"},
+        "max_lifetime_seconds": None,
+        "state": {
+            "enabled": True,
+            "next_fire_at": _future_iso(3600).split(": ", 1)[1],
+            "first_fired_at": None, "last_fired_at": None,
+            "last_error": None, "fire_count": 0, "missed_count": 0,
+        },
+    }
+    s1 = dict(base, schedule_id="abcd0000aaaa1111")
+    s2 = dict(base, schedule_id="abcd0000bbbb2222")
+    mgr.store.add(s1)
+    mgr.store.add(s2)
+
+    interaction = _make_thread_interaction(fake_bot, user_id=999)
+    await schedule_delete_cmd.callback(interaction, "abcd")
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.await_args
+    assert "Ambiguous" in args[0]
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_schedule_delete_non_creator_non_admin_denied(fake_bot):
+    """A non-creator without admin can't delete a schedule (PRD §4.4)."""
+    mgr = fake_bot.scheduler
+    s = mgr.create(
+        kind="message",
+        when=_future_iso(3600),
+        what="hi",
+        target_thread_id=42,
+        created_by="111",     # someone else
+        channel_id=100,
+        guild_id=7,
+        tz_name="UTC",
+    )
+    interaction = _make_thread_interaction(fake_bot, user_id=999)
+    await schedule_delete_cmd.callback(interaction, s["schedule_id"])
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.await_args
+    assert "permission denied" in args[0]
+    assert kwargs.get("ephemeral") is True
+    # Schedule should still exist.
+    assert mgr.store.get(s["schedule_id"]) is not None
+
+
+@pytest.mark.asyncio
+async def test_schedule_delete_by_creator_succeeds(fake_bot):
+    mgr = fake_bot.scheduler
+    s = mgr.create(
+        kind="message",
+        when=_future_iso(3600),
+        what="hi",
+        target_thread_id=42,
+        created_by="999",
+        channel_id=100,
+        guild_id=7,
+        tz_name="UTC",
+    )
+    interaction = _make_thread_interaction(fake_bot, user_id=999)
+    await schedule_delete_cmd.callback(interaction, s["schedule_id"])
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.await_args
+    assert "Deleted" in args[0]
+    assert mgr.store.get(s["schedule_id"]) is None
+
+
+# ============================================================
+# /schedule toggle — admin override
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_schedule_toggle_admin_can_disable_others(fake_bot):
+    mgr = fake_bot.scheduler
+    s = mgr.create(
+        kind="message",
+        when=_future_iso(3600),
+        what="hi",
+        target_thread_id=42,
+        created_by="111",   # someone else
+        channel_id=100,
+        guild_id=7,
+        tz_name="UTC",
+    )
+    # interaction.user is a Member with manage_guild=True
+    interaction = _make_thread_interaction(
+        fake_bot, user_id=999, is_admin=True,
+    )
+    await schedule_toggle_cmd.callback(interaction, s["schedule_id"], False)
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.await_args
+    assert "enabled=False" in args[0]
+    assert mgr.store.get(s["schedule_id"])["state"]["enabled"] is False
+
+
+# ============================================================
+# Sanity: the slash group exposes exactly 5 subcommands
+# ============================================================
+
+
+def test_schedule_group_has_five_subcommands():
+    """Spec: 5 subcommands (message, new_task, list, delete, toggle)."""
+    names = sorted(c.name for c in schedule_group.commands)
+    assert names == ["delete", "list", "message", "new_task", "toggle"]
+
+
+# ============================================================
+# Bot wiring: ctx provider + bridge MCP merge
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_bot_ctx_provider_round_trip(tmp_path, monkeypatch):
+    """``_register_scheduler_ctx`` + ``_scheduler_ctx_provider`` round-trip."""
+    monkeypatch.chdir(tmp_path)
+    from clauded.bot import ClaudedBot
+    from clauded.config import Config
+    cfg = Config(
+        discord_bot_token="x",
+        claude_model=None,
+        claude_permission_mode="default",
+        projects_root=str(tmp_path),
+        allow_unbound_fallback=False,
+    )
+    bot = ClaudedBot(cfg)
+    assert bot._scheduler_ctx_provider() == {}
+    bot._register_scheduler_ctx(thread_id=42, channel_id=100, guild_id=7)
+    ctx = bot._scheduler_ctx_provider()
+    assert ctx == {
+        "thread_id": 42,
+        "channel_id": 100,
+        "guild_id": 7,
+        "tz_name": "Asia/Shanghai",
+    }
+    # Re-register with explicit tz override
+    bot._register_scheduler_ctx(
+        thread_id=1, channel_id=2, guild_id=3, tz_name="UTC",
+    )
+    assert bot._scheduler_ctx_provider()["tz_name"] == "UTC"
+
+
+def test_claude_bridge_build_mcp_servers_merges_scheduler():
+    """``_build_mcp_servers`` always includes the ``clauded-scheduler`` key."""
+    from clauded.claude_bridge import ClaudeBridge
+    from clauded.config import Config
+    from clauded.session_config import SessionConfig
+
+    cfg = Config(
+        discord_bot_token="x",
+        claude_model=None,
+        claude_permission_mode="default",
+        projects_root="/tmp",
+        allow_unbound_fallback=False,
+    )
+    # Pre-populate a user-configured mcp dict so we can assert the merge
+    # preserves both keys.
+    sc = SessionConfig(mcp_servers={"user-mcp": {"command": "true"}})
+    bridge = ClaudeBridge("/tmp", cfg, sc)
+    merged = bridge._build_mcp_servers()
+    assert "clauded-scheduler" in merged
+    assert "user-mcp" in merged
+    # Order: scheduler shouldn't overwrite user-mcp.
+    assert merged["user-mcp"] == {"command": "true"}
+
+
+def test_claude_bridge_build_mcp_servers_with_none():
+    """``_mcp_servers=None`` still produces a dict with the scheduler key."""
+    from clauded.claude_bridge import ClaudeBridge
+    from clauded.config import Config
+    from clauded.session_config import SessionConfig
+
+    cfg = Config(
+        discord_bot_token="x",
+        claude_model=None,
+        claude_permission_mode="default",
+        projects_root="/tmp",
+        allow_unbound_fallback=False,
+    )
+    sc = SessionConfig(mcp_servers=None)
+    bridge = ClaudeBridge("/tmp", cfg, sc)
+    merged = bridge._build_mcp_servers()
+    assert list(merged.keys()) == ["clauded-scheduler"]
+
+
+# ============================================================
+# Helper: prefix resolution
+# ============================================================
+
+
+def test_resolve_full_schedule_id_unknown(fake_bot):
+    full, err = _resolve_full_schedule_id(fake_bot, "deadbeef")
+    assert full is None
+    assert "Unknown" in err

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,6 +1,6 @@
-"""Unit tests for the v1.18 scheduler core (issue #241, Subtask 1).
+"""Unit tests for the v1.18 scheduler core (issue #241, Subtasks 1 + 2).
 
-Covers, per ``/tmp/subtask-1-prompt-v2.md`` test plan:
+Covers, per ``/tmp/subtask-1-prompt-v2.md`` and ``/tmp/subtask-2-prompt-v3.md``:
 
 1. ``parse_iso_utc``                (4 tests)
 2. ``parse_cron_to_next``           (5 tests)
@@ -12,17 +12,25 @@ Covers, per ``/tmp/subtask-1-prompt-v2.md`` test plan:
 8. ``SchedulerManager.create`` caps + max_lifetime (4 tests)
 9. ``SchedulerManager.delete``      (4 tests)
 10. ``SchedulerManager.toggle``     (2 tests)
+11. ``SchedulerManager.tick``       (5 tests)  ─┐
+12. ``SchedulerManager.catch_up``   (2 tests)   │ Subtask 2 — fire executor
+13. ``SchedulerManager._fire_one``  (8 tests)   │
+14. ``_check_max_lifetime``         (2 tests)  ─┘
 """
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
+import discord
 import pytest
 
 from clauded.scheduler import (
     MAX_GLOBAL_ACTIVE,
+    MAX_GLOBAL_INFLIGHT,
     MAX_USER_ACTIVE,
     SchedulerManager,
     compute_next_fire,
@@ -642,3 +650,634 @@ class TestToggle:
             sid, False, requester="admin-user", is_admin=True
         )
         assert ok is True
+
+
+# =============================================================== Group 11+
+# Subtask 2 — fire executor + tick + catch_up + max_lifetime
+#
+# All these tests construct fully-shaped schedule dicts directly (rather
+# than going through ``mgr.create``) so they can pin ``next_fire_at`` /
+# ``first_fired_at`` to arbitrary past timestamps without fighting the
+# "future iso" guard in ``create``.
+
+
+def _due_sched_dict(
+    *,
+    schedule_id: str,
+    kind: str = "message",
+    target_thread_id: int | None = None,
+    target_channel_id: int | None = None,
+    next_fire_at: str | None = None,
+    enabled: bool = True,
+    recurring: bool = False,
+    cron: str | None = None,
+    iso: str | None = None,
+    created_by: str = "u1",
+    first_fired_at: str | None = None,
+    max_lifetime_seconds: int | None = None,
+) -> dict:
+    """Build a persisted-shape sched dict for Subtask-2 tests.
+
+    Direct construction bypasses ``mgr.create``'s future-only iso check
+    so tests can pin ``next_fire_at`` to the past for tick/catch_up.
+    """
+    trigger_kind = "cron" if cron else "once"
+    return {
+        "schedule_id": schedule_id,
+        "kind": kind,
+        "name": schedule_id[:8],
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "created_by": created_by,
+        "guild_id": 1,
+        "channel_id": 100,
+        "target_thread_id": (
+            target_thread_id if kind == "message" else None
+        ),
+        "target_channel_id": (
+            target_channel_id if kind == "new_task" else None
+        ),
+        "thread_name": "t" if kind == "new_task" else None,
+        "trigger": {
+            "kind": trigger_kind,
+            "iso": iso,
+            "cron": cron,
+            "tz_when_created": "UTC",
+            "recurring": recurring,
+        },
+        "payload": {"what": "ping"},
+        "max_lifetime_seconds": max_lifetime_seconds,
+        "state": {
+            "enabled": enabled,
+            "next_fire_at": next_fire_at,
+            "first_fired_at": first_fired_at,
+            "last_fired_at": None,
+            "last_error": None,
+            "fire_count": 0,
+            "missed_count": 0,
+        },
+    }
+
+
+def _build_mgr(
+    store: SchedulerStore,
+    *,
+    fire_message=None,
+    fire_new_task=None,
+    expire_notify=None,
+    get_lock=None,
+) -> SchedulerManager:
+    """Build a manager with optional per-test callbacks (default: noop)."""
+    return SchedulerManager(
+        store,
+        fire_message_callback=fire_message or _noop_cb,
+        fire_new_task_callback=fire_new_task or _noop_cb,
+        expire_notify_callback=expire_notify or _noop_cb,
+        get_lock=get_lock,
+    )
+
+
+def _make_notfound() -> discord.NotFound:
+    return discord.NotFound(MagicMock(status=404, reason="Not Found"), "x")
+
+
+def _make_forbidden() -> discord.Forbidden:
+    return discord.Forbidden(MagicMock(status=403, reason="Forbidden"), "x")
+
+
+# =============================================================== Group 11
+# SchedulerManager.tick
+
+
+class TestTick:
+    @pytest.mark.asyncio
+    async def test_tick_fires_due(self, store):
+        calls = []
+
+        async def cb(sched):
+            calls.append(sched["schedule_id"])
+
+        mgr = _build_mgr(store, fire_message=cb)
+        past = (
+            datetime.now(timezone.utc) - timedelta(seconds=10)
+        ).isoformat()
+        store.add(
+            _due_sched_dict(
+                schedule_id="due0001",
+                target_thread_id=1001,
+                next_fire_at=past,
+            )
+        )
+
+        await mgr.tick()
+        await asyncio.sleep(0.1)
+        assert calls == ["due0001"]
+
+    @pytest.mark.asyncio
+    async def test_tick_skips_future(self, store):
+        calls = []
+
+        async def cb(sched):
+            calls.append(sched["schedule_id"])
+
+        mgr = _build_mgr(store, fire_message=cb)
+        future = (
+            datetime.now(timezone.utc) + timedelta(hours=1)
+        ).isoformat()
+        store.add(
+            _due_sched_dict(
+                schedule_id="fut00001",
+                target_thread_id=1002,
+                next_fire_at=future,
+            )
+        )
+
+        await mgr.tick()
+        await asyncio.sleep(0.1)
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_tick_skips_disabled(self, store):
+        calls = []
+
+        async def cb(sched):
+            calls.append(sched["schedule_id"])
+
+        mgr = _build_mgr(store, fire_message=cb)
+        past = (
+            datetime.now(timezone.utc) - timedelta(seconds=10)
+        ).isoformat()
+        store.add(
+            _due_sched_dict(
+                schedule_id="off00001",
+                target_thread_id=1003,
+                next_fire_at=past,
+                enabled=False,
+            )
+        )
+
+        await mgr.tick()
+        await asyncio.sleep(0.1)
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_tick_dispatches_kind_message(self, store):
+        msg_calls = []
+        new_calls = []
+
+        async def msg_cb(sched):
+            msg_calls.append(sched["schedule_id"])
+
+        async def new_cb(sched):
+            new_calls.append(sched["schedule_id"])
+
+        mgr = _build_mgr(store, fire_message=msg_cb, fire_new_task=new_cb)
+        past = (
+            datetime.now(timezone.utc) - timedelta(seconds=10)
+        ).isoformat()
+        store.add(
+            _due_sched_dict(
+                schedule_id="kind_msg",
+                kind="message",
+                target_thread_id=1010,
+                next_fire_at=past,
+            )
+        )
+
+        await mgr.tick()
+        await asyncio.sleep(0.1)
+        assert msg_calls == ["kind_msg"]
+        assert new_calls == []
+
+    @pytest.mark.asyncio
+    async def test_tick_dispatches_kind_new_task(self, store):
+        msg_calls = []
+        new_calls = []
+
+        async def msg_cb(sched):
+            msg_calls.append(sched["schedule_id"])
+
+        async def new_cb(sched):
+            new_calls.append(sched["schedule_id"])
+
+        mgr = _build_mgr(store, fire_message=msg_cb, fire_new_task=new_cb)
+        past = (
+            datetime.now(timezone.utc) - timedelta(seconds=10)
+        ).isoformat()
+        store.add(
+            _due_sched_dict(
+                schedule_id="kind_new",
+                kind="new_task",
+                target_channel_id=2020,
+                next_fire_at=past,
+            )
+        )
+
+        await mgr.tick()
+        await asyncio.sleep(0.1)
+        assert new_calls == ["kind_new"]
+        assert msg_calls == []
+
+
+# =============================================================== Group 12
+# SchedulerManager.catch_up
+
+
+class TestCatchUp:
+    @pytest.mark.asyncio
+    async def test_catch_up_within_grace_fires(self, store):
+        calls = []
+
+        async def cb(sched):
+            calls.append(sched["schedule_id"])
+
+        mgr = _build_mgr(store, fire_message=cb)
+        # 30s late, well inside the 300s grace window
+        past = (
+            datetime.now(timezone.utc) - timedelta(seconds=30)
+        ).isoformat()
+        store.add(
+            _due_sched_dict(
+                schedule_id="grace001",
+                target_thread_id=3001,
+                next_fire_at=past,
+            )
+        )
+
+        await mgr.catch_up()
+        await asyncio.sleep(0.1)
+        assert calls == ["grace001"]
+
+    @pytest.mark.asyncio
+    async def test_catch_up_past_grace_marks_missed(self, store):
+        calls = []
+
+        async def cb(sched):
+            calls.append(sched["schedule_id"])
+
+        mgr = _build_mgr(store, fire_message=cb)
+        # 600s late on a daily cron — too stale to fire.
+        far_past = (
+            datetime.now(timezone.utc) - timedelta(seconds=600)
+        ).isoformat()
+        store.add(
+            _due_sched_dict(
+                schedule_id="miss0001",
+                target_thread_id=3002,
+                next_fire_at=far_past,
+                recurring=True,
+                cron="0 9 * * *",
+            )
+        )
+
+        await mgr.catch_up()
+        await asyncio.sleep(0.1)
+
+        assert calls == []  # NOT fired
+        persisted = store.get("miss0001")
+        assert persisted["state"]["missed_count"] == 1
+        new_next_str = persisted["state"]["next_fire_at"]
+        assert new_next_str is not None
+        new_next = datetime.fromisoformat(new_next_str)
+        # Rolled forward to a future fire time.
+        assert new_next > datetime.now(timezone.utc)
+
+
+# =============================================================== Group 13
+# SchedulerManager._fire_one (direct invocation)
+
+
+class TestFireOne:
+    @pytest.mark.asyncio
+    async def test_fire_one_success_oneshot_disables(self, store):
+        async def cb(_sched):
+            return None
+
+        mgr = _build_mgr(store, fire_message=cb)
+        sched = _due_sched_dict(
+            schedule_id="one0one1",
+            target_thread_id=4001,
+            recurring=False,
+            iso=(
+                datetime.now(timezone.utc) - timedelta(seconds=10)
+            ).isoformat(),
+            next_fire_at=(
+                datetime.now(timezone.utc) - timedelta(seconds=10)
+            ).isoformat(),
+        )
+        store.add(sched)
+
+        await mgr._fire_one(sched)
+
+        persisted = store.get("one0one1")
+        assert persisted["state"]["enabled"] is False
+        assert persisted["state"]["fire_count"] == 1
+        assert persisted["state"]["last_fired_at"] is not None
+        assert persisted["state"]["first_fired_at"] is not None
+        assert persisted["state"]["next_fire_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_fire_one_success_cron_recomputes(self, store):
+        async def cb(_sched):
+            return None
+
+        mgr = _build_mgr(store, fire_message=cb)
+        sched = _due_sched_dict(
+            schedule_id="cronfire",
+            target_thread_id=4002,
+            recurring=True,
+            cron="0 9 * * *",
+            next_fire_at=(
+                datetime.now(timezone.utc) - timedelta(seconds=10)
+            ).isoformat(),
+        )
+        store.add(sched)
+
+        await mgr._fire_one(sched)
+
+        persisted = store.get("cronfire")
+        assert persisted["state"]["enabled"] is True
+        assert persisted["state"]["fire_count"] == 1
+        new_next = datetime.fromisoformat(
+            persisted["state"]["next_fire_at"]
+        )
+        assert new_next > datetime.now(timezone.utc)
+
+    @pytest.mark.asyncio
+    async def test_fire_one_notfound_disables(self, store):
+        expire_calls = []
+
+        async def cb(_sched):
+            raise _make_notfound()
+
+        async def expire(sched):
+            expire_calls.append(sched["schedule_id"])
+
+        mgr = _build_mgr(
+            store,
+            fire_message=cb,
+            expire_notify=expire,
+        )
+        sched = _due_sched_dict(
+            schedule_id="gone0001",
+            target_thread_id=4003,
+            next_fire_at=(
+                datetime.now(timezone.utc) - timedelta(seconds=10)
+            ).isoformat(),
+        )
+        store.add(sched)
+
+        await mgr._fire_one(sched)
+        await asyncio.sleep(0)  # let any spawned tasks settle
+
+        persisted = store.get("gone0001")
+        assert persisted["state"]["enabled"] is False
+        assert "NotFound" in (persisted["state"]["last_error"] or "")
+        assert expire_calls == []  # terminal != lifetime
+
+    @pytest.mark.asyncio
+    async def test_fire_one_forbidden_disables(self, store):
+        async def cb(_sched):
+            raise _make_forbidden()
+
+        mgr = _build_mgr(store, fire_message=cb)
+        sched = _due_sched_dict(
+            schedule_id="forbid01",
+            target_thread_id=4004,
+            next_fire_at=(
+                datetime.now(timezone.utc) - timedelta(seconds=10)
+            ).isoformat(),
+        )
+        store.add(sched)
+
+        await mgr._fire_one(sched)
+
+        persisted = store.get("forbid01")
+        assert persisted["state"]["enabled"] is False
+        assert "Forbidden" in (persisted["state"]["last_error"] or "")
+
+    @pytest.mark.asyncio
+    async def test_fire_one_transient_retries_three_times(
+        self, store, monkeypatch
+    ):
+        # Don't actually wait 1+4+16 seconds during backoff.
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr(asyncio, "sleep", sleep_mock)
+
+        call_count = {"n": 0}
+
+        async def cb(_sched):
+            call_count["n"] += 1
+            raise RuntimeError("boom")
+
+        mgr = _build_mgr(store, fire_message=cb)
+        sched = _due_sched_dict(
+            schedule_id="tx3retry",
+            target_thread_id=4005,
+            next_fire_at=(
+                datetime.now(timezone.utc) - timedelta(seconds=10)
+            ).isoformat(),
+        )
+        store.add(sched)
+
+        await mgr._fire_one(sched)
+
+        assert call_count["n"] == 3
+        persisted = store.get("tx3retry")
+        assert persisted["state"]["enabled"] is False
+        assert "boom" in (persisted["state"]["last_error"] or "")
+        # backoff sleeps were attempted between attempts 1→2 and 2→3
+        # (no sleep before terminal disable after attempt 3).
+        sleep_calls = [c.args for c in sleep_mock.await_args_list]
+        # Only assert that at least the two scheduler backoff sleeps fired.
+        assert (1,) in sleep_calls
+        assert (4,) in sleep_calls
+
+    @pytest.mark.asyncio
+    async def test_fire_one_transient_recovers_on_attempt_2(
+        self, store, monkeypatch
+    ):
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+        call_count = {"n": 0}
+
+        async def cb(_sched):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("transient")
+
+        mgr = _build_mgr(store, fire_message=cb)
+        sched = _due_sched_dict(
+            schedule_id="recover2",
+            target_thread_id=4006,
+            recurring=True,
+            cron="0 9 * * *",
+            next_fire_at=(
+                datetime.now(timezone.utc) - timedelta(seconds=10)
+            ).isoformat(),
+        )
+        store.add(sched)
+
+        await mgr._fire_one(sched)
+
+        assert call_count["n"] == 2
+        persisted = store.get("recover2")
+        assert persisted["state"]["fire_count"] == 1
+        assert persisted["state"]["enabled"] is True
+        assert persisted["state"]["last_error"] is None
+
+    @pytest.mark.asyncio
+    async def test_fire_one_acquires_lock(self, store):
+        events: list[str] = []
+
+        class TrackingLock:
+            def __init__(self):
+                self._lock = asyncio.Lock()
+
+            async def __aenter__(self):
+                await self._lock.__aenter__()
+                events.append("lock_acquired")
+                return self
+
+            async def __aexit__(self, *args):
+                events.append("lock_released")
+                return await self._lock.__aexit__(*args)
+
+        tracking = TrackingLock()
+
+        def get_lock(_lock_id: int):
+            return tracking
+
+        async def cb(_sched):
+            events.append("fire_invoked")
+
+        mgr = _build_mgr(store, fire_message=cb, get_lock=get_lock)
+        sched = _due_sched_dict(
+            schedule_id="lockord1",
+            target_thread_id=4007,
+            next_fire_at=(
+                datetime.now(timezone.utc) - timedelta(seconds=10)
+            ).isoformat(),
+        )
+        store.add(sched)
+
+        await mgr._fire_one(sched)
+
+        assert events == [
+            "lock_acquired",
+            "fire_invoked",
+            "lock_released",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_max_global_inflight_cap(self, store):
+        counter = {"current": 0, "peak": 0}
+
+        async def cb(_sched):
+            counter["current"] += 1
+            if counter["current"] > counter["peak"]:
+                counter["peak"] = counter["current"]
+            await asyncio.sleep(0.05)
+            counter["current"] -= 1
+
+        mgr = _build_mgr(store, fire_message=cb)
+
+        past = (
+            datetime.now(timezone.utc) - timedelta(seconds=10)
+        ).isoformat()
+        n_sched = 15  # > MAX_GLOBAL_INFLIGHT (10)
+        for i in range(n_sched):
+            store.add(
+                _due_sched_dict(
+                    schedule_id=f"capN{i:04d}",
+                    # Distinct target_thread_id per schedule so the
+                    # per-target lock doesn't serialize them.
+                    target_thread_id=5000 + i,
+                    next_fire_at=past,
+                )
+            )
+
+        await mgr.tick()
+        # 15 schedules × 0.05s wait / 10 inflight = ~0.1s; sleep longer
+        # to be safe so all tasks finish before the test exits.
+        await asyncio.sleep(0.5)
+
+        assert counter["peak"] <= MAX_GLOBAL_INFLIGHT
+        assert counter["peak"] > 1  # Some concurrency really happened.
+
+
+# =============================================================== Group 14
+# _check_max_lifetime
+
+
+class TestMaxLifetime:
+    @pytest.mark.asyncio
+    async def test_max_lifetime_expires(self, store):
+        expire_calls = []
+
+        async def cb(_sched):
+            return None
+
+        async def expire(sched):
+            expire_calls.append(sched["schedule_id"])
+
+        mgr = _build_mgr(store, fire_message=cb, expire_notify=expire)
+        # first_fired_at 5s in the past + max_lifetime 2s → expired.
+        first_fired = (
+            datetime.now(timezone.utc) - timedelta(seconds=5)
+        ).isoformat()
+        sched = _due_sched_dict(
+            schedule_id="lifeOver",
+            target_thread_id=6001,
+            recurring=True,
+            cron="0 9 * * *",
+            next_fire_at=(
+                datetime.now(timezone.utc) - timedelta(seconds=10)
+            ).isoformat(),
+            first_fired_at=first_fired,
+            max_lifetime_seconds=2,
+        )
+        store.add(sched)
+
+        await mgr._fire_one(sched)
+        # Give the spawned expire-notify task a chance to run.
+        await asyncio.sleep(0.05)
+
+        persisted = store.get("lifeOver")
+        assert persisted["state"]["enabled"] is False
+        assert persisted["state"]["last_error"] == "max_lifetime reached"
+        assert expire_calls == ["lifeOver"]
+
+    @pytest.mark.asyncio
+    async def test_max_lifetime_not_yet_reached(self, store):
+        expire_calls = []
+
+        async def cb(_sched):
+            return None
+
+        async def expire(sched):
+            expire_calls.append(sched["schedule_id"])
+
+        mgr = _build_mgr(store, fire_message=cb, expire_notify=expire)
+        # first_fired_at is now → 0s elapsed, well below 3600s cap.
+        first_fired = datetime.now(timezone.utc).isoformat()
+        sched = _due_sched_dict(
+            schedule_id="lifeOK01",
+            target_thread_id=6002,
+            recurring=True,
+            cron="0 9 * * *",
+            next_fire_at=(
+                datetime.now(timezone.utc) - timedelta(seconds=10)
+            ).isoformat(),
+            first_fired_at=first_fired,
+            max_lifetime_seconds=3600,
+        )
+        store.add(sched)
+
+        await mgr._fire_one(sched)
+        await asyncio.sleep(0.05)
+
+        persisted = store.get("lifeOK01")
+        # cron + within lifetime → still enabled, no expire callback.
+        assert persisted["state"]["enabled"] is True
+        assert persisted["state"]["last_error"] is None
+        assert expire_calls == []

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,644 @@
+"""Unit tests for the v1.18 scheduler core (issue #241, Subtask 1).
+
+Covers, per ``/tmp/subtask-1-prompt-v2.md`` test plan:
+
+1. ``parse_iso_utc``                (4 tests)
+2. ``parse_cron_to_next``           (5 tests)
+3. ``parse_duration``               (8 tests)
+4. ``compute_next_fire``            (3 tests)
+5. ``SchedulerStore``               (7 tests)
+6. ``SchedulerManager.create`` kind=message (8 tests)
+7. ``SchedulerManager.create`` kind=new_task (3 tests)
+8. ``SchedulerManager.create`` caps + max_lifetime (4 tests)
+9. ``SchedulerManager.delete``      (4 tests)
+10. ``SchedulerManager.toggle``     (2 tests)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from clauded.scheduler import (
+    MAX_GLOBAL_ACTIVE,
+    MAX_USER_ACTIVE,
+    SchedulerManager,
+    compute_next_fire,
+    parse_cron_to_next,
+    parse_duration,
+    parse_iso_utc,
+)
+from clauded.scheduler_store import SchedulerStore
+
+
+# ---------------------------------------------------------------- Fixtures
+
+
+@pytest.fixture
+def tmp_store_dir(tmp_path):
+    """Fresh, isolated data dir per test."""
+    d = tmp_path / "data"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def store(tmp_store_dir):
+    return SchedulerStore(data_dir=str(tmp_store_dir))
+
+
+async def _noop_cb(_sched):
+    return None
+
+
+@pytest.fixture
+def mgr(store):
+    return SchedulerManager(
+        store,
+        fire_message_callback=_noop_cb,
+        fire_new_task_callback=_noop_cb,
+        expire_notify_callback=_noop_cb,
+    )
+
+
+def _future_iso(seconds_ahead: int = 3600) -> str:
+    dt = datetime.now(timezone.utc) + timedelta(seconds=seconds_ahead)
+    return "iso: " + dt.isoformat()
+
+
+# =============================================================== Group 1
+# parse_iso_utc
+
+
+class TestParseIsoUtc:
+    def test_tz_aware_happy(self):
+        dt = parse_iso_utc("2026-05-19T09:00:00+08:00")
+        assert dt.tzinfo is not None
+        # 09:00 +08:00 = 01:00 UTC
+        assert dt.utcoffset() == timedelta(0)
+        assert dt.hour == 1
+
+    def test_iso_prefix_stripped(self):
+        dt = parse_iso_utc("iso: 2026-05-19T09:00:00+00:00")
+        assert dt.year == 2026 and dt.month == 5 and dt.day == 19
+        assert dt.hour == 9 and dt.tzinfo is not None
+
+    def test_naive_rejected(self):
+        with pytest.raises(ValueError, match="timezone"):
+            parse_iso_utc("2026-05-19T09:00:00")
+
+    def test_garbage_rejected(self):
+        with pytest.raises(ValueError):
+            parse_iso_utc("not a date at all")
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValueError):
+            parse_iso_utc("iso:")
+
+
+# =============================================================== Group 2
+# parse_cron_to_next
+
+
+class TestParseCronToNext:
+    def test_happy_utc(self):
+        base = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        nxt = parse_cron_to_next("0 9 * * *", "UTC", base=base)
+        assert nxt > base
+        assert nxt.hour == 9 and nxt.minute == 0
+
+    def test_non_utc_timezone(self):
+        # Asia/Shanghai is UTC+8; cron "0 9 * * *" daily 09:00 local
+        # → 01:00 UTC.
+        base = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        nxt = parse_cron_to_next("0 9 * * *", "Asia/Shanghai", base=base)
+        assert nxt.tzinfo is not None
+        assert nxt.utcoffset() == timedelta(0)
+        assert nxt.hour == 1 and nxt.minute == 0
+
+    def test_cron_prefix_stripped(self):
+        base = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        nxt = parse_cron_to_next("cron: 0 9 * * *", "UTC", base=base)
+        assert nxt.hour == 9
+
+    def test_bad_timezone_raises(self):
+        with pytest.raises(ValueError, match="timezone"):
+            parse_cron_to_next("0 9 * * *", "Mars/Olympus_Mons")
+
+    def test_bad_cron_raises(self):
+        with pytest.raises(ValueError):
+            parse_cron_to_next("not a cron expression", "UTC")
+
+
+# =============================================================== Group 3
+# parse_duration
+
+
+class TestParseDuration:
+    def test_30d(self):
+        assert parse_duration("30d") == 30 * 86_400
+
+    def test_7d(self):
+        assert parse_duration("7d") == 7 * 86_400
+
+    def test_24h(self):
+        assert parse_duration("24h") == 24 * 3600
+
+    def test_3600s(self):
+        assert parse_duration("3600s") == 3600
+
+    def test_1w(self):
+        assert parse_duration("1w") == 7 * 86_400
+
+    def test_400d_over_cap(self):
+        with pytest.raises(ValueError, match="365d"):
+            parse_duration("400d")
+
+    def test_bad_format(self):
+        with pytest.raises(ValueError):
+            parse_duration("abc")
+
+    def test_bad_suffix(self):
+        with pytest.raises(ValueError):
+            parse_duration("5z")
+
+
+# =============================================================== Group 4
+# compute_next_fire
+
+
+class TestComputeNextFire:
+    def test_once_future(self):
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        trigger = {"kind": "once", "iso": future.isoformat()}
+        nxt = compute_next_fire(trigger)
+        assert nxt is not None
+        # Allow microsecond drift via approximate comparison.
+        assert abs((nxt - future).total_seconds()) < 1
+
+    def test_once_past_returns_none(self):
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        trigger = {"kind": "once", "iso": past.isoformat()}
+        assert compute_next_fire(trigger) is None
+
+    def test_cron_rolls_forward(self):
+        base = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+        trigger = {
+            "kind": "cron",
+            "cron": "0 9 * * *",
+            "tz_when_created": "UTC",
+        }
+        nxt = compute_next_fire(trigger, after=base)
+        assert nxt is not None
+        assert nxt > base
+        # 09:00 UTC tomorrow.
+        assert nxt.day == 2 and nxt.hour == 9
+
+
+# =============================================================== Group 5
+# SchedulerStore
+
+
+class TestSchedulerStore:
+    def test_empty_load(self, tmp_store_dir):
+        s = SchedulerStore(data_dir=str(tmp_store_dir))
+        assert s.list_all() == {}
+
+    def test_add_get_delete_roundtrip(self, store):
+        sched = {
+            "schedule_id": "abc123",
+            "kind": "message",
+            "created_by": "u1",
+            "state": {"enabled": True},
+        }
+        sid = store.add(sched)
+        assert sid == "abc123"
+        assert store.get("abc123") == sched
+        assert store.delete("abc123") is True
+        assert store.get("abc123") is None
+        assert store.delete("abc123") is False
+
+    def test_list_for_thread(self, store):
+        store.add({
+            "schedule_id": "m1",
+            "kind": "message",
+            "target_thread_id": 111,
+            "created_by": "u",
+            "state": {"enabled": True},
+        })
+        store.add({
+            "schedule_id": "m2",
+            "kind": "message",
+            "target_thread_id": 222,
+            "created_by": "u",
+            "state": {"enabled": True},
+        })
+        store.add({
+            "schedule_id": "n1",
+            "kind": "new_task",
+            "target_channel_id": 111,  # same id, different kind → excluded
+            "created_by": "u",
+            "state": {"enabled": True},
+        })
+        out = store.list_for_thread(111)
+        assert [s["schedule_id"] for s in out] == ["m1"]
+
+    def test_list_for_channel(self, store):
+        store.add({
+            "schedule_id": "a",
+            "kind": "message",
+            "channel_id": 500,
+            "created_by": "u",
+            "state": {"enabled": True},
+        })
+        store.add({
+            "schedule_id": "b",
+            "kind": "new_task",
+            "channel_id": 999,
+            "target_channel_id": 500,
+            "created_by": "u",
+            "state": {"enabled": True},
+        })
+        store.add({
+            "schedule_id": "c",
+            "kind": "message",
+            "channel_id": 999,
+            "created_by": "u",
+            "state": {"enabled": True},
+        })
+        out = store.list_for_channel(500)
+        assert sorted(s["schedule_id"] for s in out) == ["a", "b"]
+
+    def test_count_active(self, store):
+        for i in range(3):
+            store.add({
+                "schedule_id": f"u{i}",
+                "created_by": "alice",
+                "state": {"enabled": True},
+            })
+        store.add({
+            "schedule_id": "d1",
+            "created_by": "alice",
+            "state": {"enabled": False},
+        })
+        store.add({
+            "schedule_id": "b1",
+            "created_by": "bob",
+            "state": {"enabled": True},
+        })
+        assert store.count_active_for_user("alice") == 3
+        assert store.count_active_for_user("bob") == 1
+        assert store.count_active_total() == 4
+
+    def test_corrupt_json_fallback(self, tmp_store_dir, caplog):
+        path = Path(tmp_store_dir) / "schedules.json"
+        path.write_text("{{this is not valid json")
+        with caplog.at_level("WARNING"):
+            s = SchedulerStore(data_dir=str(tmp_store_dir))
+        assert s.list_all() == {}
+        # WARNING was emitted (don't raise).
+        assert any("schedules.json" in r.message for r in caplog.records)
+
+    def test_reload_preserves_state(self, tmp_store_dir):
+        s1 = SchedulerStore(data_dir=str(tmp_store_dir))
+        s1.add({
+            "schedule_id": "keep",
+            "kind": "message",
+            "created_by": "u",
+            "state": {"enabled": True, "fire_count": 5},
+        })
+        # Fresh instance pointing at the same dir reads from disk.
+        s2 = SchedulerStore(data_dir=str(tmp_store_dir))
+        got = s2.get("keep")
+        assert got is not None
+        assert got["state"]["fire_count"] == 5
+
+
+# =============================================================== Group 6
+# SchedulerManager.create kind=message
+
+
+class TestCreateMessage:
+    def test_happy_iso_future(self, mgr):
+        sched = mgr.create(
+            kind="message",
+            when=_future_iso(3600),
+            what="ping",
+            target_thread_id=111,
+            created_by="u1",
+        )
+        assert sched["kind"] == "message"
+        assert sched["payload"]["what"] == "ping"
+        assert sched["target_thread_id"] == 111
+        assert sched["target_channel_id"] is None
+        assert sched["state"]["enabled"] is True
+        assert sched["trigger"]["kind"] == "once"
+        # schedule_id is 16-char hex (token_hex(8))
+        assert len(sched["schedule_id"]) == 16
+        # Default name = sched_id[:8]
+        assert sched["name"] == sched["schedule_id"][:8]
+
+    def test_past_iso_rejected(self, mgr):
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        with pytest.raises(ValueError, match="future"):
+            mgr.create(
+                kind="message",
+                when="iso: " + past.isoformat(),
+                what="ping",
+                target_thread_id=111,
+                created_by="u1",
+            )
+
+    def test_what_empty(self, mgr):
+        with pytest.raises(ValueError, match="what"):
+            mgr.create(
+                kind="message",
+                when=_future_iso(),
+                what="",
+                target_thread_id=111,
+                created_by="u1",
+            )
+
+    def test_what_too_long(self, mgr):
+        with pytest.raises(ValueError, match="what"):
+            mgr.create(
+                kind="message",
+                when=_future_iso(),
+                what="x" * 501,
+                target_thread_id=111,
+                created_by="u1",
+            )
+
+    def test_name_too_long(self, mgr):
+        with pytest.raises(ValueError, match="name"):
+            mgr.create(
+                kind="message",
+                when=_future_iso(),
+                what="ping",
+                target_thread_id=111,
+                created_by="u1",
+                name="x" * 51,
+            )
+
+    def test_target_thread_id_missing(self, mgr):
+        with pytest.raises(ValueError, match="target_thread_id"):
+            mgr.create(
+                kind="message",
+                when=_future_iso(),
+                what="ping",
+                created_by="u1",
+            )
+
+    def test_claude_every_minute_cron_rejected(self, mgr):
+        with pytest.raises(ValueError, match="min interval"):
+            mgr.create(
+                kind="message",
+                when="cron: * * * * *",  # every minute
+                what="ping",
+                target_thread_id=111,
+                created_by="claude",
+                is_claude_created=True,
+                recurring=True,
+            )
+
+    def test_user_every_minute_cron_allowed(self, mgr):
+        sched = mgr.create(
+            kind="message",
+            when="cron: * * * * *",
+            what="ping",
+            target_thread_id=111,
+            created_by="u1",
+            is_claude_created=False,
+            recurring=True,
+        )
+        assert sched["trigger"]["cron"] == "* * * * *"
+        assert sched["trigger"]["recurring"] is True
+
+
+# =============================================================== Group 7
+# SchedulerManager.create kind=new_task
+
+
+class TestCreateNewTask:
+    def test_happy(self, mgr):
+        sched = mgr.create(
+            kind="new_task",
+            when=_future_iso(3600),
+            what="run weekly report",
+            target_channel_id=2222,
+            thread_name="weekly-report",
+            created_by="u1",
+        )
+        assert sched["kind"] == "new_task"
+        assert sched["target_channel_id"] == 2222
+        assert sched["thread_name"] == "weekly-report"
+        assert sched["target_thread_id"] is None
+
+    def test_target_channel_id_missing(self, mgr):
+        with pytest.raises(ValueError, match="target_channel_id"):
+            mgr.create(
+                kind="new_task",
+                when=_future_iso(),
+                what="task",
+                created_by="u1",
+            )
+
+    def test_thread_name_too_long(self, mgr):
+        with pytest.raises(ValueError, match="thread_name"):
+            mgr.create(
+                kind="new_task",
+                when=_future_iso(),
+                what="task",
+                target_channel_id=222,
+                thread_name="x" * 51,
+                created_by="u1",
+            )
+
+
+# =============================================================== Group 8
+# Caps + max_lifetime
+
+
+class TestCaps:
+    def test_per_user_cap_for_claude(self, mgr, store):
+        # Pre-populate 20 claude-owned active schedules.
+        for i in range(MAX_USER_ACTIVE):
+            store.add({
+                "schedule_id": f"c{i:02d}",
+                "kind": "message",
+                "created_by": "claude",
+                "state": {"enabled": True},
+            })
+        with pytest.raises(ValueError, match="per-user"):
+            mgr.create(
+                kind="message",
+                when=_future_iso(3600),
+                what="one more",
+                target_thread_id=111,
+                created_by="claude",
+                is_claude_created=True,
+            )
+
+    def test_global_cap(self, mgr, store):
+        # Spread across users to avoid hitting per-user cap first.
+        for i in range(MAX_GLOBAL_ACTIVE):
+            store.add({
+                "schedule_id": f"g{i:03d}",
+                "kind": "message",
+                "created_by": f"user_{i % 50}",
+                "state": {"enabled": True},
+            })
+        with pytest.raises(ValueError, match="global"):
+            mgr.create(
+                kind="message",
+                when=_future_iso(),
+                what="extra",
+                target_thread_id=111,
+                created_by="newbie",
+            )
+
+    def test_max_lifetime_without_recurring_rejected(self, mgr):
+        with pytest.raises(ValueError, match="max_lifetime"):
+            mgr.create(
+                kind="message",
+                when=_future_iso(),
+                what="task",
+                target_thread_id=111,
+                created_by="u1",
+                recurring=False,
+                max_lifetime="30d",
+            )
+
+    def test_max_lifetime_400d_rejected(self, mgr):
+        with pytest.raises(ValueError, match="365d"):
+            mgr.create(
+                kind="message",
+                when="cron: 0 9 * * *",
+                what="task",
+                target_thread_id=111,
+                created_by="u1",
+                recurring=True,
+                max_lifetime="400d",
+            )
+
+    def test_max_lifetime_happy_persisted_as_seconds(self, mgr):
+        sched = mgr.create(
+            kind="message",
+            when="cron: 0 9 * * *",
+            what="task",
+            target_thread_id=111,
+            created_by="u1",
+            recurring=True,
+            max_lifetime="30d",
+        )
+        assert sched["max_lifetime_seconds"] == 30 * 86_400
+
+    def test_recurring_with_iso_rejected(self, mgr):
+        with pytest.raises(ValueError, match="recurring"):
+            mgr.create(
+                kind="message",
+                when=_future_iso(),
+                what="task",
+                target_thread_id=111,
+                created_by="u1",
+                recurring=True,
+            )
+
+
+# =============================================================== Group 9
+# SchedulerManager.delete
+
+
+class TestDelete:
+    def _make(self, mgr, *, created_by="u1"):
+        return mgr.create(
+            kind="message",
+            when=_future_iso(),
+            what="ping",
+            target_thread_id=111,
+            created_by=created_by,
+        )
+
+    def test_creator_can_delete(self, mgr, store):
+        s = self._make(mgr, created_by="u1")
+        ok, _ = mgr.delete(s["schedule_id"], requester="u1")
+        assert ok is True
+        assert store.get(s["schedule_id"]) is None
+
+    def test_other_cannot_delete(self, mgr, store):
+        s = self._make(mgr, created_by="u1")
+        ok, reason = mgr.delete(s["schedule_id"], requester="u2")
+        assert ok is False
+        assert "permission" in reason.lower()
+        assert store.get(s["schedule_id"]) is not None
+
+    def test_admin_override(self, mgr, store):
+        s = self._make(mgr, created_by="u1")
+        ok, _ = mgr.delete(
+            s["schedule_id"], requester="other", is_admin=True
+        )
+        assert ok is True
+        assert store.get(s["schedule_id"]) is None
+
+    def test_claude_cannot_delete_user_schedule(self, mgr):
+        s_user = self._make(mgr, created_by="u1")
+        ok, reason = mgr.delete(s_user["schedule_id"], requester="claude")
+        assert ok is False
+        assert "claude" in reason.lower()
+
+        # But claude CAN delete its own.
+        s_claude = mgr.create(
+            kind="message",
+            when="cron: 0 9 * * *",
+            what="ping",
+            target_thread_id=222,
+            created_by="claude",
+            is_claude_created=True,
+        )
+        ok2, _ = mgr.delete(s_claude["schedule_id"], requester="claude")
+        assert ok2 is True
+
+
+# =============================================================== Group 10
+# SchedulerManager.toggle
+
+
+class TestToggle:
+    def test_disable_then_enable(self, mgr, store):
+        s = mgr.create(
+            kind="message",
+            when=_future_iso(),
+            what="ping",
+            target_thread_id=111,
+            created_by="u1",
+        )
+        sid = s["schedule_id"]
+        ok, _ = mgr.toggle(sid, False, requester="u1")
+        assert ok is True
+        assert store.get(sid)["state"]["enabled"] is False
+        ok, _ = mgr.toggle(sid, True, requester="u1")
+        assert ok is True
+        assert store.get(sid)["state"]["enabled"] is True
+
+    def test_toggle_permission_matrix(self, mgr):
+        s = mgr.create(
+            kind="message",
+            when=_future_iso(),
+            what="ping",
+            target_thread_id=111,
+            created_by="u1",
+        )
+        sid = s["schedule_id"]
+
+        ok, _ = mgr.toggle(sid, False, requester="someone-else")
+        assert ok is False
+
+        ok, _ = mgr.toggle(sid, False, requester="claude")
+        assert ok is False
+
+        ok, _ = mgr.toggle(
+            sid, False, requester="admin-user", is_admin=True
+        )
+        assert ok is True

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1085,12 +1085,23 @@ class TestFireOne:
         persisted = store.get("tx3retry")
         assert persisted["state"]["enabled"] is False
         assert "boom" in (persisted["state"]["last_error"] or "")
-        # backoff sleeps were attempted between attempts 1→2 and 2→3
-        # (no sleep before terminal disable after attempt 3).
+        # M12: pin the EXACT scheduler-backoff sleep sequence.
+        # The 5/19 directive requires strict assertions; the previous
+        # ``(1,) in sleep_calls and (4,) in sleep_calls`` subset check
+        # would have missed a regression that (a) swapped the 1↔4 order,
+        # (b) added a spurious 16s sleep before terminal disable (the
+        # contract is "no sleep after the 3rd failure — disable immediately"),
+        # or (c) regressed to a single retry.
         sleep_calls = [c.args for c in sleep_mock.await_args_list]
-        # Only assert that at least the two scheduler backoff sleeps fired.
-        assert (1,) in sleep_calls
-        assert (4,) in sleep_calls
+        # Filter to just the scheduler retry backoffs in case the
+        # production code grows an unrelated asyncio.sleep elsewhere in
+        # the path (e.g. for log flush).
+        backoff_sleeps = [c for c in sleep_calls if c in ((1,), (4,), (16,))]
+        # Exactly 2, in order, with NO 16-second sleep before terminal.
+        assert backoff_sleeps == [(1,), (4,)], (
+            f"expected [(1,), (4,)] in order, got {backoff_sleeps!r} "
+            f"(all sleep calls: {sleep_calls!r})"
+        )
 
     @pytest.mark.asyncio
     async def test_fire_one_transient_recovers_on_attempt_2(
@@ -1167,6 +1178,69 @@ class TestFireOne:
             "fire_invoked",
             "lock_released",
         ]
+
+    @pytest.mark.asyncio
+    async def test_two_fires_same_lock_id_serialize(self, store):
+        """M13 / R1 Tester #3: the per-target lock's actual contract is
+        *mutual exclusion of overlapping fires aimed at the same target* —
+        not "a lock is acquired somewhere around the call." A buggy
+        ``_fire_one`` that ``await``-ed the lock but never wrapped the
+        callback in ``async with`` would still pass the
+        ``test_fire_one_acquires_lock`` event-trace test.
+
+        This test pins serialization directly: two schedules with the
+        same ``target_thread_id`` (and therefore the same lock id) are
+        dispatched concurrently. Each callback sleeps 0.05s between
+        ``enter`` and ``exit`` events. With the lock honoured, the
+        events must be one of two ordered, non-interleaved sequences.
+        Without the lock (regression), an interleaved sequence like
+        ``[enter:A, enter:B, exit:A, exit:B]`` would land.
+        """
+        events: list[str] = []
+
+        async def cb(sched):
+            sid = sched["schedule_id"]
+            events.append(f"enter:{sid}")
+            await asyncio.sleep(0.05)
+            events.append(f"exit:{sid}")
+
+        # Shared lock pool: one asyncio.Lock per lock-id, returned to both
+        # _fire_one calls. _build_mgr's default get_lock already uses a
+        # shared map, so we just use it here.
+        mgr = _build_mgr(store, fire_message=cb)
+
+        past = (
+            datetime.now(timezone.utc) - timedelta(seconds=10)
+        ).isoformat()
+        sched_a = _due_sched_dict(
+            schedule_id="serialA",
+            target_thread_id=9999,  # SAME lock id
+            next_fire_at=past,
+        )
+        sched_b = _due_sched_dict(
+            schedule_id="serialB",
+            target_thread_id=9999,  # SAME lock id
+            next_fire_at=past,
+        )
+        store.add(sched_a)
+        store.add(sched_b)
+
+        # Dispatch concurrently — gather forces both _fire_one calls
+        # onto the event loop simultaneously, so without the lock they
+        # would interleave inside the 0.05s callback sleep.
+        await asyncio.gather(
+            mgr._fire_one(sched_a),
+            mgr._fire_one(sched_b),
+        )
+
+        # Strict: events must be one of the two non-interleaved orders.
+        # A regression that removed the ``async with self.get_lock(...)``
+        # would produce an interleaved sequence like
+        # ``["enter:serialA", "enter:serialB", "exit:serialA", "exit:serialB"]``.
+        assert events in (
+            ["enter:serialA", "exit:serialA", "enter:serialB", "exit:serialB"],
+            ["enter:serialB", "exit:serialB", "enter:serialA", "exit:serialA"],
+        ), f"fires interleaved (lock contract broken): {events!r}"
 
     @pytest.mark.asyncio
     async def test_max_global_inflight_cap(self, store):

--- a/tests/test_scheduler_mcp.py
+++ b/tests/test_scheduler_mcp.py
@@ -1,0 +1,483 @@
+"""Unit tests for the v1.18 scheduler MCP server (issue #241, Subtask 3).
+
+Per ``docs/prd/v1.18-scheduler.md`` §3.7 + §4 and the Subtask 3 brief, this
+exercises the 5 ``schedule_*`` tools registered on the in-process SDK MCP
+server. We invoke each tool's ``.handler`` directly (the ``@tool``
+decorator wraps the underlying async fn into an ``SdkMcpTool`` dataclass
+whose ``.handler`` is the original async callable).
+
+Test groups:
+  1. ``build_scheduler_mcp_server`` smoke         (2 tests)
+  2. ``set_scheduler_manager`` clear-via-None     (1 test)
+  3. ``schedule_message_tool``                    (6 tests)
+  4. ``schedule_new_task_tool``                   (3 tests)
+  5. ``schedule_list_tool``                       (4 tests)
+  6. ``schedule_delete_tool``                     (3 tests)
+  7. ``schedule_toggle_tool``                     (2 tests)
+  8. global cap                                   (1 test)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from clauded import scheduler_mcp
+from clauded.scheduler import SchedulerManager
+from clauded.scheduler_mcp import (
+    _require_mgr,
+    build_scheduler_mcp_server,
+    schedule_delete_tool,
+    schedule_list_tool,
+    schedule_message_tool,
+    schedule_new_task_tool,
+    schedule_toggle_tool,
+    set_scheduler_manager,
+)
+from clauded.scheduler_store import SchedulerStore
+
+
+# ---------------------------------------------------------------- Helpers
+
+async def _noop_cb(_sched):
+    return None
+
+
+def _future_iso(seconds_ahead: int = 3600) -> str:
+    dt = datetime.now(timezone.utc) + timedelta(seconds=seconds_ahead)
+    return "iso: " + dt.isoformat()
+
+
+async def _call(tool_obj, args: dict) -> dict:
+    """Invoke an SdkMcpTool handler directly.
+
+    The ``@tool`` decorator returns an ``SdkMcpTool`` dataclass whose
+    ``.handler`` is the original async function. Fall back to calling
+    the object itself in case the SDK shape changes in the future.
+    """
+    handler = getattr(tool_obj, "handler", tool_obj)
+    return await handler(args)
+
+
+# --------------------------------------------------------------- Fixtures
+
+@pytest.fixture
+def store(tmp_path):
+    d = tmp_path / "data"
+    d.mkdir()
+    return SchedulerStore(data_dir=str(d))
+
+
+@pytest.fixture
+def mgr(store):
+    return SchedulerManager(
+        store,
+        fire_message_callback=_noop_cb,
+        fire_new_task_callback=_noop_cb,
+        expire_notify_callback=_noop_cb,
+    )
+
+
+@pytest.fixture
+def ctx():
+    """Default per-turn context."""
+    return {
+        "thread_id": 42,
+        "channel_id": 10,
+        "guild_id": 1,
+        "tz_name": "UTC",
+    }
+
+
+@pytest.fixture
+def wired(mgr, ctx):
+    """Wire mgr + ctx_provider; tear down by clearing both."""
+    set_scheduler_manager(mgr, ctx_provider=lambda: ctx)
+    try:
+        yield mgr
+    finally:
+        set_scheduler_manager(None)
+
+
+# ============================================================= Group 1
+# build_scheduler_mcp_server smoke
+
+
+class TestBuildServer:
+    def test_build_returns_config(self):
+        cfg = build_scheduler_mcp_server()
+        assert cfg is not None
+        # McpSdkServerConfig is a TypedDict — accept dict-like access.
+        assert cfg["type"] == "sdk"
+        assert cfg["name"] == "clauded-scheduler"
+        assert cfg["instance"] is not None
+
+    def test_each_tool_has_handler(self):
+        # Direct invocation contract: every @tool object exposes .handler
+        for t in (
+            schedule_message_tool,
+            schedule_new_task_tool,
+            schedule_list_tool,
+            schedule_delete_tool,
+            schedule_toggle_tool,
+        ):
+            assert hasattr(t, "handler")
+            assert callable(t.handler)
+            assert hasattr(t, "name")
+
+
+# ============================================================= Group 2
+# set_scheduler_manager clear-via-None
+
+
+class TestSetSchedulerManager:
+    def test_set_then_clear(self, mgr):
+        set_scheduler_manager(mgr, ctx_provider=lambda: {})
+        assert _require_mgr() is mgr
+        set_scheduler_manager(None)
+        assert _require_mgr() is None
+        # _GLOBAL_CTX also cleared so a stale provider can't leak.
+        assert scheduler_mcp._GLOBAL_CTX is None
+
+
+# ============================================================= Group 3
+# schedule_message_tool
+
+
+class TestScheduleMessageTool:
+    @pytest.mark.asyncio
+    async def test_happy_path_with_ctx(self, wired):
+        res = await _call(
+            schedule_message_tool,
+            {"when": _future_iso(3600), "what": "remind me"},
+        )
+        assert "is_error" not in res or res.get("is_error") is False
+        text = res["content"][0]["text"]
+        assert "Created schedule" in text
+        assert "kind=message" in text
+
+    @pytest.mark.asyncio
+    async def test_no_manager_wired(self):
+        set_scheduler_manager(None)
+        res = await _call(
+            schedule_message_tool,
+            {"when": _future_iso(3600), "what": "x"},
+        )
+        assert res.get("is_error") is True
+        assert "scheduler not initialized" in res["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_no_ctx_and_no_target_thread_id(self, mgr):
+        # Wire mgr but ctx_provider returns empty dict.
+        set_scheduler_manager(mgr, ctx_provider=lambda: {})
+        try:
+            res = await _call(
+                schedule_message_tool,
+                {"when": _future_iso(3600), "what": "x"},
+            )
+        finally:
+            set_scheduler_manager(None)
+        assert res.get("is_error") is True
+        assert "no target thread" in res["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_bad_target_thread_id_str(self, wired):
+        res = await _call(
+            schedule_message_tool,
+            {
+                "when": _future_iso(3600),
+                "what": "x",
+                "target_thread_id": "not-numeric",
+            },
+        )
+        assert res.get("is_error") is True
+        assert "invalid target_thread_id" in res["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_validation_failure_empty_what(self, wired):
+        res = await _call(
+            schedule_message_tool,
+            {"when": _future_iso(3600), "what": ""},
+        )
+        assert res.get("is_error") is True
+        # ValueError from SchedulerManager.create: "what must be non-empty…"
+        assert "what" in res["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_claude_min_interval_cron_rejected(self, wired):
+        # 1-minute cron — well under 5-min claude min interval.
+        res = await _call(
+            schedule_message_tool,
+            {
+                "when": "cron: * * * * *",
+                "what": "ping",
+                "recurring": True,
+            },
+        )
+        assert res.get("is_error") is True
+        assert "min interval" in res["content"][0]["text"]
+
+
+# ============================================================= Group 4
+# schedule_new_task_tool
+
+
+class TestScheduleNewTaskTool:
+    @pytest.mark.asyncio
+    async def test_happy_path_with_ctx(self, wired):
+        res = await _call(
+            schedule_new_task_tool,
+            {"when": _future_iso(3600), "what": "write report"},
+        )
+        assert res.get("is_error", False) is False
+        text = res["content"][0]["text"]
+        assert "Created schedule" in text
+        assert "kind=new_task" in text
+
+    @pytest.mark.asyncio
+    async def test_no_ctx_and_no_target_channel_id(self, mgr):
+        set_scheduler_manager(mgr, ctx_provider=lambda: {})
+        try:
+            res = await _call(
+                schedule_new_task_tool,
+                {"when": _future_iso(3600), "what": "x"},
+            )
+        finally:
+            set_scheduler_manager(None)
+        assert res.get("is_error") is True
+        assert "no target channel" in res["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_validation_failure_long_what(self, wired):
+        res = await _call(
+            schedule_new_task_tool,
+            {
+                "when": _future_iso(3600),
+                "what": "x" * 501,  # exceeds 500-char cap
+            },
+        )
+        assert res.get("is_error") is True
+        assert "what" in res["content"][0]["text"]
+
+
+# ============================================================= Group 5
+# schedule_list_tool
+
+
+class TestScheduleListTool:
+    @pytest.mark.asyncio
+    async def test_empty(self, wired):
+        res = await _call(schedule_list_tool, {"scope": "thread"})
+        assert res.get("is_error", False) is False
+        assert "(no schedules)" in res["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_markers_message_and_new_task(self, wired, ctx):
+        mgr = wired
+        # claude-created message into the current thread
+        mgr.create(
+            kind="message",
+            when=_future_iso(3600),
+            what="msg",
+            target_thread_id=ctx["thread_id"],
+            created_by="claude",
+            is_claude_created=True,
+            guild_id=ctx["guild_id"],
+            channel_id=ctx["channel_id"],
+            tz_name=ctx["tz_name"],
+        )
+        # user-created new_task into the current channel
+        mgr.create(
+            kind="new_task",
+            when=_future_iso(7200),
+            what="task",
+            target_channel_id=ctx["channel_id"],
+            created_by="123456789",
+            is_claude_created=False,
+            guild_id=ctx["guild_id"],
+            channel_id=ctx["channel_id"],
+            tz_name=ctx["tz_name"],
+        )
+
+        res = await _call(schedule_list_tool, {"scope": "all"})
+        text = res["content"][0]["text"]
+        assert "📨" in text  # message marker
+        assert "🧵" in text  # new_task marker
+        assert "🤖" in text  # claude creator
+        assert "👤" in text  # user creator
+
+    @pytest.mark.asyncio
+    async def test_scope_all(self, wired, ctx):
+        mgr = wired
+        mgr.create(
+            kind="message",
+            when=_future_iso(3600),
+            what="m",
+            target_thread_id=999,  # different thread
+            created_by="claude",
+            is_claude_created=True,
+            tz_name=ctx["tz_name"],
+        )
+        res = await _call(schedule_list_tool, {"scope": "all"})
+        assert res.get("is_error", False) is False
+        assert "(no schedules)" not in res["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_scope(self, wired):
+        res = await _call(schedule_list_tool, {"scope": "bogus"})
+        assert res.get("is_error") is True
+        assert "invalid scope" in res["content"][0]["text"]
+
+
+# ============================================================= Group 6
+# schedule_delete_tool
+
+
+class TestScheduleDeleteTool:
+    @pytest.mark.asyncio
+    async def test_claude_deletes_own(self, wired, ctx):
+        mgr = wired
+        sched = mgr.create(
+            kind="message",
+            when=_future_iso(3600),
+            what="m",
+            target_thread_id=ctx["thread_id"],
+            created_by="claude",
+            is_claude_created=True,
+            tz_name=ctx["tz_name"],
+        )
+        res = await _call(
+            schedule_delete_tool,
+            {"schedule_id": sched["schedule_id"]},
+        )
+        assert res.get("is_error", False) is False
+        assert "Deleted" in res["content"][0]["text"]
+        assert mgr.store.get(sched["schedule_id"]) is None
+
+    @pytest.mark.asyncio
+    async def test_claude_cannot_delete_user_schedule(self, wired, ctx):
+        mgr = wired
+        sched = mgr.create(
+            kind="message",
+            when=_future_iso(3600),
+            what="m",
+            target_thread_id=ctx["thread_id"],
+            created_by="123456789",
+            is_claude_created=False,
+            tz_name=ctx["tz_name"],
+        )
+        res = await _call(
+            schedule_delete_tool,
+            {"schedule_id": sched["schedule_id"]},
+        )
+        assert res.get("is_error") is True
+        assert "claude-created" in res["content"][0]["text"]
+        # still in store
+        assert mgr.store.get(sched["schedule_id"]) is not None
+
+    @pytest.mark.asyncio
+    async def test_missing_schedule_id_arg(self, wired):
+        res = await _call(schedule_delete_tool, {})
+        assert res.get("is_error") is True
+        assert "schedule_id required" in res["content"][0]["text"]
+
+
+# ============================================================= Group 7
+# schedule_toggle_tool
+
+
+class TestScheduleToggleTool:
+    @pytest.mark.asyncio
+    async def test_disable_then_enable_roundtrip(self, wired, ctx):
+        mgr = wired
+        sched = mgr.create(
+            kind="message",
+            when=_future_iso(3600),
+            what="m",
+            target_thread_id=ctx["thread_id"],
+            created_by="claude",
+            is_claude_created=True,
+            tz_name=ctx["tz_name"],
+        )
+        sid = sched["schedule_id"]
+
+        res = await _call(
+            schedule_toggle_tool,
+            {"schedule_id": sid, "enabled": False},
+        )
+        assert res.get("is_error", False) is False
+        assert mgr.store.get(sid)["state"]["enabled"] is False
+
+        res = await _call(
+            schedule_toggle_tool,
+            {"schedule_id": sid, "enabled": True},
+        )
+        assert res.get("is_error", False) is False
+        assert mgr.store.get(sid)["state"]["enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_id(self, wired):
+        res = await _call(
+            schedule_toggle_tool,
+            {"schedule_id": "deadbeefdeadbeef", "enabled": False},
+        )
+        assert res.get("is_error") is True
+        assert "not found" in res["content"][0]["text"]
+
+
+# ============================================================= Group 8
+# global active cap
+
+
+class TestGlobalCap:
+    @pytest.mark.asyncio
+    async def test_101st_schedule_rejected_via_tool(self, wired, ctx):
+        mgr = wired
+        # Pre-populate 100 active claude-created schedules directly in the
+        # store (bypassing mgr.create — we only want the count_active_total
+        # path to fire; we don't want to validate the 100 themselves).
+        now_iso = datetime.now(timezone.utc).isoformat()
+        future_iso = (
+            datetime.now(timezone.utc) + timedelta(hours=1)
+        ).isoformat()
+        for i in range(100):
+            mgr.store.add({
+                "schedule_id": f"{i:016x}",
+                "kind": "message",
+                "name": f"s{i}",
+                "created_at": now_iso,
+                "created_by": "claude",
+                "guild_id": 1,
+                "channel_id": 10,
+                "target_thread_id": 42,
+                "target_channel_id": None,
+                "thread_name": None,
+                "trigger": {
+                    "kind": "once",
+                    "iso": future_iso,
+                    "cron": None,
+                    "tz_when_created": "UTC",
+                    "recurring": False,
+                },
+                "payload": {"what": "x"},
+                "max_lifetime_seconds": None,
+                "state": {
+                    "enabled": True,
+                    "next_fire_at": future_iso,
+                    "first_fired_at": None,
+                    "last_fired_at": None,
+                    "last_error": None,
+                    "fire_count": 0,
+                    "missed_count": 0,
+                },
+            })
+
+        assert mgr.store.count_active_total() == 100
+
+        res = await _call(
+            schedule_message_tool,
+            {"when": _future_iso(7200), "what": "one too many"},
+        )
+        assert res.get("is_error") is True
+        assert "cap" in res["content"][0]["text"]


### PR DESCRIPTION
## #241 — `/schedule` Timer System

Implements PRD `docs/prd/v1.18-scheduler.md` (locked after DDD with user; see commit `f1ec3d4`).

### What

Two-kind scheduler with cross-restart persistence, exposed both as Discord slash commands and as in-process MCP tools so claude can create schedules from natural conversation:

- **`schedule_message`** — fire-time inject a user message into an existing thread's session (resurrects via stored resume_session_id if the session was idle)
- **`schedule_new_task`** — fire-time spawn a brand-new thread + fresh claude session, with `what` as the first user prompt

### Files (6 commits, 5 subtasks)

```
docs/prd/v1.18-scheduler.md   # locked PRD (550 lines)
src/clauded/scheduler_store.py  # JSON persistence, atomic write (mirrors session_store.py)
src/clauded/scheduler.py        # SchedulerManager — trigger parsing + tick + catch_up + fire executors + max_lifetime
src/clauded/scheduler_mcp.py    # 5 in-process @tool definitions + create_sdk_mcp_server
src/clauded/cogs/schedule.py    # /schedule message|new_task|list|delete|toggle
src/clauded/bot.py              # init scheduler + tasks.loop tick + 3 fire callbacks + ctx provider + render_with_retry ctx register
src/clauded/claude_bridge.py    # _build_mcp_servers — merge scheduler server into all sessions
src/clauded/discord_renderer.py # remove 4 dead PascalCase branches (CronCreate/CronDelete/CronList/ScheduleWakeup)
tests/test_scheduler.py         # 68 tests (parsing + store + manager + tick + catch_up + fire + max_lifetime + lock + cap)
tests/test_scheduler_mcp.py     # 22 tests (5 tools × happy + error paths + permission + cap)
tests/test_cogs_schedule.py     # 16 tests (5 cog subcommands × thread-only + unbound + render + permission + admin)
scripts/e2e/run_real_e2e.py     # 2 new real-Discord cases: case_schedule_message_e2e + case_schedule_new_task_e2e
README.md / docs/TESTING.md     # /schedule sections
pyproject.toml                  # + croniter>=2.0
```

### Tests

- **1065 baseline → 1178 passed** (+113 net new; 0 regressions)
- 17 xfailed unchanged (existing open-bug reproducers)
- 106 schedule-related (68 unit + 22 MCP + 16 cog)
- 2 real-Discord e2e cases added (not yet run; will run post-merge as part of close-out)

### Decisions (PRD §3, all DDD-approved)

| Decision | Value |
|---|---|
| Tool naming | `schedule_message` + `schedule_new_task` (snake_case; doesn't collide with claudecode internal PascalCase `CronCreate`/`ScheduleWakeup`) |
| Slash naming | `/schedule message|new_task|list|delete|toggle` (single Group, 5 subcommands) |
| Schedule id | 16-char hex (`secrets.token_hex(8)`) |
| `max_lifetime` | duration string `"30d"`/`"7d"`/...; from **first_fired_at**; ≤365d hard cap; recurring-only; claude-only (slash UI doesn't expose) |
| Expiry notification | embed to schedule's **original created channel** |
| Injected content visibility | `> 「<what>」` Discord block-quote shown in target thread for AC13 |
| Kind 2 thread | public + 1d auto-archive + parent-channel announce embed |
| Kind 1 session resurrect | via stored `resume_session_id` (UX-transparent) |
| Caps | 20/user + 100/global active (kinds shared); 10 in-flight; 5-min min claude cron interval |
| TZ | `Asia/Shanghai` default; bad tz → raise (not silent UTC fallback) |
| Persistence | `data/schedules.json` atomic (tmp+fsync+os.replace), corrupt→empty + WARNING |
| Missed grace | ≤5min → fire immediately; >5min → mark+roll forward + WARNING |
| Fire failure | NotFound/Forbidden → terminal disable; other → 1s/4s/16s 3× backoff |

### Acceptance criteria (PRD §9)

| AC | Status |
|---|---|
| AC1 slash creates via tool path | ✅ unit + ready for real-e2e |
| AC2 timer really fires | ⏳ ready for real-e2e (Subtask 5 cases) |
| AC3 natural conversation also creates | ✅ tool globally enabled in `_build_mcp_servers` |
| AC4 1-min cron rejected for claude | ✅ unit |
| AC5 restart missed-grace logic | ✅ unit |
| AC6 NotFound auto-disable | ✅ unit |
| AC7 per-thread serial | ✅ unit lock contract |
| AC8 list 🤖/👤 marker | ✅ unit |
| AC9 cross-user delete reject | ✅ unit |
| AC10 dead code removed | ✅ verified `grep -c=0` |
| AC11 new_task fires spawn new thread | ⏳ ready for real-e2e |
| AC12 max_lifetime disable+notify | ✅ unit |
| AC13 injected prompt visible | ✅ unit asserts on `> ` quote pattern + ready for real-e2e |

### Process

All 5 subtasks implemented by dispatched `coding` sub-agents per crew workflow (not manager-direct). DDD discussion + PRD final + per-subtask brief + sub-agent commit + manager sanity check. R1 7-perspective review happens on this PR.

Closes #241.
