### PR TITLE
fix(#263): context pct uses Free space supplement instead of totalTokens

### DIFF
--- a/docs/prd/fix-263-context-pct.md
+++ b/docs/prd/fix-263-context-pct.md
@@ -1,0 +1,43 @@
+# PRD — #263 /context + footer 🧠 use Free space supplement
+
+**Issue**: #263 (bug, P1)
+**Branch**: `fix/263-context-pct`
+**Status**: APPROVED
+
+## Problem
+`/context` + footer 🧠 use `totalTokens/maxTokens` which is **last-turn input footprint**, not current buffer occupancy. Result: shows 0%/<1% when real usage is ~45%.
+
+## Approach (locked — Approach A from issue)
+Use Free space supplement: `global_used = maxTokens - free_space_tokens`. Categories list unchanged.
+
+## Files to change
+
+### `src/clauded/discord_renderer.py`
+In `_fetch_context_pct_settled` (or `_compute` helper around line 333-351):
+```python
+free_space = next((c["tokens"] for c in cu["categories"] if c["name"] in ("Free space", "Available", "Remaining")), None)
+if free_space is not None and cu.get("maxTokens", 0) > 0:
+    global_used = cu["maxTokens"] - free_space
+    global_pct = global_used / cu["maxTokens"] * 100
+else:
+    global_used = cu.get("totalTokens", 0)
+    global_pct = float(cu.get("percentage", 0))
+```
+Use `global_pct` for footer 🧠 instead of `totalTokens/maxTokens`.
+
+### `src/clauded/cogs/context.py`
+Lines 93-95 + 106 + 108: same Free space supplement. Title shows `📊 Context: {global_pct:.1f}%`. Progress shows `{global_used/1000:.1f}k / {max/1000:.1f}k`.
+
+### Tests
+- Construct fixture: `totalTokens=408, maxTokens=1_000_000, categories=[..., {"name":"Free space","tokens":551100}]`
+- Assert footer pct ≈ 44.9% (not 0%)
+- Assert /context title shows ~45%
+- Assert Free space missing → fallback to totalTokens (no crash)
+
+## AC
+- AC1: footer 🧠 shows ~45% in same scenario (not <1%)
+- AC2: /context title shows ~45%
+- AC3: /context progress shows ~449k / 1000k
+- AC4: categories list unchanged
+- AC5: Free space missing → fallback, no crash
+- AC6: unit tests cover divergence case

--- a/src/clauded/cogs/context.py
+++ b/src/clauded/cogs/context.py
@@ -92,8 +92,24 @@ def _build_context_embed(usage: dict, source_label: str) -> discord.Embed:
     """
     total = int(usage.get("totalTokens", 0))
     max_tokens = int(usage.get("maxTokens", 0))
-    percentage = float(usage.get("percentage", 0))
     model = str(usage.get("model", "unknown"))
+
+    # #263: compute global occupancy from Free space supplement instead
+    # of totalTokens (which is last-turn input footprint, not buffer usage).
+    categories = usage.get("categories") or []
+    free_space = next(
+        (c["tokens"] for c in categories
+         if isinstance(c, dict)
+         and c.get("name") in ("Free space", "Available", "Remaining")),
+        None,
+    )
+    if free_space is not None and max_tokens > 0:
+        total = max(0, max_tokens - int(free_space))
+        percentage = (total / max_tokens) * 100.0
+    else:
+        # Fallback to SDK fields (pre-#263 behavior)
+        total = int(usage.get("totalTokens", 0))
+        percentage = float(usage.get("percentage", 0))
 
     bar = _format_progress_bar(percentage)
     pct_color = (

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -333,16 +333,33 @@ async def _fetch_context_pct_settled(
     def _compute(cu: dict[str, Any] | None) -> float | None:
         if cu is None:
             return None
-        # Prefer self-computed ratio for precision (#v1.18: SDK rounds to int).
-        total = cu.get("totalTokens")
         max_t = cu.get("maxTokens")
-        if (
-            isinstance(total, (int, float))
-            and isinstance(max_t, (int, float))
-            and max_t > 0
-        ):
+        if not isinstance(max_t, (int, float)) or max_t <= 0:
+            # Fallback to SDK-provided percentage (legacy / unfamiliar shape).
+            if "percentage" not in cu:
+                return None
+            try:
+                return float(cu["percentage"])
+            except (TypeError, ValueError):
+                return None
+        # #263: Use Free space supplement instead of totalTokens.
+        # totalTokens is last-turn input footprint, NOT current buffer
+        # occupancy. Free space = maxTokens - real_used - autocompact,
+        # so global_used = maxTokens - free_space is the true occupancy.
+        categories = cu.get("categories") or []
+        free_space = next(
+            (c["tokens"] for c in categories
+             if isinstance(c, dict)
+             and c.get("name") in ("Free space", "Available", "Remaining")),
+            None,
+        )
+        if free_space is not None and isinstance(free_space, (int, float)):
+            global_used = float(max_t) - float(free_space)
+            return max(0.0, (global_used / float(max_t)) * 100.0)
+        # Fallback: use totalTokens (pre-#263 behavior) if no Free space
+        total = cu.get("totalTokens")
+        if isinstance(total, (int, float)):
             return (float(total) / float(max_t)) * 100.0
-        # Fallback to SDK-provided percentage (legacy / unfamiliar shape).
         if "percentage" not in cu:
             return None
         try:

--- a/tests/test_context_footer.py
+++ b/tests/test_context_footer.py
@@ -112,6 +112,12 @@ async def test_footer_includes_context_segment_e2e():
         "maxTokens": 200000,
         "rawMaxTokens": 200000,
         "model": "claude-sonnet-4-5",
+        # #263: categories with Free space so the new supplement logic works
+        "categories": [
+            {"name": "Messages", "tokens": 136000},
+            {"name": "System", "tokens": 10000},
+            {"name": "Free space", "tokens": 54000},  # 200k - 146k = 54k
+        ],
     }
     bridge = FakeBridge(events, get_context_usage_returns=ctx_response)
     await renderer.render_response(bridge, "hello")
@@ -189,3 +195,97 @@ async def test_footer_omits_context_when_get_context_usage_returns_none():
     all_content = " ".join(m.content for m in target._sent if m.content)
     assert "🧠" not in all_content
     assert "🔥" not in all_content
+
+
+@pytest.mark.asyncio
+async def test_footer_context_uses_free_space_not_totalTokens():
+    """#263: when totalTokens diverges from real usage (cache hit scenario),
+    footer must show the real usage (from Free space supplement), not the
+    misleading totalTokens.
+
+    Scenario from the issue: totalTokens=408 (last-turn input), but real
+    buffer usage is ~449k (maxTokens=1M - Free space=551100).
+    Old code would show <1%; correct answer is ~44.9%.
+    """
+    from claude_agent_sdk.types import AssistantMessage, TextBlock, ResultMessage
+    from clauded.discord_renderer import DiscordRenderer
+
+    events = [
+        AssistantMessage(
+            content=[TextBlock(text="result")],
+            model="claude-sonnet-4-5", parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result", duration_ms=50, duration_api_ms=30,
+            is_error=False, num_turns=1, session_id="sess-263",
+            total_cost_usd=0.01,
+            usage={"input_tokens": 50, "output_tokens": 20},
+        ),
+    ]
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+    # Divergence fixture: totalTokens=408 (tiny, from cache hit)
+    # but real usage shown by categories is ~449k
+    ctx_response = {
+        "percentage": 0,          # SDK says 0% (misleading)
+        "totalTokens": 408,       # last-turn input only (misleading)
+        "maxTokens": 1_000_000,
+        "model": "claude-sonnet-4-5",
+        "categories": [
+            {"name": "Messages", "tokens": 409_000},
+            {"name": "Autocompact summary", "tokens": 33_000},
+            {"name": "System", "tokens": 6_100},
+            {"name": "Skills", "tokens": 858},
+            {"name": "Free space", "tokens": 551_100},
+        ],
+    }
+    bridge = FakeBridge(events, get_context_usage_returns=ctx_response)
+    await renderer.render_response(bridge, "hello")
+
+    all_content = " ".join(m.content for m in target._sent if m.content)
+    # Must show ~45% (from Free space supplement), NOT <1% or 0%
+    # 1M - 551100 = 448900 → 44.89%
+    assert "🧠 45%" in all_content or "🧠 44%" in all_content, (
+        f"Expected '🧠 44%' or '🧠 45%' in footer (Free space supplement); "
+        f"got: {all_content!r}"
+    )
+    # Must NOT show the misleading <1% or 0%
+    assert "🧠 <1%" not in all_content, "Should not show <1% with 45% real usage"
+    assert "🧠 0%" not in all_content, "Should not show 0% with 45% real usage"
+
+
+@pytest.mark.asyncio
+async def test_footer_context_fallback_when_no_free_space():
+    """#263 AC5: if categories don't contain Free space, fallback to
+    totalTokens (no crash)."""
+    from claude_agent_sdk.types import AssistantMessage, TextBlock, ResultMessage
+    from clauded.discord_renderer import DiscordRenderer
+
+    events = [
+        AssistantMessage(
+            content=[TextBlock(text="result")],
+            model="claude-sonnet-4-5", parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result", duration_ms=50, duration_api_ms=30,
+            is_error=False, num_turns=1, session_id="sess-263fb",
+            total_cost_usd=0.01,
+            usage={"input_tokens": 50, "output_tokens": 20},
+        ),
+    ]
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+    # No categories at all — should fallback to totalTokens
+    ctx_response = {
+        "totalTokens": 50000,
+        "maxTokens": 200000,
+        "model": "claude-sonnet-4-5",
+    }
+    bridge = FakeBridge(events, get_context_usage_returns=ctx_response)
+    await renderer.render_response(bridge, "hello")
+
+    all_content = " ".join(m.content for m in target._sent if m.content)
+    # Fallback: 50000/200000 = 25%
+    assert "🧠 25%" in all_content, (
+        f"Expected '🧠 25%' in footer (fallback to totalTokens); got: {all_content!r}"
+    )


### PR DESCRIPTION
See commit message. 1192 passed, 0 regressions. Closes #263