### PR TITLE
fix(#247): update stale KNOWN_MODELS + thread resolve + list/current consistency

### DIFF
--- a/docs/prd/fix-247-model-stale.md
+++ b/docs/prd/fix-247-model-stale.md
@@ -1,0 +1,29 @@
+# PRD — #247 /model list/current stale + resolve + consistency
+
+**Issue**: #247 (bug, P1)
+**Branch**: `fix/247-model-stale`
+**Status**: APPROVED
+
+## Problem (3 bugs)
+A. KNOWN_MODELS hardcoded table is stale (claude-sonnet-4-5 vs actual 4-6)
+B. _current_model_for_thread doesn't resolve thread→parent (shows "no session" inside threads)
+C. /model list vs /model current inconsistency on session detection
+
+## Approach
+**Bug A**: Update KNOWN_MODELS to current model names. The table serves as alias→full-id mapping for `/model switch <alias>`. Update ids to latest. If SDK provides a way to query available models at runtime, use that; otherwise just update the table.
+
+**Bug B**: In `_current_model_for_thread`, if `thread_id` doesn't have a session, try resolving it as a thread and checking parent channel sessions. Use the existing `resolve_binding_id` pattern.
+
+**Bug C**: Make `/model list` and `/model current` use the same session-detection logic.
+
+## Files
+- `src/clauded/cogs/model.py` — KNOWN_MODELS table + _current_model_for_thread + list/current commands
+- `tests/test_model_cmd.py` — existing tests to update
+
+## AC
+- AC1: /model list shows current model ids (claude-sonnet-4-6 etc.)
+- AC2: /model list marks current active model with 🟢
+- AC3: /model current in thread shows thread's active model
+- AC4: /model current in channel shows "Run inside a thread"
+- AC5: list + current consistent in same thread
+- AC6: pre-first-turn shows "(unset)" consistently

--- a/src/clauded/cogs/model.py
+++ b/src/clauded/cogs/model.py
@@ -152,6 +152,7 @@ async def model_list(interaction: discord.Interaction) -> None:
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
     current = _current_model_for_thread(bot, interaction.channel)
+    bridge = _resolve_session_bridge(bot, interaction.channel)
     # Build the rendered list
     lines = []
     for alias, info in KNOWN_MODELS.items():
@@ -160,12 +161,15 @@ async def model_list(interaction: discord.Interaction) -> None:
         model_id = info["id"]
         # Mark currently-active model (match alias OR id)
         marker = "🟢 " if current and (current == alias or current == model_id) else "• "
-        lines.append(f"{marker}**{alias}** (`{model_id}`) \u2014 {tier}, {ctx} context")
+        lines.append(f"{marker}**{alias}** (`{model_id}`) — {tier}, {ctx} context")
     desc = "\n".join(lines)
     if current:
         header = f"**Current**: `{current}`\n\n**Available models**:\n"
+    elif bridge is not None:
+        # Session exists but model not yet determined (pre-first-turn)
+        header = "**Current**: _(unset — will use CLI default)_\n\n**Available models**:\n"
     else:
-        header = "_No active session in this channel; current model unknown._\n\n**Available models**:\n"
+        header = "_No active session. Run inside a thread to see current model._\n\n**Available models**:\n"
     embed = discord.Embed(
         title="🤖 Model Selection",
         description=header + desc + "\n\nUse `/model switch <name>` to switch.\n-# Switching resets the conversation context.",
@@ -190,7 +194,7 @@ async def model_current(interaction: discord.Interaction) -> None:
     bridge = _resolve_session_bridge(bot, interaction.channel)
     if bridge is None:
         await interaction.response.send_message(
-            "ℹ️ No active session in this channel. Send a message to start one.",
+            "ℹ️ No active session. Run inside a thread to see current model.",
             ephemeral=True,
         )
         return

--- a/src/clauded/cogs/model.py
+++ b/src/clauded/cogs/model.py
@@ -17,11 +17,15 @@ log = logging.getLogger("clauded.bot")
 # releases new SKUs. Order is intentional — user-facing list preserves
 # this ordering (most-common balanced first, then deep, then fast,
 # then context-window-extended variants).
+# #247: refresh to current SKUs (claude-sonnet-4-6, claude-opus-4-7,
+# claude-haiku-4-5, claude-sonnet-4-6-1m). Old table referenced
+# claude-sonnet-4-5 / claude-opus-4-1 / claude-haiku-3-5 — a full
+# generation behind what the SDK was returning on ResultMessage.
 KNOWN_MODELS: dict[str, dict[str, str | int]] = {
-    "sonnet":   {"id": "claude-sonnet-4-5",     "context": 200_000, "tier": "balanced"},
-    "opus":     {"id": "claude-opus-4-1",       "context": 200_000, "tier": "deep"},
-    "haiku":    {"id": "claude-haiku-3-5",      "context": 200_000, "tier": "fast"},
-    "sonnet-1m":{"id": "claude-sonnet-4-5-1m",  "context": 1_000_000, "tier": "balanced"},
+    "sonnet":   {"id": "claude-sonnet-4-6",     "context": 200_000, "tier": "balanced"},
+    "opus":     {"id": "claude-opus-4-7",       "context": 1_000_000, "tier": "deep"},
+    "haiku":    {"id": "claude-haiku-4-5",      "context": 200_000, "tier": "fast"},
+    "sonnet-1m":{"id": "claude-sonnet-4-6-1m",  "context": 1_000_000, "tier": "balanced"},
 }
 
 
@@ -38,18 +42,48 @@ def _fmt_context(n: int) -> str:
     return str(n)
 
 
-def _current_model_for_thread(bot, thread_id: int | None) -> str | None:
-    """Return the active model name for ``thread_id`` if a session exists,
-    else None. Resolves through ``bridge.model`` which already follows
+def _resolve_session_bridge(bot, channel):
+    """#247 Bug B/C: shared session lookup for /model list and /model current.
+
+    Look up the session by ``channel.id`` first. If no session is found
+    and ``channel`` is a :class:`discord.Thread`, fall back to the
+    parent channel id (handles the case where the user is inside a
+    thread but the session was keyed on the parent channel).
+
+    Returns the bridge or ``None``. ``channel`` may be ``None`` (e.g.
+    DM or cache miss) — caller-friendly.
+    """
+    if channel is None:
+        return None
+    channel_id = getattr(channel, "id", None)
+    if channel_id is None:
+        return None
+    bridge = bot.session_manager.get_session(channel_id)
+    if bridge is not None:
+        return bridge
+    # #247 Bug B: thread → parent fallback. ``isinstance`` check first
+    # so non-Thread channels (DMChannel / TextChannel / etc.) short-circuit.
+    if isinstance(channel, discord.Thread):
+        parent_id = getattr(channel, "parent_id", None)
+        if parent_id is not None:
+            return bot.session_manager.get_session(parent_id)
+    return None
+
+
+def _current_model_for_thread(bot, channel) -> str | None:
+    """Return the active model name for the session bound to ``channel``,
+    else ``None``. Resolves through ``bridge.model`` which already follows
     the override > sdk-reported > config-default chain.
 
     #198: ``bridge.model`` may legitimately return ``None`` now (no
     override, no env, no first turn yet). Callers should treat ``None``
     as a valid signal rather than 'no session'.
+
+    #247: now goes through :func:`_resolve_session_bridge` so this helper
+    shares thread→parent fallback semantics with ``/model current``
+    (eliminates the list/current inconsistency).
     """
-    if thread_id is None:
-        return None
-    bridge = bot.session_manager.get_session(thread_id)
+    bridge = _resolve_session_bridge(bot, channel)
     if bridge is None:
         return None
     return getattr(bridge, "model", None)
@@ -117,8 +151,7 @@ async def model_list(interaction: discord.Interaction) -> None:
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
-    thread_id = getattr(interaction.channel, "id", None)
-    current = _current_model_for_thread(bot, thread_id)
+    current = _current_model_for_thread(bot, interaction.channel)
     # Build the rendered list
     lines = []
     for alias, info in KNOWN_MODELS.items():
@@ -148,13 +181,13 @@ async def model_current(interaction: discord.Interaction) -> None:
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
-    thread_id = getattr(interaction.channel, "id", None)
     # #198: don't collapse via ``bridge.model`` — we need to know which
     # tier the value came from so we can label it correctly. Resolve the
     # bridge directly and dispatch on the 4 tier cases.
-    bridge = (
-        bot.session_manager.get_session(thread_id) if thread_id is not None else None
-    )
+    # #247 Bug C: share session-resolution logic with ``/model list`` via
+    # ``_resolve_session_bridge`` so the two commands cannot disagree on
+    # whether a session exists for the current channel/thread.
+    bridge = _resolve_session_bridge(bot, interaction.channel)
     if bridge is None:
         await interaction.response.send_message(
             "ℹ️ No active session in this channel. Send a message to start one.",

--- a/tests/test_model_cmd.py
+++ b/tests/test_model_cmd.py
@@ -29,18 +29,59 @@ def test_fmt_context_renders_k_and_m():
 def test_current_model_for_thread_returns_bridge_model():
     from clauded.cogs.model import _current_model_for_thread
     bot = MagicMock()
-    bridge = MagicMock(model="claude-sonnet-4-5")
+    bridge = MagicMock(model="claude-sonnet-4-6")
     bot.session_manager.get_session = MagicMock(return_value=bridge)
-    assert _current_model_for_thread(bot, 42) == "claude-sonnet-4-5"
+    # #247: helper now takes a channel-like object (not a bare int) so it
+    # can introspect for thread→parent fallback. Use a plain MagicMock with
+    # ``.id`` set; ``isinstance(channel, discord.Thread)`` is False so
+    # no fallback path is exercised here.
+    channel = MagicMock(spec=[])
+    channel.id = 42
+    assert _current_model_for_thread(bot, channel) == "claude-sonnet-4-6"
 
 
 def test_current_model_for_thread_none_when_no_session():
     from clauded.cogs.model import _current_model_for_thread
     bot = MagicMock()
     bot.session_manager.get_session = MagicMock(return_value=None)
-    assert _current_model_for_thread(bot, 42) is None
-    # thread_id None -> short-circuit
+    channel = MagicMock(spec=[])
+    channel.id = 42
+    assert _current_model_for_thread(bot, channel) is None
+    # channel None -> short-circuit
     assert _current_model_for_thread(bot, None) is None
+
+
+def test_current_model_for_thread_falls_back_to_parent_for_thread():
+    """#247 Bug B: when channel is a discord.Thread and has no session of
+    its own, look up the session by ``parent_id``."""
+    import discord
+    from clauded.cogs.model import _current_model_for_thread
+    bot = MagicMock()
+    parent_bridge = MagicMock(model="claude-opus-4-7")
+
+    def _get(thread_id):
+        # Only the parent_id (777) has a session; the thread.id (42) does not.
+        return parent_bridge if thread_id == 777 else None
+
+    bot.session_manager.get_session = MagicMock(side_effect=_get)
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = 42
+    thread.parent_id = 777
+    assert _current_model_for_thread(bot, thread) == "claude-opus-4-7"
+
+
+def test_resolve_session_bridge_no_fallback_for_non_thread():
+    """#247 Bug B: only Thread channels get parent fallback — TextChannel
+    short-circuits on first miss."""
+    from clauded.cogs.model import _resolve_session_bridge
+    bot = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=None)
+    channel = MagicMock(spec=[])  # not a Thread; isinstance check is False
+    channel.id = 42
+    channel.parent_id = 999  # should be ignored
+    assert _resolve_session_bridge(bot, channel) is None
+    # session_manager called exactly once (no parent fallback)
+    bot.session_manager.get_session.assert_called_once_with(42)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #247. Updates KNOWN_MODELS to claude-sonnet-4-6/opus-4-7/haiku-4-5. Adds _resolve_session_bridge for thread→parent fallback. Unifies list/current session detection. 1200 passed.