### PR TITLE
fix(#250): resolve_session_id helper + 5 sibling session-lookup fixes

### DIFF
--- a/docs/prd/fix-250-session-resolve.md
+++ b/docs/prd/fix-250-session-resolve.md
@@ -1,0 +1,22 @@
+# PRD — #250 resolve_session_id + 5 sibling fixes
+
+**Issue**: #250 (epic, P1)
+**Branch**: `fix/250-session-resolve`
+**Status**: APPROVED
+
+## Problem
+5 cog commands use `interaction.channel.id` to look up sessions, but sessions are keyed by thread_id. In channels (non-thread), this always returns None → misleading "no active session" instead of "use in a thread".
+
+## Approach
+1. Create `resolve_session_id(interaction) -> int | None` helper in `cogs/_unbound.py` that returns `interaction.channel.id` only if channel is a Thread, else None.
+2. Apply to all 5 sibling sites:
+   - mode.py: /mode set, /mode cycle, /mode current
+   - ops.py: /health, /notify
+3. When resolve_session_id returns None → ephemeral "Use this command inside a thread."
+
+## AC (from issue)
+- AC1: resolve_session_id returns thread_id for Thread, None for channel
+- AC2: 5 sites → "Use in a thread" in channel, correct session in thread
+- AC3: grep lint test
+- AC4: #247 already fixed (done in PR #268)
+- AC5: /notify in channel → "Use in a thread"

--- a/src/clauded/cogs/_unbound.py
+++ b/src/clauded/cogs/_unbound.py
@@ -31,6 +31,13 @@ UNBOUND_HINT_MESSAGE = (
 
 NO_CHANNEL_MESSAGE = "❌ This command must be run in a channel."
 
+# #250: unified refusal for the 5 sibling sites where a per-thread
+# session lookup must reject channel/DM invocation rather than silently
+# returning "no active session". Mirrors :data:`NO_CHANNEL_MESSAGE`
+# above but is thread-specific. Centralized here so cogs/mode.py and
+# cogs/ops.py share one source of truth (DRY — R1 reviewer finding).
+USE_IN_THREAD_MESSAGE = "Use this command inside a thread."
+
 
 def resolve_channel_id(interaction: discord.Interaction) -> int | None:
     """Resolve the channel id used for **session-level state** lookups.

--- a/src/clauded/cogs/_unbound.py
+++ b/src/clauded/cogs/_unbound.py
@@ -58,6 +58,29 @@ def resolve_channel_id(interaction: discord.Interaction) -> int | None:
     return ch.id
 
 
+def resolve_session_id(interaction: discord.Interaction) -> int | None:
+    """Resolve the session id (``thread.id``) for **per-thread live state** lookups.
+
+    Returns ``interaction.channel.id`` only when invoked from inside a
+    :class:`discord.Thread`. For any other surface (top-level
+    :class:`~discord.TextChannel`, :class:`~discord.DMChannel`, cache
+    miss, etc.) returns ``None`` so callers must surface a friendly
+    "use this command inside a thread" message rather than silently
+    falling through to ``session_manager.get_session(None)``.
+
+    Sibling of :func:`resolve_binding_id` (binding state is keyed by
+    parent; session state is keyed by thread). See #197 / #209 / #247
+    / #250 for the bug lineage that motivated this helper. Use this
+    helper anywhere live SDK ``ClaudeBridge`` / per-thread settings
+    (e.g. ``_notify_enabled``) are read or written — never pass raw
+    ``interaction.channel_id`` or ``getattr(interaction.channel, "id", None)``.
+    """
+    channel = interaction.channel
+    if isinstance(channel, discord.Thread):
+        return channel.id
+    return None
+
+
 def resolve_binding_id(interaction: discord.Interaction) -> int | None:
     """Resolve the channel id for **project-level state** lookups.
 

--- a/src/clauded/cogs/mode.py
+++ b/src/clauded/cogs/mode.py
@@ -21,7 +21,7 @@ import logging
 import discord
 from discord import app_commands
 
-from ._unbound import resolve_session_id
+from ._unbound import USE_IN_THREAD_MESSAGE, resolve_session_id
 from ..discord_renderer import (
     COLOR_INFO,
     COLOR_TOOL_FAILURE,
@@ -29,12 +29,6 @@ from ..discord_renderer import (
     MODE_EMOJI,
 )
 
-
-# #250: unified message for the 5 sibling sites where a per-thread
-# session lookup must reject channel/DM invocation rather than silently
-# returning "no active session". Mirrors the existing NO_CHANNEL_MESSAGE
-# in _unbound.py but is thread-specific.
-_USE_IN_THREAD_MESSAGE = "Use this command inside a thread."
 
 log = logging.getLogger("clauded.bot")
 
@@ -179,7 +173,7 @@ async def mode_set(
     thread_id = resolve_session_id(interaction)
     if thread_id is None:
         await interaction.response.send_message(
-            _USE_IN_THREAD_MESSAGE, ephemeral=True
+            USE_IN_THREAD_MESSAGE, ephemeral=True
         )
         return
     bridge = bot.session_manager.get_session(thread_id)
@@ -262,7 +256,7 @@ async def mode_cycle(interaction: discord.Interaction) -> None:
     thread_id = resolve_session_id(interaction)
     if thread_id is None:
         await interaction.response.send_message(
-            _USE_IN_THREAD_MESSAGE, ephemeral=True
+            USE_IN_THREAD_MESSAGE, ephemeral=True
         )
         return
     bridge = bot.session_manager.get_session(thread_id)
@@ -332,7 +326,7 @@ async def mode_current(interaction: discord.Interaction) -> None:
     thread_id = resolve_session_id(interaction)
     if thread_id is None:
         await interaction.response.send_message(
-            _USE_IN_THREAD_MESSAGE, ephemeral=True
+            USE_IN_THREAD_MESSAGE, ephemeral=True
         )
         return
     bridge = bot.session_manager.get_session(thread_id)

--- a/src/clauded/cogs/mode.py
+++ b/src/clauded/cogs/mode.py
@@ -21,12 +21,20 @@ import logging
 import discord
 from discord import app_commands
 
+from ._unbound import resolve_session_id
 from ..discord_renderer import (
     COLOR_INFO,
     COLOR_TOOL_FAILURE,
     COLOR_TOOL_SUCCESS,
     MODE_EMOJI,
 )
+
+
+# #250: unified message for the 5 sibling sites where a per-thread
+# session lookup must reject channel/DM invocation rather than silently
+# returning "no active session". Mirrors the existing NO_CHANNEL_MESSAGE
+# in _unbound.py but is thread-specific.
+_USE_IN_THREAD_MESSAGE = "Use this command inside a thread."
 
 log = logging.getLogger("clauded.bot")
 
@@ -168,10 +176,13 @@ async def mode_set(
             ephemeral=True,
         )
         return
-    thread_id = getattr(interaction.channel, "id", None)
-    bridge = (
-        bot.session_manager.get_session(thread_id) if thread_id is not None else None
-    )
+    thread_id = resolve_session_id(interaction)
+    if thread_id is None:
+        await interaction.response.send_message(
+            _USE_IN_THREAD_MESSAGE, ephemeral=True
+        )
+        return
+    bridge = bot.session_manager.get_session(thread_id)
     if bridge is None or not bridge.is_active:
         await interaction.response.send_message(
             "ℹ️ No active session in this channel. Send a message to start one, "
@@ -248,10 +259,13 @@ async def mode_cycle(interaction: discord.Interaction) -> None:
             ephemeral=True,
         )
         return
-    thread_id = getattr(interaction.channel, "id", None)
-    bridge = (
-        bot.session_manager.get_session(thread_id) if thread_id is not None else None
-    )
+    thread_id = resolve_session_id(interaction)
+    if thread_id is None:
+        await interaction.response.send_message(
+            _USE_IN_THREAD_MESSAGE, ephemeral=True
+        )
+        return
+    bridge = bot.session_manager.get_session(thread_id)
     if bridge is None or not bridge.is_active:
         await interaction.response.send_message(
             "ℹ️ No active session in this channel. Send a message to start one.",
@@ -315,10 +329,13 @@ async def mode_current(interaction: discord.Interaction) -> None:
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
-    thread_id = getattr(interaction.channel, "id", None)
-    bridge = (
-        bot.session_manager.get_session(thread_id) if thread_id is not None else None
-    )
+    thread_id = resolve_session_id(interaction)
+    if thread_id is None:
+        await interaction.response.send_message(
+            _USE_IN_THREAD_MESSAGE, ephemeral=True
+        )
+        return
+    bridge = bot.session_manager.get_session(thread_id)
     if bridge is None:
         await interaction.response.send_message(
             "ℹ️ No active session in this channel. Send a message to start one.",

--- a/src/clauded/cogs/ops.py
+++ b/src/clauded/cogs/ops.py
@@ -10,7 +10,13 @@ from pathlib import Path
 import discord
 from discord import app_commands
 
-from ._unbound import NO_CHANNEL_MESSAGE, reject_if_unbound, resolve_binding_id, resolve_session_id
+from ._unbound import (
+    NO_CHANNEL_MESSAGE,
+    USE_IN_THREAD_MESSAGE,
+    reject_if_unbound,
+    resolve_binding_id,
+    resolve_session_id,
+)
 from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE
 from ..interaction_handler import InteractionHandler
 from ..session_config import SessionConfig
@@ -120,7 +126,7 @@ async def health_check(interaction: discord.Interaction) -> None:
     thread_id = resolve_session_id(interaction)
     if thread_id is None:
         await interaction.response.send_message(
-            "Use this command inside a thread.", ephemeral=True
+            USE_IN_THREAD_MESSAGE, ephemeral=True
         )
         return
     bridge = bot.session_manager.get_session(thread_id)
@@ -398,7 +404,7 @@ async def notify_toggle(interaction: discord.Interaction) -> None:
     tid = resolve_session_id(interaction)
     if tid is None:
         await interaction.response.send_message(
-            "Use this command inside a thread.", ephemeral=True
+            USE_IN_THREAD_MESSAGE, ephemeral=True
         )
         return
     current = bot._notify_enabled.get(tid, True)

--- a/src/clauded/cogs/ops.py
+++ b/src/clauded/cogs/ops.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import discord
 from discord import app_commands
 
-from ._unbound import NO_CHANNEL_MESSAGE, reject_if_unbound, resolve_binding_id
+from ._unbound import NO_CHANNEL_MESSAGE, reject_if_unbound, resolve_binding_id, resolve_session_id
 from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE
 from ..interaction_handler import InteractionHandler
 from ..session_config import SessionConfig
@@ -114,10 +114,16 @@ async def health_check(interaction: discord.Interaction) -> None:
     # in scope), in which case we silently skip the field. Centralized
     # ``_format_mode_display`` keeps the label format in sync with
     # ``/mode current`` + ``/session info``.
-    thread_id = getattr(interaction.channel, "id", None)
-    bridge = (
-        bot.session_manager.get_session(thread_id) if thread_id is not None else None
-    )
+    # #250: gate the session lookup behind resolve_session_id so a
+    # channel/DM invocation refuses with the unified "Use this command
+    # inside a thread." message instead of silently hiding the field.
+    thread_id = resolve_session_id(interaction)
+    if thread_id is None:
+        await interaction.response.send_message(
+            "Use this command inside a thread.", ephemeral=True
+        )
+        return
+    bridge = bot.session_manager.get_session(thread_id)
     if bridge is not None:
         from .mode import _mode_source_for_bridge, _format_mode_display
 
@@ -384,14 +390,20 @@ async def notify_toggle(interaction: discord.Interaction) -> None:
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
-    tid = interaction.channel_id
-    if tid is not None:
-        current = bot._notify_enabled.get(tid, True)
-        bot._notify_enabled[tid] = not current
-        state = "ON" if not current else "OFF"
-    else:
-        bot._pre_tool_notifications = not bot._pre_tool_notifications
-        state = "ON" if bot._pre_tool_notifications else "OFF"
+    # #250: ``_notify_enabled`` is keyed by thread.id (bot.py reads it
+    # with thread.id when rendering messages). Writing to it from a
+    # channel/DM would land under channel.id and never be read back,
+    # producing a silent no-op. Gate behind resolve_session_id so the
+    # caller gets a clear refusal instead.
+    tid = resolve_session_id(interaction)
+    if tid is None:
+        await interaction.response.send_message(
+            "Use this command inside a thread.", ephemeral=True
+        )
+        return
+    current = bot._notify_enabled.get(tid, True)
+    bot._notify_enabled[tid] = not current
+    state = "ON" if not current else "OFF"
     await interaction.response.send_message(
         embed=discord.Embed(
             title=f"🔔 Pre-tool notifications: {state}",

--- a/tests/test_permission_mode.py
+++ b/tests/test_permission_mode.py
@@ -563,6 +563,7 @@ async def test_session_resume_threads_permission_mode_override() -> None:
 async def test_mode_set_calls_bridge_and_persists() -> None:
     from clauded.cogs.mode import mode_set
     from clauded.bot import ClaudedBot
+    import discord
 
     bridge = _bridge(override=None, env_mode="default")
     bot = MagicMock(spec=ClaudedBot)
@@ -572,10 +573,12 @@ async def test_mode_set_calls_bridge_and_persists() -> None:
 
     interaction = MagicMock()
     interaction.client = bot
+    # #250: resolve_session_id requires isinstance(channel, discord.Thread)
+    interaction.channel = MagicMock(spec=discord.Thread)
     interaction.channel.id = 1
+    interaction.user.guild_permissions = MagicMock(administrator=True)
     interaction.response.send_message = AsyncMock()
 
-    import discord
     choice = discord.app_commands.Choice(name="plan 🔒", value="plan")
     await mode_set.callback(interaction, choice)
 
@@ -593,6 +596,7 @@ async def test_mode_set_calls_bridge_and_persists() -> None:
 async def test_mode_set_no_session_replies_with_hint() -> None:
     from clauded.cogs.mode import mode_set
     from clauded.bot import ClaudedBot
+    import discord
 
     bot = MagicMock(spec=ClaudedBot)
     bot.session_manager = MagicMock()
@@ -600,10 +604,12 @@ async def test_mode_set_no_session_replies_with_hint() -> None:
 
     interaction = MagicMock()
     interaction.client = bot
+    # #250: resolve_session_id requires isinstance(channel, discord.Thread)
+    interaction.channel = MagicMock(spec=discord.Thread)
     interaction.channel.id = 1
+    interaction.user.guild_permissions = MagicMock(administrator=True)
     interaction.response.send_message = AsyncMock()
 
-    import discord
     choice = discord.app_commands.Choice(name="plan", value="plan")
     await mode_set.callback(interaction, choice)
     args = interaction.response.send_message.await_args
@@ -638,7 +644,11 @@ async def test_mode_cycle_five_steps_returns_to_default() -> None:
 
     interaction = MagicMock()
     interaction.client = bot
+    # #250: resolve_session_id requires isinstance(channel, discord.Thread)
+    import discord as _discord
+    interaction.channel = MagicMock(spec=_discord.Thread)
     interaction.channel.id = 7
+    interaction.user.guild_permissions = MagicMock(administrator=True)
     interaction.response.send_message = AsyncMock()
 
     expected_sequence = [
@@ -658,6 +668,7 @@ async def test_mode_cycle_five_steps_returns_to_default() -> None:
 async def test_mode_current_displays_source_override() -> None:
     from clauded.cogs.mode import mode_current
     from clauded.bot import ClaudedBot
+    import discord
 
     bridge = _bridge(override="plan", env_mode="default")
     bot = MagicMock(spec=ClaudedBot)
@@ -666,6 +677,8 @@ async def test_mode_current_displays_source_override() -> None:
 
     interaction = MagicMock()
     interaction.client = bot
+    # #250: resolve_session_id requires isinstance(channel, discord.Thread)
+    interaction.channel = MagicMock(spec=discord.Thread)
     interaction.channel.id = 1
     interaction.response.send_message = AsyncMock()
     await mode_current.callback(interaction)
@@ -679,6 +692,7 @@ async def test_mode_current_displays_source_override() -> None:
 async def test_mode_current_displays_source_env() -> None:
     from clauded.cogs.mode import mode_current
     from clauded.bot import ClaudedBot
+    import discord
 
     bridge = _bridge(override=None, env_mode="acceptEdits")
     bot = MagicMock(spec=ClaudedBot)
@@ -687,6 +701,7 @@ async def test_mode_current_displays_source_env() -> None:
 
     interaction = MagicMock()
     interaction.client = bot
+    interaction.channel = MagicMock(spec=discord.Thread)
     interaction.channel.id = 1
     interaction.response.send_message = AsyncMock()
     await mode_current.callback(interaction)
@@ -700,6 +715,7 @@ async def test_mode_current_displays_source_env() -> None:
 async def test_mode_current_displays_source_default() -> None:
     from clauded.cogs.mode import mode_current
     from clauded.bot import ClaudedBot
+    import discord
 
     bridge = _bridge(override=None, env_mode="default")
     bot = MagicMock(spec=ClaudedBot)
@@ -708,6 +724,7 @@ async def test_mode_current_displays_source_default() -> None:
 
     interaction = MagicMock()
     interaction.client = bot
+    interaction.channel = MagicMock(spec=discord.Thread)
     interaction.channel.id = 1
     interaction.response.send_message = AsyncMock()
     await mode_current.callback(interaction)
@@ -835,6 +852,7 @@ async def test_footer_omits_mode_line_when_default(
 async def test_health_displays_permission_mode_when_session_active() -> None:
     from clauded.cogs.ops import health_check
     from clauded.bot import ClaudedBot
+    import discord
 
     bridge = _bridge(override="plan", env_mode="default")
     bot = MagicMock(spec=ClaudedBot)
@@ -848,7 +866,8 @@ async def test_health_displays_permission_mode_when_session_active() -> None:
 
     interaction = MagicMock()
     interaction.client = bot
-    interaction.channel = MagicMock()
+    # #250: resolve_session_id requires isinstance(channel, discord.Thread)
+    interaction.channel = MagicMock(spec=discord.Thread)
     interaction.channel.id = 1
     interaction.response.send_message = AsyncMock()
     await health_check.callback(interaction)
@@ -1066,6 +1085,8 @@ async def test_mode_set_emits_security_audit_log(caplog):
 
     interaction = MagicMock()
     interaction.client = bot_spec
+    # #250: resolve_session_id requires isinstance(channel, discord.Thread)
+    interaction.channel = MagicMock(spec=discord.Thread)
     interaction.channel.id = 42
     interaction.guild_id = 99
     interaction.channel_id = 42

--- a/tests/test_session_id_resolution.py
+++ b/tests/test_session_id_resolution.py
@@ -9,18 +9,23 @@ returning ``None`` for any non-thread surface so the caller can surface
 a uniform "Use this command inside a thread." refusal.
 
 This file covers the AC1 unit-test surface of the issue (channel-type
-matrix). The 5-site behavior change is exercised end-to-end by the
-existing cog tests (test_permission_mode.py for /mode set/cycle/current,
-ad-hoc smoke for /health + /notify).
+matrix), the AC3 grep-lint surface (no cog calls
+``session_manager.get_session(interaction.channel...`` raw — must flow
+through ``resolve_session_id``), and the per-site refusal contract for
+the 5 migrated cog sites (``/mode set``, ``/mode cycle``,
+``/mode current``, ``/health``, ``/notify``).
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import discord
+import pytest
 
-from clauded.cogs._unbound import resolve_session_id
+from clauded.cogs._unbound import USE_IN_THREAD_MESSAGE, resolve_session_id
 
 
 def test_resolve_session_id_thread_returns_thread_id() -> None:
@@ -64,3 +69,284 @@ def test_resolve_session_id_none_channel_returns_none() -> None:
     interaction.channel_id = 222
 
     assert resolve_session_id(interaction) is None
+
+
+# ---------------------------------------------------------------------------
+# AC3 — Audit grep lint (mirror of
+# ``test_no_cog_passes_raw_channel_id_to_project_manager`` in
+# tests/test_binding_id_resolution.py for the session-lookup surface).
+#
+# Manager protocol: pre-commit, temporarily revert one fix site to
+# ``bot.session_manager.get_session(interaction.channel.id)`` (or
+# ``getattr(interaction.channel, "id", None)``) — this test MUST fail
+# pointing at that line. Revert the revert; this test passes again.
+# ---------------------------------------------------------------------------
+
+
+def test_no_cog_passes_raw_channel_to_session_manager() -> None:
+    """Lint test: every cog call to ``bot.session_manager.get_session(...)``
+    must source the thread id from ``resolve_session_id`` — i.e. from a
+    variable named ``thread_id`` or ``tid``, never from a raw
+    ``interaction.channel.*`` expression.
+
+    This is a source-level substring grep (not AST) because perfect is
+    the enemy of good for this defensive lint. Two forbidden inline
+    patterns:
+
+      1. ``session_manager.get_session(interaction.channel.id``
+      2. ``session_manager.get_session(getattr(interaction.channel,``
+
+    Bypass still possible by binding ``interaction.channel.id`` to a
+    local var with a misleading name (e.g. ``tid = interaction.channel.id``);
+    PRD §Risks documents this as accepted fragility, the trip-wire is
+    the inline-access shape that produced the original five #250 bugs.
+
+    Headline scope: ``cogs/mode.py`` + ``cogs/ops.py`` (the two files
+    migrated by this PR) must have 0 hits. We assert the lint over all
+    ``cogs/*.py`` so a future cog backsliding into the same pattern
+    trips the test, matching the sibling-lint discipline established
+    in #209's audit test.
+    """
+    cogs_dir = Path(__file__).resolve().parent.parent / "src" / "clauded" / "cogs"
+    forbidden_patterns = (
+        re.compile(
+            r"session_manager\.get_session\(\s*interaction\.channel\.id\b",
+            re.MULTILINE,
+        ),
+        re.compile(
+            r"session_manager\.get_session\(\s*getattr\(\s*interaction\.channel\b",
+            re.MULTILINE,
+        ),
+    )
+    violations: list[str] = []
+    for cog_file in cogs_dir.glob("*.py"):
+        text = cog_file.read_text()
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            for pat in forbidden_patterns:
+                if pat.search(line):
+                    violations.append(f"{cog_file.name}:{line_no}: {line.strip()}")
+                    break  # don't double-report
+
+    # Headline scope assertion: the two migrated files must be clean.
+    headline = [v for v in violations if v.startswith(("mode.py:", "ops.py:"))]
+    assert not headline, (
+        "cogs/mode.py + cogs/ops.py must use resolve_session_id(interaction) "
+        "(variable named `thread_id` / `tid`), not raw "
+        "`interaction.channel.id` / `getattr(interaction.channel, ...)` when "
+        "calling session_manager.get_session(). Violations:\n"
+        + "\n".join(headline)
+    )
+    # Whole-cogs assertion (defense for future cogs).
+    assert not violations, (
+        "Cogs must use resolve_session_id(interaction) when calling "
+        "session_manager.get_session(). Violations:\n" + "\n".join(violations)
+    )
+
+
+def test_audit_grep_catches_inline_interaction_channel_id_pattern() -> None:
+    """Smoke test for the AC3 lint regex itself — positive + negative.
+
+    Mirror of ``test_audit_grep_catches_inline_interaction_channel_id_pattern``
+    in tests/test_binding_id_resolution.py. Guards against a regex typo
+    silently disabling the lint (R1 architect finding pattern).
+    """
+    pat_dot = re.compile(
+        r"session_manager\.get_session\(\s*interaction\.channel\.id\b"
+    )
+    pat_getattr = re.compile(
+        r"session_manager\.get_session\(\s*getattr\(\s*interaction\.channel\b"
+    )
+    # Positive matches
+    bad_dot = "bridge = bot.session_manager.get_session(interaction.channel.id)"
+    bad_getattr = (
+        "bridge = bot.session_manager.get_session("
+        "getattr(interaction.channel, 'id', None))"
+    )
+    assert pat_dot.search(bad_dot) is not None
+    assert pat_getattr.search(bad_getattr) is not None
+    # Negative: resolved-var path OK.
+    good = "bridge = bot.session_manager.get_session(thread_id)"
+    assert pat_dot.search(good) is None
+    assert pat_getattr.search(good) is None
+
+
+# ---------------------------------------------------------------------------
+# Per-site refusal tests — one per migrated cog site (5 total).
+#
+# Each test mocks an interaction whose channel is a TextChannel (not
+# Thread), invokes the command callback, and asserts the response is
+# an ephemeral reply containing the substring "thread". This pins the
+# end-to-end contract: every migrated site refuses non-thread invocation
+# with the unified ``USE_IN_THREAD_MESSAGE`` (rather than silently
+# returning a "no active session" or producing a no-op write).
+# ---------------------------------------------------------------------------
+
+
+def _make_text_channel_interaction() -> MagicMock:
+    """Build an Interaction whose channel is a top-level TextChannel.
+
+    The 5 migrated callbacks all gate behind ``resolve_session_id`` which
+    returns ``None`` for any non-Thread surface; a ``TextChannel`` is the
+    most common refusal trigger and exercises the same code path as
+    DMChannel + cache-miss (covered separately by the AC1 unit tests
+    above).
+    """
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = 444
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = channel
+    interaction.channel_id = 444
+    interaction.guild_id = 7777
+    # Admin permissions so the /mode set + /mode cycle gates pass and we
+    # actually reach the resolve_session_id check (not the admin refusal).
+    interaction.user = MagicMock()
+    interaction.user.guild_permissions = MagicMock(administrator=True)
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_bot_with_session_manager() -> MagicMock:
+    """Build a ClaudedBot mock with a session_manager that would raise if
+    the refusal short-circuit fails (so we get a loud signal if a site
+    regresses to ``get_session(None)`` rather than refusing first)."""
+    from clauded.bot import ClaudedBot
+
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    # If a callback regresses and calls get_session anyway, raise loudly.
+    bot.session_manager.get_session = MagicMock(
+        side_effect=AssertionError(
+            "regression: callback reached session_manager.get_session() in a "
+            "non-thread context instead of refusing via USE_IN_THREAD_MESSAGE"
+        )
+    )
+    bot._notify_enabled = {}
+    bot._start_time = 0.0
+    bot._claude_version = "test"
+    bot._debug_logging = False
+    bot.allow_unbound_fallback = False
+    bot.project_manager = MagicMock()
+    bot.project_manager._projects = {}
+    bot.cost_tracker = MagicMock()
+    return bot
+
+
+def _assert_thread_refusal(interaction: MagicMock) -> None:
+    """Shared assertion: response was an ephemeral message mentioning ``thread``.
+
+    Centralized so a future tweak to the refusal copy (e.g. emoji prefix)
+    only needs to update one assertion. Substring match on ``thread``
+    (case-insensitive) intentionally lenient — pins the behavior class,
+    not the exact wording.
+    """
+    assert interaction.response.send_message.await_count == 1, (
+        "Expected exactly one ephemeral refusal reply"
+    )
+    call = interaction.response.send_message.await_args
+    msg = call.args[0]
+    assert "thread" in msg.lower(), (
+        f"Refusal must mention 'thread'; got {msg!r}"
+    )
+    assert call.kwargs.get("ephemeral") is True, (
+        "Refusal must be ephemeral"
+    )
+    # And it must be the centralized constant, not a drifted inline copy.
+    assert msg == USE_IN_THREAD_MESSAGE, (
+        f"Refusal must use the shared USE_IN_THREAD_MESSAGE constant; "
+        f"got {msg!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mode_set_in_text_channel_refuses_with_thread_hint() -> None:
+    """``/mode set`` in a TextChannel must refuse with USE_IN_THREAD_MESSAGE."""
+    from clauded.cogs.mode import mode_set
+
+    interaction = _make_text_channel_interaction()
+    interaction.client = _make_bot_with_session_manager()
+
+    choice = discord.app_commands.Choice(name="plan 🔒", value="plan")
+    await mode_set.callback(interaction, choice)
+
+    _assert_thread_refusal(interaction)
+
+
+@pytest.mark.asyncio
+async def test_mode_cycle_in_text_channel_refuses_with_thread_hint() -> None:
+    """``/mode cycle`` in a TextChannel must refuse with USE_IN_THREAD_MESSAGE."""
+    from clauded.cogs.mode import mode_cycle
+
+    interaction = _make_text_channel_interaction()
+    interaction.client = _make_bot_with_session_manager()
+
+    await mode_cycle.callback(interaction)
+
+    _assert_thread_refusal(interaction)
+
+
+@pytest.mark.asyncio
+async def test_mode_current_in_text_channel_refuses_with_thread_hint() -> None:
+    """``/mode current`` in a TextChannel must refuse with USE_IN_THREAD_MESSAGE."""
+    from clauded.cogs.mode import mode_current
+
+    interaction = _make_text_channel_interaction()
+    interaction.client = _make_bot_with_session_manager()
+
+    await mode_current.callback(interaction)
+
+    _assert_thread_refusal(interaction)
+
+
+@pytest.mark.asyncio
+async def test_health_in_text_channel_refuses_with_thread_hint() -> None:
+    """``/health`` in a TextChannel must refuse with USE_IN_THREAD_MESSAGE.
+
+    ``/health`` is a slightly different surface than the /mode subcommands:
+    it builds an embed first and only then gates behind resolve_session_id.
+    The refusal must still fire (the embed must not be sent), so we assert
+    on send_message exclusively — followup.send must NOT be called.
+    """
+    from clauded.cogs.ops import health_check
+
+    interaction = _make_text_channel_interaction()
+    interaction.client = _make_bot_with_session_manager()
+    # Make list_sessions safe (called before the refusal branch).
+    interaction.client.session_manager.list_sessions = MagicMock(return_value=[])
+
+    await health_check.callback(interaction)
+
+    _assert_thread_refusal(interaction)
+    # Belt-and-suspenders: the embed-success path must NOT have been taken.
+    # (send_message was called with the refusal string, not an embed kwarg.)
+    call = interaction.response.send_message.await_args
+    assert call.kwargs.get("embed") is None, (
+        "/health refusal path must not also send the health embed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_notify_in_text_channel_refuses_with_thread_hint() -> None:
+    """``/notify`` in a TextChannel must refuse with USE_IN_THREAD_MESSAGE.
+
+    Critical because ``_notify_enabled`` is a per-thread dict; a no-op
+    write under channel.id (the pre-fix behavior) would be silent and
+    never read back. This test pins the loud-refusal contract.
+    """
+    from clauded.cogs.ops import notify_toggle
+
+    interaction = _make_text_channel_interaction()
+    bot = _make_bot_with_session_manager()
+    interaction.client = bot
+
+    await notify_toggle.callback(interaction)
+
+    _assert_thread_refusal(interaction)
+    # And _notify_enabled must remain untouched.
+    assert bot._notify_enabled == {}, (
+        "/notify refusal path must not mutate _notify_enabled"
+    )

--- a/tests/test_session_id_resolution.py
+++ b/tests/test_session_id_resolution.py
@@ -1,0 +1,66 @@
+"""Unit tests for #250 — ``resolve_session_id`` helper.
+
+Sibling of ``tests/test_binding_id_resolution.py`` (#209). Sessions
+(live ``ClaudeBridge`` + per-thread settings such as
+``_notify_enabled``) are keyed by ``thread.id`` and must never fall
+through to a top-level :class:`discord.TextChannel` / :class:`DMChannel`
+/ cache-miss surface. ``resolve_session_id`` enforces that contract by
+returning ``None`` for any non-thread surface so the caller can surface
+a uniform "Use this command inside a thread." refusal.
+
+This file covers the AC1 unit-test surface of the issue (channel-type
+matrix). The 5-site behavior change is exercised end-to-end by the
+existing cog tests (test_permission_mode.py for /mode set/cycle/current,
+ad-hoc smoke for /health + /notify).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import discord
+
+from clauded.cogs._unbound import resolve_session_id
+
+
+def test_resolve_session_id_thread_returns_thread_id() -> None:
+    """In a Thread, returns the thread's own id (not parent_id)."""
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = 999
+    thread.parent_id = 555
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = thread
+    interaction.channel_id = 999
+
+    assert resolve_session_id(interaction) == 999
+
+
+def test_resolve_session_id_text_channel_returns_none() -> None:
+    """Top-level TextChannel must return None (force "use in thread" refusal)."""
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = 444
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = channel
+    interaction.channel_id = 444
+
+    assert resolve_session_id(interaction) is None
+
+
+def test_resolve_session_id_dm_returns_none() -> None:
+    """DM must also return None — no live session can exist outside a thread."""
+    dm = MagicMock(spec=discord.DMChannel)
+    dm.id = 333
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = dm
+    interaction.channel_id = 333
+
+    assert resolve_session_id(interaction) is None
+
+
+def test_resolve_session_id_none_channel_returns_none() -> None:
+    """Cache miss / permission gap — channel is None — must return None."""
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = None
+    interaction.channel_id = 222
+
+    assert resolve_session_id(interaction) is None


### PR DESCRIPTION
Closes #250. Adds resolve_session_id to _unbound.py. Fixes 5 sibling sites in mode.py + ops.py. 1232 passed.