### PR TITLE
fix(#280): cache context window on set_model to prevent stale maxTokens

### DIFF
--- a/docs/prd/fix-280-context-stale.md
+++ b/docs/prd/fix-280-context-stale.md
@@ -1,0 +1,23 @@
+# PRD — #280 /context stale maxTokens after model switch
+
+**Issue**: #280 (bug, P1)
+**Branch**: `fix/280-context-stale-maxtokens`
+**Status**: APPROVED
+
+## Problem
+After `/model switch opus`, `/context` shows maxTokens=200k (sonnet's) instead of 1M (opus's). SDK `get_context_usage()` returns stale maxTokens until the next API turn.
+
+## Approach (B hybrid)
+After `set_model()` succeeds in the cog handler, look up the new model's context window from KNOWN_MODELS and cache it on the bridge as `_context_window_override`. `compute_global_context_pct` checks this override before using SDK's maxTokens.
+
+## Files
+- `src/clauded/claude_bridge.py` — add `_context_window_override: int | None` field, set in `set_model()`
+- `src/clauded/_context_usage.py` — accept optional `max_tokens_override` param
+- `src/clauded/discord_renderer.py` — pass bridge's override to compute
+- `src/clauded/cogs/context.py` — same
+- Tests
+
+## AC
+- AC1: /context shows 1M maxTokens after switching to opus
+- AC2: percentage computed with correct denominator
+- AC3: override cleared on next real turn (SDK catches up)

--- a/src/clauded/_context_usage.py
+++ b/src/clauded/_context_usage.py
@@ -10,6 +10,7 @@ _FREE_SPACE_NAMES = frozenset({"Free space", "Available", "Remaining"})
 
 def compute_global_context_pct(
     cu: dict | None,
+    max_tokens_override: int | float | None = None,
 ) -> tuple[float, float, float] | None:
     """Return ``(global_used, max_tokens, percentage)`` or ``None``.
 
@@ -18,12 +19,30 @@ def compute_global_context_pct(
     input footprint and is used as a fallback when categories are absent.
 
     Returns ``None`` when the input is missing or unparseable.
+
+    Parameters
+    ----------
+    cu:
+        The raw ``ContextUsageResponse`` dict from the SDK.
+    max_tokens_override:
+        #280 — When the user runs ``/model switch opus`` mid-session,
+        the SDK keeps returning the previous model's ``maxTokens`` (e.g.
+        sonnet's 200k) until the next turn refreshes its metadata.
+        Callers that know the *real* window (e.g. via ``KNOWN_MODELS``
+        lookup cached on the bridge) can pass it here; when it differs
+        from ``cu["maxTokens"]`` the supplement and percentage are
+        recomputed against the override. We still derive ``global_used``
+        from the SDK's stale ``maxTokens`` ↔ ``free_space`` pair (those
+        two are internally consistent) so the *used* number stays
+        truthful — only the denominator (and resulting percentage)
+        switches to the override. Pass ``None`` (default) to preserve
+        legacy behaviour.
     """
     if cu is None:
         return None
 
-    max_t = cu.get("maxTokens")
-    if not isinstance(max_t, (int, float)) or max_t <= 0:
+    sdk_max = cu.get("maxTokens")
+    if not isinstance(sdk_max, (int, float)) or sdk_max <= 0:
         # No maxTokens → try SDK percentage as last resort
         if "percentage" not in cu:
             return None
@@ -33,9 +52,25 @@ def compute_global_context_pct(
         except (TypeError, ValueError):
             return None
 
-    max_t = float(max_t)
+    sdk_max = float(sdk_max)
 
-    # Primary: Free space supplement
+    # #280: use override iff it's valid AND differs from the SDK's value.
+    # When they match (post-refresh) keep SDK's value to avoid silently
+    # diverging once the SDK catches up.
+    if (
+        max_tokens_override is not None
+        and isinstance(max_tokens_override, (int, float))
+        and max_tokens_override > 0
+        and float(max_tokens_override) != sdk_max
+    ):
+        effective_max = float(max_tokens_override)
+    else:
+        effective_max = sdk_max
+
+    # Primary: Free space supplement. ``free_space`` is reported by the
+    # SDK against its own (possibly stale) ``maxTokens``, so we compute
+    # ``global_used`` against ``sdk_max`` (the matching pair) then
+    # express the percentage against ``effective_max``.
     categories = cu.get("categories") or []
     free_space = next(
         (c["tokens"] for c in categories
@@ -43,18 +78,18 @@ def compute_global_context_pct(
         None,
     )
     if free_space is not None and isinstance(free_space, (int, float)):
-        global_used = max(0.0, max_t - float(free_space))
-        return (global_used, max_t, (global_used / max_t) * 100.0)
+        global_used = max(0.0, sdk_max - float(free_space))
+        return (global_used, effective_max, (global_used / effective_max) * 100.0)
 
     # Fallback: totalTokens (pre-#263 behaviour)
     total = cu.get("totalTokens")
     if isinstance(total, (int, float)):
-        return (float(total), max_t, (float(total) / max_t) * 100.0)
+        return (float(total), effective_max, (float(total) / effective_max) * 100.0)
 
     # Last resort: SDK percentage
     if "percentage" in cu:
         try:
-            return (0.0, max_t, float(cu["percentage"]))
+            return (0.0, effective_max, float(cu["percentage"]))
         except (TypeError, ValueError):
             pass
 

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -131,6 +131,15 @@ class ClaudeBridge:
         self.total_cost: float = 0.0
         self.num_turns: int = 0
         self._sdk_model: str | None = None
+        # #280: cached context window for the active model. After a
+        # runtime ``/model switch`` the SDK's ``get_context_usage()``
+        # keeps returning the *old* model's ``maxTokens`` until the
+        # next turn refreshes its metadata. We populate this in
+        # :meth:`set_model` so ``/context`` and the footer 🧠 segment
+        # can display the correct denominator immediately. ``None``
+        # means "trust the SDK's value as-is" (no switch has happened
+        # yet, or we couldn't resolve the model in KNOWN_MODELS).
+        self._context_window_override: int | None = None
 
     @property
     def session_id(self) -> str | None:
@@ -252,11 +261,40 @@ class ClaudeBridge:
         and downstream consumers reflect the change. The SDK call
         happens FIRST so a rejection from the underlying CLI leaves
         our override unchanged (no lying display).
+
+        #280: also caches the new model's context window from
+        ``KNOWN_MODELS`` into ``_context_window_override``. The SDK's
+        ``get_context_usage()`` does NOT refresh its ``maxTokens`` /
+        ``rawMaxTokens`` until the next turn round-trips, so without
+        this cache ``/context`` and the footer 🧠 segment would
+        display the *previous* model's window (e.g. sonnet's 200k
+        instead of opus's 1M) until the user sends another message.
+        Unknown models leave the override unset so we fall back to
+        whatever the SDK eventually reports.
         """
         if self._client is None or not self._active:
             raise RuntimeError("bridge not active")
         await self._client.set_model(model)
         self._model_override = model
+        # #280: cache the new model's context window for /context display.
+        # Local import avoids a hard cog→bridge dependency cycle at import
+        # time; ``cogs.model`` already imports from this module's siblings.
+        from .cogs.model import KNOWN_MODELS
+        self._context_window_override = None
+        for info in KNOWN_MODELS.values():
+            model_id = info["id"]
+            if model == model_id or model.startswith(model_id):
+                ctx = info.get("context")
+                if isinstance(ctx, int) and ctx > 0:
+                    self._context_window_override = ctx
+                break
+        else:
+            # Alias-keyed lookup (e.g. user passed "opus" / "sonnet")
+            alias_info = KNOWN_MODELS.get(model)
+            if alias_info is not None:
+                ctx = alias_info.get("context")
+                if isinstance(ctx, int) and ctx > 0:
+                    self._context_window_override = ctx
 
     @property
     def is_active(self) -> bool:

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -281,20 +281,18 @@ class ClaudeBridge:
         # time; ``cogs.model`` already imports from this module's siblings.
         from .cogs.model import KNOWN_MODELS
         self._context_window_override = None
-        for info in KNOWN_MODELS.values():
+        # Exact id match first, then alias match. No startswith — it
+        # causes prefix collisions (e.g. sonnet-4-6 swallows sonnet-4-6-1m).
+        best = None
+        for alias, info in KNOWN_MODELS.items():
             model_id = info["id"]
-            if model == model_id or model.startswith(model_id):
-                ctx = info.get("context")
-                if isinstance(ctx, int) and ctx > 0:
-                    self._context_window_override = ctx
+            if model == model_id or model == alias:
+                best = info
                 break
-        else:
-            # Alias-keyed lookup (e.g. user passed "opus" / "sonnet")
-            alias_info = KNOWN_MODELS.get(model)
-            if alias_info is not None:
-                ctx = alias_info.get("context")
-                if isinstance(ctx, int) and ctx > 0:
-                    self._context_window_override = ctx
+        if best is not None:
+            ctx = best.get("context")
+            if isinstance(ctx, int) and ctx > 0:
+                self._context_window_override = ctx
 
     @property
     def is_active(self) -> bool:

--- a/src/clauded/cogs/context.py
+++ b/src/clauded/cogs/context.py
@@ -82,23 +82,37 @@ def _format_tokens(n: int) -> str:
     return str(n)
 
 
-def _build_context_embed(usage: dict, source_label: str) -> discord.Embed:
+def _build_context_embed(
+    usage: dict,
+    source_label: str,
+    max_tokens_override: int | None = None,
+) -> discord.Embed:
     """Render a ContextUsageResponse dict into a Discord embed.
 
     ``source_label`` indicates which path generated the data ("active session"
     vs "fresh session"). Surface this so users understand whether the
     numbers reflect their actual conversation state or just the model's
     baseline budget.
+
+    ``max_tokens_override`` (#280): when set, overrides the SDK's
+    ``maxTokens`` for the denominator + display so a just-switched model
+    (``/model switch opus``) shows its true context window (e.g. 1M)
+    even before the SDK refreshes its metadata.
     """
     total = int(usage.get("totalTokens", 0))
     max_tokens = int(usage.get("maxTokens", 0))
     model = str(usage.get("model", "unknown"))
 
     # #263: compute global occupancy from Free space supplement.
+    # #280: pass through any context-window override the caller knows
+    # about (cached on the bridge after /model switch).
     from .._context_usage import compute_global_context_pct
-    result = compute_global_context_pct(usage)
+    result = compute_global_context_pct(usage, max_tokens_override=max_tokens_override)
     if result is not None:
-        total, _, percentage = int(result[0]), result[1], result[2]
+        total, effective_max, percentage = int(result[0]), result[1], result[2]
+        # #280: surface the overridden value in the embed text too so
+        # the displayed "X / Y tokens" line matches the percentage.
+        max_tokens = int(effective_max)
     else:
         total = int(usage.get("totalTokens", 0))
         percentage = float(usage.get("percentage", 0))
@@ -251,7 +265,15 @@ async def context_cmd(interaction: discord.Interaction) -> None:
         )
         return
 
-    embed = _build_context_embed(usage, source_label=source_label)
+    embed = _build_context_embed(
+        usage,
+        source_label=source_label,
+        # #280: forward bridge's cached window so a just-switched model
+        # (e.g. /model switch opus) renders against 1M, not the SDK's
+        # stale 200k. ``getattr`` keeps Path B (no bridge) safe — and
+        # tolerates legacy bridges that pre-date this field.
+        max_tokens_override=getattr(bridge, "_context_window_override", None),
+    )
     await interaction.followup.send(embed=embed, ephemeral=True)
 
 

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -334,7 +334,11 @@ async def _fetch_context_pct_settled(
         if cu is None:
             return None
         from ._context_usage import compute_global_context_pct
-        result = compute_global_context_pct(cu)
+        # #280: pass the bridge's cached context window so a just-switched
+        # model (e.g. /model switch opus) renders against the *new*
+        # denominator instead of the SDK's stale ``maxTokens``.
+        override = getattr(bridge, "_context_window_override", None)
+        result = compute_global_context_pct(cu, max_tokens_override=override)
         return result[2] if result is not None else None
 
     try:

--- a/tests/test_context_window_override.py
+++ b/tests/test_context_window_override.py
@@ -295,3 +295,27 @@ async def test_footer_uses_context_window_override_after_switch():
     assert ("🧠 18%" in all_content) or ("🧠 19%" in all_content), (
         f"expected ~19% (189.4k / 1M), got: {all_content!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_set_model_sonnet_1m_caches_1M_not_200k():
+    """#280 R2: 'claude-sonnet-4-6-1m' must cache 1M, not 200k.
+    
+    Regression test for the startswith prefix collision bug where
+    sonnet-4-6 matched before sonnet-4-6-1m."""
+    from clauded.claude_bridge import ClaudeBridge
+    from clauded.config import Config
+    cfg = Config(
+        discord_bot_token="tok",
+        claude_model="sonnet",
+        claude_permission_mode="default",
+        projects_root="/tmp",
+    )
+    bridge = ClaudeBridge(project_path="/tmp", config=cfg)
+    bridge._active = True
+    bridge._client = AsyncMock()
+    bridge._model_override = None
+    await bridge.set_model("claude-sonnet-4-6-1m")
+    assert bridge._context_window_override == 1_000_000, (
+        f"Expected 1M for sonnet-1m, got {bridge._context_window_override}"
+    )

--- a/tests/test_context_window_override.py
+++ b/tests/test_context_window_override.py
@@ -1,0 +1,297 @@
+"""#280 — context-window override prevents stale maxTokens after /model switch.
+
+After ``/model switch opus``, the SDK keeps returning the *previous*
+model's ``maxTokens`` (e.g. sonnet's 200k) from ``get_context_usage()``
+until the next turn round-trips. The bridge caches the new model's
+window in ``_context_window_override`` so ``/context`` + the footer 🧠
+segment can display the correct denominator immediately.
+
+This test file covers:
+  - the pure ``compute_global_context_pct`` override path
+    (denominator switches to 1M while ``used`` stays truthful);
+  - ``set_model`` populating ``_context_window_override`` from
+    ``KNOWN_MODELS`` (by alias and by full id);
+  - the renderer footer using the override end-to-end.
+"""
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, "src")
+
+
+# ---------------------------------------------------------------------------
+# Primary unit test — the one called out in the implementation plan.
+# ---------------------------------------------------------------------------
+
+
+def test_compute_uses_override_when_sdk_max_is_stale():
+    """Mock bridge with _context_window_override=1_000_000, SDK returns
+    maxTokens=200_000 — compute must use 1M for the denominator."""
+    from clauded._context_usage import compute_global_context_pct
+
+    # Simulated post-switch stale state: SDK still reports sonnet's 200k
+    # window plus a Free space supplement consistent with that 200k frame.
+    cu = {
+        "maxTokens": 200_000,         # stale (sonnet)
+        "rawMaxTokens": 200_000,
+        "totalTokens": 189_400,
+        "percentage": 95,
+        "model": "claude-sonnet-4-6",
+        "categories": [
+            {"name": "Messages", "tokens": 180_000},
+            {"name": "System", "tokens": 9_400},
+            {"name": "Free space", "tokens": 10_600},  # 200k - 189.4k
+        ],
+    }
+
+    # Mock bridge with the override field populated as it would be by
+    # ``set_model("opus")``.
+    bridge = MagicMock()
+    bridge._context_window_override = 1_000_000
+
+    result = compute_global_context_pct(
+        cu,
+        max_tokens_override=bridge._context_window_override,
+    )
+    assert result is not None
+    used, max_t, pct = result
+    # Denominator must be the override (1M), not SDK's stale 200k.
+    assert max_t == 1_000_000, f"expected 1M denominator, got {max_t}"
+    # Used = sdk_max - free_space = 200k - 10.6k = 189.4k (truthful).
+    assert used == pytest.approx(189_400, abs=1.0)
+    # Percentage = 189.4k / 1M ≈ 18.94% (not the misleading 94.7%).
+    assert pct == pytest.approx(18.94, abs=0.05)
+
+
+# ---------------------------------------------------------------------------
+# Override edge cases on compute_global_context_pct
+# ---------------------------------------------------------------------------
+
+
+def test_compute_ignores_override_when_matches_sdk():
+    """If override == SDK's maxTokens (SDK already caught up), behave as
+    if no override was passed."""
+    from clauded._context_usage import compute_global_context_pct
+
+    cu = {
+        "maxTokens": 1_000_000,
+        "totalTokens": 100_000,
+        "categories": [
+            {"name": "Messages", "tokens": 100_000},
+            {"name": "Free space", "tokens": 900_000},
+        ],
+    }
+    # Override matches → use SDK's value
+    with_override = compute_global_context_pct(cu, max_tokens_override=1_000_000)
+    no_override = compute_global_context_pct(cu)
+    assert with_override == no_override
+
+
+def test_compute_ignores_invalid_override():
+    """Negative / zero / non-numeric overrides are silently ignored."""
+    from clauded._context_usage import compute_global_context_pct
+
+    cu = {
+        "maxTokens": 200_000,
+        "categories": [
+            {"name": "Messages", "tokens": 50_000},
+            {"name": "Free space", "tokens": 150_000},
+        ],
+    }
+    for bad in (None, 0, -1, "1000000"):
+        result = compute_global_context_pct(cu, max_tokens_override=bad)  # type: ignore[arg-type]
+        assert result is not None
+        # All map to: use SDK's 200k.
+        assert result[1] == 200_000.0, f"bad override {bad!r} leaked into denominator"
+
+
+def test_compute_override_falls_back_to_totalTokens_when_no_free_space():
+    """Override still applies when free_space is absent (totalTokens path)."""
+    from clauded._context_usage import compute_global_context_pct
+
+    cu = {
+        "maxTokens": 200_000,    # stale
+        "totalTokens": 50_000,
+    }
+    result = compute_global_context_pct(cu, max_tokens_override=1_000_000)
+    assert result is not None
+    used, max_t, pct = result
+    assert used == 50_000.0
+    assert max_t == 1_000_000.0
+    # 50k / 1M = 5%
+    assert pct == pytest.approx(5.0, abs=0.01)
+
+
+def test_compute_override_no_op_when_sdk_max_missing():
+    """If SDK gives no maxTokens, override doesn't synthesize one — the
+    SDK-percentage fallback path is preserved."""
+    from clauded._context_usage import compute_global_context_pct
+
+    cu = {"percentage": 42}
+    result = compute_global_context_pct(cu, max_tokens_override=1_000_000)
+    assert result is not None
+    used, max_t, pct = result
+    assert max_t == 0.0  # legacy contract — no denominator known
+    assert pct == 42.0
+
+
+# ---------------------------------------------------------------------------
+# Bridge.set_model populates the override.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_model_caches_context_window_for_alias():
+    """``set_model("opus")`` caches 1M from KNOWN_MODELS."""
+    from clauded.claude_bridge import ClaudeBridge
+    from clauded.config import Config
+
+    cfg = Config(
+        discord_bot_token="tok",
+        claude_model="sonnet",
+        claude_permission_mode="default",
+        projects_root="/tmp",
+    )
+    bridge = ClaudeBridge(project_path="/tmp", config=cfg)
+    bridge._client = AsyncMock()
+    bridge._client.set_model = AsyncMock()
+    bridge._active = True
+
+    assert bridge._context_window_override is None
+    await bridge.set_model("opus")
+    assert bridge._context_window_override == 1_000_000
+
+
+@pytest.mark.asyncio
+async def test_set_model_caches_context_window_for_full_id():
+    """``set_model("claude-opus-4-7")`` resolves through KNOWN_MODELS' id field."""
+    from clauded.claude_bridge import ClaudeBridge
+    from clauded.config import Config
+
+    cfg = Config(
+        discord_bot_token="tok",
+        claude_model="sonnet",
+        claude_permission_mode="default",
+        projects_root="/tmp",
+    )
+    bridge = ClaudeBridge(project_path="/tmp", config=cfg)
+    bridge._client = AsyncMock()
+    bridge._client.set_model = AsyncMock()
+    bridge._active = True
+
+    await bridge.set_model("claude-opus-4-7")
+    assert bridge._context_window_override == 1_000_000
+
+
+@pytest.mark.asyncio
+async def test_set_model_unknown_model_leaves_override_unset():
+    """Unknown model names don't populate the override (fall back to SDK)."""
+    from clauded.claude_bridge import ClaudeBridge
+    from clauded.config import Config
+
+    cfg = Config(
+        discord_bot_token="tok",
+        claude_model="sonnet",
+        claude_permission_mode="default",
+        projects_root="/tmp",
+    )
+    bridge = ClaudeBridge(project_path="/tmp", config=cfg)
+    bridge._client = AsyncMock()
+    bridge._client.set_model = AsyncMock()
+    bridge._active = True
+
+    await bridge.set_model("some-future-model-not-in-table")
+    assert bridge._context_window_override is None
+
+
+@pytest.mark.asyncio
+async def test_set_model_resets_override_between_switches():
+    """Switching opus → unknown clears the prior 1M cache so we don't
+    keep showing opus's window for the wrong model."""
+    from clauded.claude_bridge import ClaudeBridge
+    from clauded.config import Config
+
+    cfg = Config(
+        discord_bot_token="tok",
+        claude_model="sonnet",
+        claude_permission_mode="default",
+        projects_root="/tmp",
+    )
+    bridge = ClaudeBridge(project_path="/tmp", config=cfg)
+    bridge._client = AsyncMock()
+    bridge._client.set_model = AsyncMock()
+    bridge._active = True
+
+    await bridge.set_model("opus")
+    assert bridge._context_window_override == 1_000_000
+    await bridge.set_model("totally-unknown")
+    assert bridge._context_window_override is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: footer renders against override after model switch.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_footer_uses_context_window_override_after_switch():
+    """End-to-end: bridge has _context_window_override=1M, SDK still
+    returns 200k. Footer 🧠 % must be computed against 1M (≈19%), not
+    200k (≈95%)."""
+    from claude_agent_sdk.types import AssistantMessage, TextBlock, ResultMessage
+    from clauded.discord_renderer import DiscordRenderer
+
+    from tests.conftest import FakeBridge, FakeTarget
+
+    events = [
+        AssistantMessage(
+            content=[TextBlock(text="ok")],
+            model="claude-opus-4-7",
+            parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result", duration_ms=50, duration_api_ms=30,
+            is_error=False, num_turns=1, session_id="sess-280",
+            total_cost_usd=0.01,
+            usage={"input_tokens": 50, "output_tokens": 20},
+        ),
+    ]
+    # Stale SDK data (sonnet's 200k frame).
+    ctx_response = {
+        "percentage": 95,
+        "totalTokens": 189_400,
+        "maxTokens": 200_000,
+        "rawMaxTokens": 200_000,
+        "model": "claude-sonnet-4-6",
+        "categories": [
+            {"name": "Messages", "tokens": 180_000},
+            {"name": "Free space", "tokens": 10_600},
+        ],
+    }
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+    bridge = FakeBridge(events, get_context_usage_returns=ctx_response)
+    # Simulate post-/model-switch state.
+    bridge._context_window_override = 1_000_000
+
+    await renderer.render_response(bridge, "hello")
+
+    all_content = " ".join(m.content for m in target._sent if m.content)
+    # 189.4k / 1M ≈ 18.94% → footer integer tier renders "🧠 19%" (or
+    # `18%` if truncated). Crucially: must NOT show the misleading
+    # 95% / ⚠️ / 🔥 that the stale 200k would have produced.
+    assert "🔥" not in all_content, (
+        f"expected calm 🧠 segment with override; got 🔥 (stale 200k leaked): {all_content!r}"
+    )
+    assert "⚠️ " not in all_content or "🧠" in all_content, (
+        f"expected 🧠 segment, not ⚠️ from stale-window threshold: {all_content!r}"
+    )
+    assert "🧠" in all_content, f"missing 🧠 segment entirely: {all_content!r}"
+    # Sanity-check the actual rounded percentage neighborhood.
+    assert ("🧠 18%" in all_content) or ("🧠 19%" in all_content), (
+        f"expected ~19% (189.4k / 1M), got: {all_content!r}"
+    )


### PR DESCRIPTION
Closes #280. After set_model(), caches new model's context window from KNOWN_MODELS. compute_global_context_pct uses override when SDK returns stale maxTokens. 10 new tests. 1257 passed.