### PR TITLE
feat(#279): /session info displays session_id

### DIFF
--- a/docs/prd/fix-279-session-info.md
+++ b/docs/prd/fix-279-session-info.md
@@ -1,0 +1,12 @@
+# PRD — #279 /session info shows session_id
+
+**Issue**: #279 (enhancement, P2)
+**Branch**: `fix/279-session-info-id`
+**Status**: APPROVED
+
+## Fix
+Add `session_id` line to `/session info` embed. Use `bridge.session_id or '(pending)'`.
+
+## AC
+- AC1: /session info shows session_id
+- AC2: pre-first-turn shows "(pending)"

--- a/src/clauded/cogs/session.py
+++ b/src/clauded/cogs/session.py
@@ -163,6 +163,7 @@ async def session_info(interaction: discord.Interaction) -> None:
         mode_line = _format_mode_display(mode_value, mode_source)
         lines = [
             f"📡 **Session active** — cwd `{bridge.project_path}`",
+            f"• Session ID: `{bridge.session_id or '(pending — send a message first)'}`",
             f"• Model: {model_display}",
             f"• Mode: {mode_line}",
             f"• Turns: `{bridge.num_turns}`",


### PR DESCRIPTION
Closes #279. 1 line added. 1258 passed.