### PR TITLE
feat(#286): upgrade claude-agent-sdk 0.1.80 → 0.2.110

### DIFF
--- a/docs/prd/feat-286-sdk-upgrade.md
+++ b/docs/prd/feat-286-sdk-upgrade.md
@@ -1,0 +1,25 @@
+# PRD — #286 SDK upgrade 0.1.80 → 0.2.107+
+
+**Issue**: #286 (epic, P1)
+**Branch**: `feat/286-sdk-upgrade`
+**Status**: APPROVED
+
+## Approach
+5 subtasks, one PR. Subtasks 1-4 in scope, Subtask 5 (new hooks) deferred to Phase 2.
+
+## Subtask 1 — pip upgrade + regression test
+- `pyproject.toml`: change `claude-agent-sdk>=0.1.70,<0.2` → `>=0.2.100,<0.3`
+- `pip install "claude-agent-sdk==0.2.107"`
+- Run full pytest — must pass with 0 regressions
+
+## Subtask 2 — /effort add xhigh + max
+- `cogs/model.py`: add xhigh and max to effort choices
+- Test
+
+## Subtask 3 — renderer subagent pressure (deferred to manual test)
+## Subtask 4 — new Message types fallback (verify renderer duck-typing handles them)
+
+## AC
+- AC1: pyproject.toml updated, pip install succeeds
+- AC2: full pytest passes (0 regressions)
+- AC3: /effort supports xhigh + max

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 dependencies = [
     "discord.py>=2.4,<3.0",
-    "claude-agent-sdk==0.1.80",
+    "claude-agent-sdk>=0.2.100,<0.3",
     "python-dotenv>=1.0",
     "Pillow>=10",
     "croniter>=2.0",


### PR DESCRIPTION
Closes #286. SDK 0.2.110 installed. All imports OK. 1258 passed. /effort already has xhigh+max.