### PR TITLE
feat(#291): default effort=max, configurable via CLAUDED_DEFAULT_EFFORT

### DIFF
--- a/docs/prd/feat-291-default-effort.md
+++ b/docs/prd/feat-291-default-effort.md
@@ -1,0 +1,14 @@
+# PRD — #291 default effort=max
+
+**Issue**: #291 (feat, P1)
+**Branch**: `feat/291-default-effort`
+**Status**: APPROVED
+
+## Fix
+`session_config.py`: change `effort` default from `None` to `os.environ.get("CLAUDED_DEFAULT_EFFORT", "max")`.
+
+## AC
+- AC1: new session effort=max by default
+- AC2: /effort can override
+- AC3: env CLAUDED_DEFAULT_EFFORT works
+- AC4: resume unchanged

--- a/src/clauded/session_config.py
+++ b/src/clauded/session_config.py
@@ -1,6 +1,7 @@
 """Session configuration dataclass — replaces 25+ kwargs threading."""
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -13,7 +14,7 @@ class SessionConfig:
     model_override: str | None = None
     permission_mode_override: str | None = None
     resume_session_id: str | None = None
-    effort: str | None = None
+    effort: str | None = field(default_factory=lambda: os.environ.get("CLAUDED_DEFAULT_EFFORT", "max"))
     allowed_tools: list[str] = field(default_factory=list)
     disallowed_tools: list[str] = field(default_factory=list)
     max_budget_usd: float | None = None

--- a/tests/test_claude_bridge.py
+++ b/tests/test_claude_bridge.py
@@ -184,7 +184,8 @@ def test_bridge_default_session_config(cfg: Config) -> None:
     """ClaudeBridge uses default SessionConfig when none is provided."""
     bridge = ClaudeBridge(project_path="/tmp/p", config=cfg)
     assert bridge.system_prompt is None
-    assert bridge._effort is None
+    # #291: default effort is now "max" (configurable via CLAUDED_DEFAULT_EFFORT)
+    assert bridge._effort == "max"
     assert bridge._user is None
 
 

--- a/tests/test_session_config.py
+++ b/tests/test_session_config.py
@@ -13,7 +13,8 @@ def test_default_values():
     assert sc.system_prompt is None
     assert sc.model_override is None
     assert sc.resume_session_id is None
-    assert sc.effort is None
+    # effort default is now driven by CLAUDED_DEFAULT_EFFORT env (see #291);
+    # covered by dedicated tests below.
     assert sc.allowed_tools == []
     assert sc.disallowed_tools == []
     assert sc.max_budget_usd is None
@@ -225,3 +226,21 @@ def test_bridge_stores_bare_and_session_name():
     bridge = ClaudeBridge(project_path="/tmp/p", config=cfg, session_config=sc)
     assert bridge._bare is True
     assert bridge._session_name == "test-session"
+
+
+def test_effort_default_is_max(monkeypatch):
+    """AC1: effort defaults to 'max' when CLAUDED_DEFAULT_EFFORT is unset."""
+    monkeypatch.delenv("CLAUDED_DEFAULT_EFFORT", raising=False)
+    sc = SessionConfig()
+    assert sc.effort == "max"
+
+
+def test_effort_env_override(monkeypatch):
+    """AC3: CLAUDED_DEFAULT_EFFORT env overrides the default."""
+    monkeypatch.setenv("CLAUDED_DEFAULT_EFFORT", "high")
+    sc = SessionConfig()
+    assert sc.effort == "high"
+
+    monkeypatch.setenv("CLAUDED_DEFAULT_EFFORT", "low")
+    sc2 = SessionConfig()
+    assert sc2.effort == "low"


### PR DESCRIPTION
Closes #291. New sessions default to effort=max. Env override supported. 2 new tests.