### PR TITLE
chore(#295): clean sessions.json shadow fields + permission_mode alignment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ DISCORD_BOT_TOKEN=your-bot-token-here
 # confirmation. Anyone who can post in a bound Discord channel will be able to
 # trigger arbitrary code execution on this host. Only enable bypassPermissions
 # if every potential message author is fully trusted with shell access.
-CLAUDE_PERMISSION_MODE=default
+# CLAUDE_PERMISSION_MODE=  # unset = CLI settings.json takes over
 
 # Root directory under which `/project bind` paths must live. Optional,
 # defaults to the current user's home directory. Bindings that resolve outside

--- a/docs/prd/chore-295-session-cleanup.md
+++ b/docs/prd/chore-295-session-cleanup.md
@@ -1,0 +1,17 @@
+# PRD — #295 sessions.json cleanup + permission_mode alignment
+
+**Issue**: #295 (chore, P2)
+**Branch**: `chore/295-session-cleanup`
+**Status**: APPROVED
+
+## Subtask 1: sessions.json shadow fields
+- `session_store.save_session_state()`: stop writing `system_prompt`, `project_path`
+- Read sites: use `project_manager` instead of stored values
+- Startup migration: strip `model`, `system_prompt`, `project_path` from existing entries
+
+## Subtask 2: permission_mode default
+- `config.py`: `claude_permission_mode` default `None` instead of `"default"`
+- `claude_bridge.py`: don't pass permission_mode when None
+
+## AC
+- AC1-AC5 per issue

--- a/scripts/e2e/run_e2e.py
+++ b/scripts/e2e/run_e2e.py
@@ -2812,7 +2812,7 @@ async def case_session_state_resume_after_restart(bot) -> CaseResult:
     import tempfile
     d = tempfile.mkdtemp(prefix="cc_ss_")
     ss = SessionStore(data_dir=d)
-    ss.save_session(thread_id=999, session_id="sess-x", project_path="/tmp")
+    ss.save_session(thread_id=999, session_id="sess-x")
     # Pretend restart
     ss2 = SessionStore(data_dir=d)
     stored = ss2.get_session_info(999)
@@ -2833,10 +2833,10 @@ async def case_save_session_state_after_crash(bot) -> CaseResult:
     d = tempfile.mkdtemp(prefix="cc_ssac_")
     ss = SessionStore(data_dir=d)
     # First, write a known-good state
-    ss.save_session(thread_id=1, session_id="a", project_path="/x")
+    ss.save_session(thread_id=1, session_id="a")
     # Now simulate concurrent _save call
     try:
-        await asyncio.to_thread(ss.save_session, 2, "b", "/y")
+        await asyncio.to_thread(ss.save_session, 2, "b")
     except Exception:
         pass
     # File should still parse as valid JSON

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -923,7 +923,10 @@ class ClaudedBot(commands.Bot):
                     # intent ("没设置就是 claude code 默认的"). The SDK falls
                     # back to ~/.claude/settings.json (CLI default) when
                     # model_override is None.
-                    stored_prompt = stored.get("system_prompt") if stored else None
+                    # #295: system_prompt is likewise NOT read from stored —
+                    # ``ProjectManager.get_system_prompt(parent_id)`` above is
+                    # the canonical source; the old shadow copy has been
+                    # dropped from sessions.json.
                     # #211: read the user-explicit permission-mode override
                     # from the stored row so a bot restart preserves the
                     # user's last ``/mode set`` / cycle choice (PRD user
@@ -952,7 +955,7 @@ class ClaudedBot(commands.Bot):
                     env_vars = self.project_manager.get_env(parent_id)
                     _notify = self._notify_enabled.get(thread_id, self._pre_tool_notifications)
                     sc = SessionConfig(
-                        system_prompt=stored_prompt or system_prompt,
+                        system_prompt=system_prompt,
                         model_override=None,  # #210: ephemeral; see note above
                         permission_mode_override=stored_perm_mode,  # #211: persistent
                         resume_session_id=resume_id,

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -542,6 +542,19 @@ class ClaudeBridge:
         # whatever was resolved on turn 1 even if settings.json changes.
         chosen_model = self._model_override or self._config.claude_model
 
+        # #295: SDK-input value for ``permission_mode``. We deliberately
+        # do NOT use ``effective_permission_mode`` here — that accessor
+        # falls back to ``"default"`` for display purposes, but sending
+        # ``permission_mode="default"`` to the SDK overrides the CLI's
+        # own ``~/.claude/settings.json`` ``permissions.defaultMode``.
+        # We want the SDK to receive a value ONLY when the user (or
+        # operator via env) has explicitly asked for one; otherwise pass
+        # None so CLI settings govern (mirror of #198's ``model`` gate).
+        perm_mode_for_sdk = (
+            self._permission_mode_override
+            or self._config.claude_permission_mode
+        )
+
         options = ClaudeAgentOptions(
             cwd=self.project_path,
             env=self._env or {},
@@ -550,7 +563,9 @@ class ClaudeBridge:
             # an auto-resumed session with a persisted override re-enters the
             # bridge with the right mode on the very first turn (not just
             # after the user re-runs ``/mode set``).
-            permission_mode=self.effective_permission_mode,
+            # #295: passing ``None`` when nothing is explicitly set — see
+            # ``perm_mode_for_sdk`` above.
+            permission_mode=perm_mode_for_sdk,
             model=chosen_model,
             resume=self._resume_session_id,
             # R3 (#116): system_prompt preset dict replaces append_system_prompt

--- a/src/clauded/cogs/session.py
+++ b/src/clauded/cogs/session.py
@@ -215,6 +215,19 @@ async def session_resume(interaction: discord.Interaction) -> None:
     if not stored:
         await interaction.response.send_message("No saved session to resume.", ephemeral=True)
         return
+    # #295: system_prompt and project_path are no longer shadowed in
+    # sessions.json — read them from ``ProjectManager`` (canonical source)
+    # keyed off the parent channel so bindings still resolve inside threads.
+    parent_id = getattr(interaction.channel, "parent_id", None) or thread_id
+    project_path = bot.project_manager.get_path(parent_id)
+    if not project_path:
+        await interaction.response.send_message(
+            "Cannot resume: this channel is no longer bound to a project. "
+            "Use `/project bind` first.",
+            ephemeral=True,
+        )
+        return
+    system_prompt = bot.project_manager.get_system_prompt(parent_id)
     await interaction.response.defer()
     lock = bot.session_manager.get_lock(thread_id)
     async with lock:
@@ -227,7 +240,7 @@ async def session_resume(interaction: discord.Interaction) -> None:
         # user intent ("没设置就是 claude code 默认的"). The SDK falls back
         # to ~/.claude/settings.json (CLI default) when model_override is None.
         sc = SessionConfig(
-            system_prompt=stored.get("system_prompt"),
+            system_prompt=system_prompt,
             model_override=None,  # #210: ephemeral; see note above
             # #211: opposite of model_override — permission_mode_override
             # IS persistent (PRD user decision #4 contrast with #210). Read
@@ -239,7 +252,7 @@ async def session_resume(interaction: discord.Interaction) -> None:
         )
         try:
             await bot.session_manager.create_session(
-                thread_id, stored["project_path"], bot.config, sc,
+                thread_id, project_path, bot.config, sc,
             )
         except Exception as exc:
             await interaction.followup.send(f"❌ Failed to resume: `{exc}`", ephemeral=True)

--- a/src/clauded/config.py
+++ b/src/clauded/config.py
@@ -20,7 +20,12 @@ class Config:
 
     discord_bot_token: str
     claude_model: Optional[str]
-    claude_permission_mode: str
+    # #295: mirrors #198's ``claude_model`` semantics. Unset env
+    # (``CLAUDE_PERMISSION_MODE``) → ``None`` → SDK call omits
+    # ``permission_mode`` → CLI's ``~/.claude/settings.json``
+    # ``permissions.defaultMode`` governs. Setting the env var pins the
+    # mode for every session (still overridable per-thread via ``/mode set``).
+    claude_permission_mode: Optional[str]
     projects_root: str
     # SECURITY: when False (default), an unbound channel's @bot message is
     # silently ignored — restoring v1.0 behavior. When True, the on-message
@@ -63,13 +68,17 @@ def load_config() -> Config:
     _claude_model_env = os.environ.get("CLAUDE_MODEL", "").strip()
     claude_model: Optional[str] = _claude_model_env or None
 
+    # #295: same shape as #198 above — unset env var means "let CLI
+    # settings.json govern" (no forced ``permission_mode=default`` that
+    # used to override ``permissions.defaultMode``). Empty / whitespace
+    # is treated as unset.
+    _claude_perm_env = os.environ.get("CLAUDE_PERMISSION_MODE", "").strip()
+    claude_permission_mode: Optional[str] = _claude_perm_env or None
+
     return Config(
         discord_bot_token=token,
         claude_model=claude_model,
-        claude_permission_mode=(
-            os.environ.get("CLAUDE_PERMISSION_MODE", "default").strip()
-            or "default"
-        ),
+        claude_permission_mode=claude_permission_mode,
         projects_root=projects_root,
         allow_unbound_fallback=(
             os.environ.get("CLAUDED_ALLOW_UNBOUND_FALLBACK", "").strip().lower()

--- a/src/clauded/session_manager.py
+++ b/src/clauded/session_manager.py
@@ -95,33 +95,22 @@ class SessionManager:
     def save_session_state(self, thread_id: int) -> None:
         """Persist the current session state for ``thread_id`` to the store.
 
-        #198 PRD §Design line 92: persist ONLY the user-explicit override
-        (``bridge.explicit_model_override``), not the collapsed
-        ``bridge.model`` property. The collapsed property includes
-        ``_sdk_model`` (what the SDK reported back), and persisting it
-        would lock future resumes onto the SDK-observed value even after
-        the user edits ``~/.claude/settings.json``.
+        #295: The store now holds only ``session_id`` and
+        ``permission_mode_override`` (plus ``last_active``). The former
+        shadow fields (``project_path``, ``system_prompt``, ``model``)
+        have canonical sources on ``ProjectManager`` / are already
+        deprecated (#210), so we no longer duplicate them here.
 
-        #210: After the read-side stopped reading ``stored.get("model")``
-        (see ``bot.py`` thread-resume and ``cogs/session.py`` /session
-        resume), the persisted ``model`` field is purely vestigial — it
-        is never consumed. To keep new rows clearly distinguishable from
-        legacy "sonnet"-polluted rows during forensic inspection, we now
-        always write ``model=None`` regardless of the explicit override.
-        ``/model switch`` is intentionally ephemeral per user intent;
-        cross-restart, the user re-runs ``/model switch`` if they want
-        it again.
+        #211 semantics preserved: we persist ONLY the user-explicit
+        override (``bridge.permission_mode_override``). Missing/None
+        means the user has not run ``/mode set`` / cycle on this thread
+        and readers should fall back to env / CLI settings.
         """
         bridge = self._sessions.get(thread_id)
         if bridge and bridge.session_id:
             self._session_store.save_session(
-                thread_id, bridge.session_id, bridge.project_path,
-                model=None,  # #210: ephemeral; read-side ignores this field
-                system_prompt=bridge.system_prompt,
-                # #211: persist the user-explicit override (None when
-                # they've never run /mode set on this thread; the
-                # SessionStore happily round-trips None for legacy rows
-                # / unset cases).
+                thread_id,
+                bridge.session_id,
                 permission_mode_override=getattr(
                     bridge, "permission_mode_override", None
                 ),

--- a/src/clauded/session_store.py
+++ b/src/clauded/session_store.py
@@ -12,6 +12,19 @@ from ._json_store import atomic_write_json
 log = logging.getLogger("clauded.session_store")
 
 
+# #295: fields that used to be persisted per-thread but now have canonical
+# sources of truth elsewhere:
+#   - ``model``          — deprecated by #210 (read side ignores it; write
+#                          side wrote None); no consumer left.
+#   - ``system_prompt``  — canonical source is
+#                          ``ProjectManager.get_system_prompt(parent_id)``.
+#   - ``project_path``   — canonical source is
+#                          ``ProjectManager.get_path(parent_id)``.
+# ``_load`` strips these on startup so we don't carry legacy shadow data
+# forward, and ``save_session`` no longer writes them.
+_LEGACY_SHADOW_FIELDS: tuple[str, ...] = ("model", "system_prompt", "project_path")
+
+
 class SessionStore:
     """Maps thread_id -> session metadata, persisted to JSON."""
 
@@ -33,40 +46,52 @@ class SessionStore:
         except (json.JSONDecodeError, OSError):
             log.warning("Failed to load sessions.json, starting fresh")
             self._sessions = {}
-        # #210: count legacy rows with a non-null ``model`` field for
-        # operator visibility. The field is deprecated as of v1.18 — read
-        # paths ignore it and write paths emit None. We do NOT mutate the
-        # file here (forensic preservation); the count naturally shrinks
-        # as old entries are overwritten or expire via the 1h idle GC.
-        legacy_count = sum(
-            1
-            for v in self._sessions.values()
-            if isinstance(v, dict) and v.get("model") is not None
-        )
-        if legacy_count:
+        # #295: one-shot startup migration — strip the shadow fields
+        # (``model``, ``system_prompt``, ``project_path``) from every entry
+        # so operators aren't stuck with stale copies of data whose
+        # canonical source is ``ProjectManager`` (or, for ``model``, an
+        # already-deprecated no-op from #210). We ONLY drop these fields;
+        # ``session_id``, ``last_active``, ``permission_mode_override`` and
+        # any future schema additions are preserved verbatim.
+        stripped = 0
+        for entry in self._sessions.values():
+            if not isinstance(entry, dict):
+                continue
+            for field in _LEGACY_SHADOW_FIELDS:
+                if field in entry:
+                    del entry[field]
+                    stripped += 1
+        if stripped:
             log.info(
-                "#210: %d legacy stored.model entries ignored "
-                "(deprecated field; not mutating data)",
-                legacy_count,
+                "#295: stripped %d legacy shadow field(s) from sessions.json",
+                stripped,
             )
+            self._save()
 
     def _save(self) -> None:
         atomic_write_json(self._path, self._sessions, self._lock)
 
-    def save_session(self, thread_id: int, session_id: str, project_path: str,
-                     model: str | None = None, system_prompt: str | None = None,
-                     permission_mode_override: str | None = None) -> None:
+    def save_session(
+        self,
+        thread_id: int,
+        session_id: str,
+        *,
+        permission_mode_override: str | None = None,
+    ) -> None:
+        """Persist minimal per-thread session metadata.
+
+        #295: ``project_path``, ``model`` and ``system_prompt`` are no
+        longer persisted. Callers that need those values must read them
+        from ``ProjectManager`` (which is the canonical source of truth)
+        rather than shadowing them here.
+        """
         with self._lock:
             self._sessions[str(thread_id)] = {
                 "session_id": session_id,
-                "project_path": project_path,
-                "model": model,
-                "system_prompt": system_prompt,
-                # #211: persist the user's explicit ``/mode set`` / cycle choice
-                # so it survives bot restart (per PRD user decision #4). Unlike
-                # ``model`` (which #210 made vestigial because of legacy
-                # pollution), ``permission_mode_override`` is a fresh schema
-                # field with no prior writes — read-side honors it unmodified.
+                # #211: persist the user's explicit ``/mode set`` / cycle
+                # choice so it survives bot restart (per PRD user
+                # decision #4). Legacy rows without this field safely
+                # return None via ``dict.get``.
                 "permission_mode_override": permission_mode_override,
                 "last_active": datetime.now(timezone.utc).isoformat(),
             }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,10 +67,26 @@ def test_blank_model_env_is_none(isolated_env: pytest.MonkeyPatch) -> None:
 
 
 def test_default_permission_mode(isolated_env: pytest.MonkeyPatch) -> None:
-    """The current default permission mode is ``"default"``."""
+    """#295: CLAUDE_PERMISSION_MODE unset → ``None`` (was ``"default"``).
+
+    Mirrors the #198 ``claude_model`` semantic: ``None`` signals "no
+    admin override, let SDK omit the flag so ``~/.claude/settings.json``
+    ``permissions.defaultMode`` governs" — matches terminal ``claude``
+    behavior instead of silently overriding it with ``"default"``.
+    """
     isolated_env.setenv("DISCORD_BOT_TOKEN", "tok-abc")
     cfg = load_config()
-    assert cfg.claude_permission_mode == "default"
+    assert cfg.claude_permission_mode is None
+
+
+def test_blank_permission_mode_env_is_none(
+    isolated_env: pytest.MonkeyPatch,
+) -> None:
+    """#295: whitespace-only CLAUDE_PERMISSION_MODE is treated as unset → None."""
+    isolated_env.setenv("DISCORD_BOT_TOKEN", "tok-abc")
+    isolated_env.setenv("CLAUDE_PERMISSION_MODE", "   ")
+    cfg = load_config()
+    assert cfg.claude_permission_mode is None
 
 
 def test_explicit_overrides(isolated_env: pytest.MonkeyPatch) -> None:

--- a/tests/test_model_default.py
+++ b/tests/test_model_default.py
@@ -481,24 +481,26 @@ def test_save_session_state_persists_only_explicit_override_no_sdk_loop():
     # Capture what gets passed to the store
     captured: dict = {}
 
-    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None, **kwargs):
+    def _fake_save(thread_id, session_id, *, permission_mode_override=None):
         captured.update(
-            thread_id=thread_id, session_id=session_id, project_path=project_path,
-            model=model, system_prompt=system_prompt,
+            thread_id=thread_id, session_id=session_id,
+            permission_mode_override=permission_mode_override,
         )
 
     sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
     sm.save_session_state(42)
 
-    # The persisted model MUST be the explicit override (None), NOT the
-    # SDK-observed value. Without this, future resumes lock to
-    # "claude-haiku-4-5" even when user changes settings.json.
-    assert captured["model"] is None, (
-        f"save_session_state must persist user-explicit override only, "
-        f"not _sdk_model. Got: {captured['model']!r} (expected None for "
-        f"the no-override case). This is the architect-flagged "
-        f"persistence-loop bug from #198 R1 review."
+    # #295 update: model is no longer in the persisted payload at all.
+    # Pre-#295 this test asserted ``captured["model"] is None``; post-#295
+    # the field simply isn't part of ``save_session``'s signature, which
+    # makes the "no persistence loop" guarantee even stronger. Pin that
+    # the call still happened (session_id captured) — proving that
+    # save_session_state no longer threads model through.
+    assert "model" not in captured, (
+        f"save_session_state must not thread model through to save_session; "
+        f"got {captured!r}. #295 removed model from the persistence layer."
     )
+    assert captured["session_id"] == "sess-abc"
 
 
 def test_save_session_state_persists_user_override_when_set():
@@ -531,12 +533,16 @@ def test_save_session_state_persists_user_override_when_set():
 
     captured: dict = {}
 
-    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None, **kwargs):
-        captured["model"] = model
+    def _fake_save(thread_id, session_id, *, permission_mode_override=None):
+        captured["session_id"] = session_id
+        captured["permission_mode_override"] = permission_mode_override
 
     sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
     sm.save_session_state(99)
 
-    # #210: always None — model_override is ephemeral, no cross-restart
-    # persistence even when the user has explicitly switched.
-    assert captured["model"] is None
+    # #295: model is not in the payload at all — persistence layer no
+    # longer knows about model. #210's "ephemeral override" contract is
+    # thus strengthened: no dead field carrying stale state across
+    # restarts.
+    assert "model" not in captured
+    assert captured["session_id"] == "sess-xyz"

--- a/tests/test_model_stored_readside.py
+++ b/tests/test_model_stored_readside.py
@@ -261,12 +261,19 @@ async def test_session_resume_ignores_polluted_stored_model() -> None:
     bot.session_manager.get_lock = MagicMock(return_value=MagicMock(
         __aenter__=AsyncMock(), __aexit__=AsyncMock()
     ))
+    # #295: /session resume now reads project_path + system_prompt from
+    # project_manager (not from stored). Wire up a project_manager mock
+    # that returns a valid bound path.
+    bot.project_manager = MagicMock()
+    bot.project_manager.get_path = MagicMock(return_value="/tmp")
+    bot.project_manager.get_system_prompt = MagicMock(return_value="")
     bot.config = _config(claude_model=None)
 
     interaction = MagicMock()
     interaction.client = bot
     interaction.channel_id = 9999
     interaction.channel = MagicMock()
+    interaction.channel.parent_id = 9999
     interaction.response = MagicMock()
     interaction.response.defer = AsyncMock()
     interaction.followup = MagicMock()
@@ -313,24 +320,25 @@ def test_save_session_state_always_writes_none() -> None:
 
     captured: dict = {}
 
-    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None, **kwargs):
+    def _fake_save(thread_id, session_id, *, permission_mode_override=None):
         captured.update(
             thread_id=thread_id, session_id=session_id,
-            project_path=project_path, model=model,
-            system_prompt=system_prompt,
+            permission_mode_override=permission_mode_override,
         )
 
     sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
     sm.save_session_state(42)
 
-    assert captured["model"] is None, (
-        f"#210: save_session_state must always write model=None; got "
-        f"{captured['model']!r}. The persistence-field is deprecated; "
+    # #295: model field is entirely gone from save_session's signature
+    # — no stored model at all, which strengthens #210's contract
+    # (ephemeral override, read side ignores stored.model).
+    assert "model" not in captured, (
+        f"#295 + #210: save_session_state must not thread model to save_session; "
+        f"got {captured!r}. The persistence-field is deprecated; "
         f"read paths ignore it; new rows must be clean."
     )
-    # Cross-check that the rest of the kwargs are still threaded through.
+    # Cross-check that session_id still threads through.
     assert captured["session_id"] == "sess-abc"
-    assert captured["project_path"] == "/tmp/proj"
 
 
 def test_save_session_state_writes_none_when_no_user_override() -> None:
@@ -350,12 +358,13 @@ def test_save_session_state_writes_none_when_no_user_override() -> None:
 
     captured: dict = {}
 
-    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None, **kwargs):
-        captured["model"] = model
+    def _fake_save(thread_id, session_id, *, permission_mode_override=None):
+        captured["session_id"] = session_id
 
     sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
     sm.save_session_state(99)
-    assert captured["model"] is None
+    # #295: model is no longer a save_session parameter at all.
+    assert "model" not in captured
 
 
 # ---------------------------------------------------------------------------
@@ -453,20 +462,25 @@ async def test_session_info_no_bridge() -> None:
 
 
 # ---------------------------------------------------------------------------
-# S5 — Startup legacy-entry count log.
+# S5 — Startup legacy-field migration (updated for #295).
+#
+# #210's earlier forensic-preserving behavior (count + INFO log, no mutation)
+# was superseded by #295: the load path now strips ``model`` /
+# ``system_prompt`` / ``project_path`` from every entry so operators don't
+# carry stale shadow data forward. These three tests are the #295 version
+# of the previous #210 log tests.
 # ---------------------------------------------------------------------------
 
 
-def test_session_store_logs_legacy_model_count(
+def test_session_store_strips_legacy_shadow_fields(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """SessionStore._load reports the number of rows with non-null model.
-    The file is NOT mutated."""
+    """#295: _load strips model/system_prompt/project_path and rewrites the file."""
     from clauded.session_store import SessionStore
 
     payload = {
         "1": {"session_id": "a", "project_path": "/p", "model": "sonnet",
-              "system_prompt": "", "last_active": "x"},
+              "system_prompt": "sp", "last_active": "x"},
         "2": {"session_id": "b", "project_path": "/p", "model": "opus",
               "system_prompt": "", "last_active": "x"},
         "3": {"session_id": "c", "project_path": "/p", "model": None,
@@ -477,51 +491,62 @@ def test_session_store_logs_legacy_model_count(
     sessions_path = data_dir / "sessions.json"
     sessions_path.write_text(json.dumps(payload))
 
-    snapshot_before = sessions_path.read_text()
     with caplog.at_level(logging.INFO, logger="clauded.session_store"):
         store = SessionStore(data_dir=str(data_dir))
 
-    # 2 of the 3 entries have non-null model
-    matches = [r for r in caplog.records if "#210" in r.getMessage()]
-    assert matches, "expected one #210 legacy-count INFO log"
-    msg = matches[0].getMessage()
-    assert "2 legacy" in msg, f"got: {msg!r}"
-    # Forensic-preserving: file is byte-identical to before
-    assert sessions_path.read_text() == snapshot_before
-    # And the entries are still loaded (read path is unaffected)
-    assert store.get_session_info(1) == payload["1"]
+    # #295 log emitted, no more #210 forensic log.
+    matches = [r for r in caplog.records if "#295" in r.getMessage()]
+    assert matches, "expected one #295 shadow-field strip INFO log"
+    assert not [r for r in caplog.records if "#210" in r.getMessage()]
+
+    # File has been rewritten with shadow fields removed.
+    after = json.loads(sessions_path.read_text())
+    for entry in after.values():
+        assert "model" not in entry
+        assert "system_prompt" not in entry
+        assert "project_path" not in entry
+    # session_id / last_active preserved verbatim.
+    assert after["1"]["session_id"] == "a"
+    assert after["1"]["last_active"] == "x"
+    # And the in-memory copy matches the on-disk copy.
+    assert store.get_session_info(1) == after["1"]
 
 
 def test_session_store_no_legacy_no_log(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """All rows clean (model=None) → no #210 log emitted."""
+    """All rows already clean → no #295 strip log emitted, file untouched."""
     from clauded.session_store import SessionStore
 
     payload = {
-        "1": {"session_id": "a", "project_path": "/p", "model": None,
-              "system_prompt": "", "last_active": "x"},
+        "1": {"session_id": "a", "last_active": "x"},
     }
     data_dir = tmp_path / "data"
     data_dir.mkdir()
-    (data_dir / "sessions.json").write_text(json.dumps(payload))
+    sessions_path = data_dir / "sessions.json"
+    sessions_path.write_text(json.dumps(payload))
+    before = sessions_path.read_text()
 
     with caplog.at_level(logging.INFO, logger="clauded.session_store"):
         SessionStore(data_dir=str(data_dir))
 
+    assert not [r for r in caplog.records if "#295" in r.getMessage()]
     assert not [r for r in caplog.records if "#210" in r.getMessage()]
+    # No mutation when nothing to strip.
+    assert sessions_path.read_text() == before
 
 
 def test_session_store_missing_file_no_log(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """No sessions.json at all → no #210 log, no crash."""
+    """No sessions.json at all → no strip log, no crash."""
     from clauded.session_store import SessionStore
 
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     with caplog.at_level(logging.INFO, logger="clauded.session_store"):
         SessionStore(data_dir=str(data_dir))
+    assert not [r for r in caplog.records if "#295" in r.getMessage()]
     assert not [r for r in caplog.records if "#210" in r.getMessage()]
 
 
@@ -595,16 +620,18 @@ def test_regression_199_r1_no_sdk_loop_still_holds() -> None:
 
     captured: dict = {}
 
-    def _fake_save(thread_id, session_id, project_path, *, model=None, system_prompt=None, **kwargs):
-        captured["model"] = model
+    def _fake_save(thread_id, session_id, *, permission_mode_override=None):
+        captured["session_id"] = session_id
+        captured["permission_mode_override"] = permission_mode_override
 
     sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
     sm.save_session_state(42)
 
-    # The #199 invariant: model is NOT _sdk_model
-    assert captured["model"] != bridge._sdk_model
-    # The #210 strengthening: model is None
-    assert captured["model"] is None
+    # #295: model is no longer a save_session parameter at all — the
+    # #199 "model != _sdk_model" and #210 "model is None" invariants
+    # are subsumed: the field simply doesn't exist in the payload,
+    # which is the strongest possible form of both guarantees.
+    assert "model" not in captured
 
 
 @pytest.mark.asyncio

--- a/tests/test_permission_mode.py
+++ b/tests/test_permission_mode.py
@@ -341,8 +341,7 @@ def test_session_store_round_trips_permission_mode_override(tmp_path: Path) -> N
 
     store = SessionStore(data_dir=str(tmp_path))
     store.save_session(
-        thread_id=42, session_id="sess-1", project_path="/tmp/p",
-        model=None, system_prompt="",
+        thread_id=42, session_id="sess-1",
         permission_mode_override="bypassPermissions",
     )
     info = store.get_session_info(42)
@@ -393,16 +392,15 @@ def test_save_session_state_persists_explicit_override() -> None:
 
     captured: dict = {}
 
-    def _fake_save(thread_id, session_id, project_path, *, model=None,
-                   system_prompt=None, permission_mode_override=None):
+    def _fake_save(thread_id, session_id, *, permission_mode_override=None):
+        captured["thread_id"] = thread_id
+        captured["session_id"] = session_id
         captured["permission_mode_override"] = permission_mode_override
-        captured["model"] = model
 
     sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
     sm.save_session_state(1)
     assert captured["permission_mode_override"] == "plan"
-    # #211 doesn't change the #210 model=None invariant
-    assert captured["model"] is None
+    assert captured["session_id"] == "sess"
 
 
 def test_save_session_state_persists_none_when_no_user_override() -> None:
@@ -420,8 +418,7 @@ def test_save_session_state_persists_none_when_no_user_override() -> None:
 
     captured: dict = {}
 
-    def _fake_save(thread_id, session_id, project_path, *, model=None,
-                   system_prompt=None, permission_mode_override=None):
+    def _fake_save(thread_id, session_id, *, permission_mode_override=None):
         captured["permission_mode_override"] = permission_mode_override
 
     sm._session_store.save_session = _fake_save  # type: ignore[method-assign]
@@ -534,12 +531,18 @@ async def test_session_resume_threads_permission_mode_override() -> None:
     bot.session_manager.get_lock = MagicMock(return_value=MagicMock(
         __aenter__=AsyncMock(), __aexit__=AsyncMock(),
     ))
+    # #295: /session resume now reads project_path + system_prompt from
+    # project_manager (not from stored).
+    bot.project_manager = MagicMock()
+    bot.project_manager.get_path = MagicMock(return_value="/tmp")
+    bot.project_manager.get_system_prompt = MagicMock(return_value="")
     bot.config = _config()
 
     interaction = MagicMock()
     interaction.client = bot
     interaction.channel_id = 99
     interaction.channel = MagicMock()
+    interaction.channel.parent_id = 99
     interaction.response = MagicMock()
     interaction.response.defer = AsyncMock()
     interaction.followup = MagicMock()

--- a/tests/test_session_clear.py
+++ b/tests/test_session_clear.py
@@ -85,8 +85,7 @@ async def test_session_clear_removes_persisted_resume(bot: ClaudedBot) -> None:
     thread_id = 23456
     # Pre-seed a stored session via the store directly
     bot.session_manager._session_store.save_session(
-        thread_id, "sess-stored-id", "/tmp/proj",
-        model="sonnet", system_prompt=None,
+        thread_id, "sess-stored-id",
     )
     assert bot.session_manager.get_stored_session(thread_id) is not None
 
@@ -136,8 +135,7 @@ async def test_session_clear_both_active_and_stored(bot: ClaudedBot) -> None:
     mock_bridge.system_prompt = None
     bot.session_manager._sessions[thread_id] = mock_bridge
     bot.session_manager._session_store.save_session(
-        thread_id, "sess-stored-id", "/tmp/proj",
-        model="sonnet", system_prompt=None,
+        thread_id, "sess-stored-id",
     )
 
     interaction = _make_interaction(bot, thread_id)
@@ -176,8 +174,7 @@ async def test_clear_session_holds_per_thread_lock(bot: ClaudedBot) -> None:
     import asyncio
     thread_id = 67890
     bot.session_manager._session_store.save_session(
-        thread_id, "sess-id", "/tmp/proj",
-        model="sonnet", system_prompt=None,
+        thread_id, "sess-id",
     )
 
     pre_held = asyncio.Event()
@@ -217,8 +214,7 @@ async def test_clear_session_atomic_against_concurrent_resume(bot: ClaudedBot) -
     import asyncio
     thread_id = 78901
     bot.session_manager._session_store.save_session(
-        thread_id, "sess-stored", "/tmp",
-        model="sonnet", system_prompt=None,
+        thread_id, "sess-stored",
     )
 
     # Race: kick off clear_session AND a re-save (simulating resume's
@@ -227,8 +223,7 @@ async def test_clear_session_atomic_against_concurrent_resume(bot: ClaudedBot) -
         async with bot.session_manager.get_lock(thread_id):
             # Simulate what resume does: save_session_state
             bot.session_manager._session_store.save_session(
-                thread_id, "sess-resumed", "/tmp",
-                model="sonnet", system_prompt=None,
+                thread_id, "sess-resumed",
             )
 
     # Order: clear acquires first, completes; then fake_resume acquires,

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import os
 import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -18,19 +20,22 @@ def tmp_data_dir(tmp_path):
 
 def test_save_and_get(tmp_data_dir: str) -> None:
     store = SessionStore(data_dir=tmp_data_dir)
-    store.save_session(123, "sess-abc", "/tmp/project", model="sonnet", system_prompt="be helpful")
+    store.save_session(123, "sess-abc", permission_mode_override="plan")
     info = store.get_session_info(123)
     assert info is not None
     assert info["session_id"] == "sess-abc"
-    assert info["project_path"] == "/tmp/project"
-    assert info["model"] == "sonnet"
-    assert info["system_prompt"] == "be helpful"
+    assert info["permission_mode_override"] == "plan"
     assert "last_active" in info
+    # #295: shadow fields must NOT be persisted (canonical source is
+    # ProjectManager / already-deprecated).
+    assert "project_path" not in info
+    assert "model" not in info
+    assert "system_prompt" not in info
 
 
 def test_remove(tmp_data_dir: str) -> None:
     store = SessionStore(data_dir=tmp_data_dir)
-    store.save_session(456, "sess-def", "/tmp/p2")
+    store.save_session(456, "sess-def")
     assert store.get_session_info(456) is not None
     store.remove_session(456)
     assert store.get_session_info(456) is None
@@ -38,21 +43,21 @@ def test_remove(tmp_data_dir: str) -> None:
 
 def test_persistence(tmp_data_dir: str) -> None:
     store1 = SessionStore(data_dir=tmp_data_dir)
-    store1.save_session(789, "sess-ghi", "/tmp/p3", model="opus")
+    store1.save_session(789, "sess-ghi", permission_mode_override="acceptEdits")
 
     # Create a new instance pointing at the same directory
     store2 = SessionStore(data_dir=tmp_data_dir)
     info = store2.get_session_info(789)
     assert info is not None
     assert info["session_id"] == "sess-ghi"
-    assert info["model"] == "opus"
+    assert info["permission_mode_override"] == "acceptEdits"
 
 
 def test_list_all(tmp_data_dir: str) -> None:
     store = SessionStore(data_dir=tmp_data_dir)
-    store.save_session(1, "s1", "/p1")
-    store.save_session(2, "s2", "/p2")
-    store.save_session(3, "s3", "/p3")
+    store.save_session(1, "s1")
+    store.save_session(2, "s2")
+    store.save_session(3, "s3")
     all_sessions = store.list_all()
     assert len(all_sessions) == 3
     assert "1" in all_sessions
@@ -63,3 +68,89 @@ def test_list_all(tmp_data_dir: str) -> None:
 def test_missing_returns_none(tmp_data_dir: str) -> None:
     store = SessionStore(data_dir=tmp_data_dir)
     assert store.get_session_info(999) is None
+
+
+def test_load_strips_legacy_shadow_fields(tmp_path: Path) -> None:
+    """#295: on load, ``model`` / ``system_prompt`` / ``project_path``
+    should be stripped from every entry and the migration should
+    rewrite ``sessions.json`` in place.
+
+    Preserves: ``session_id``, ``last_active``, ``permission_mode_override``
+    (and any future unknown fields — we only drop the 3 named shadows).
+    """
+    data_dir = tmp_path / "d"
+    data_dir.mkdir()
+    legacy = {
+        "1": {
+            "session_id": "s1",
+            "project_path": "/tmp/legacy",
+            "model": "sonnet",
+            "system_prompt": "hello",
+            "permission_mode_override": "plan",
+            "last_active": "2024-01-01T00:00:00+00:00",
+            "future_field": "keep-me",
+        },
+        "2": {
+            "session_id": "s2",
+            # older schema: missing permission_mode_override
+            "project_path": "/tmp/older",
+            "model": None,
+            "system_prompt": "",
+            "last_active": "x",
+        },
+    }
+    (data_dir / "sessions.json").write_text(json.dumps(legacy))
+
+    store = SessionStore(data_dir=str(data_dir))
+
+    info1 = store.get_session_info(1)
+    assert info1 is not None
+    assert info1["session_id"] == "s1"
+    assert info1["permission_mode_override"] == "plan"
+    assert info1["last_active"] == "2024-01-01T00:00:00+00:00"
+    assert info1["future_field"] == "keep-me"
+    # Shadow fields dropped
+    assert "project_path" not in info1
+    assert "model" not in info1
+    assert "system_prompt" not in info1
+
+    info2 = store.get_session_info(2)
+    assert info2 is not None
+    assert info2["session_id"] == "s2"
+    assert "project_path" not in info2
+    assert "model" not in info2
+    assert "system_prompt" not in info2
+    # Legacy row without permission_mode_override stays field-less
+    assert info2.get("permission_mode_override") is None
+
+    # Migration wrote back to disk — reloading confirms.
+    on_disk = json.loads((data_dir / "sessions.json").read_text())
+    assert "project_path" not in on_disk["1"]
+    assert "model" not in on_disk["1"]
+    assert "system_prompt" not in on_disk["1"]
+    assert on_disk["1"]["future_field"] == "keep-me"
+
+
+def test_load_no_migration_when_clean(tmp_path: Path) -> None:
+    """Startup should NOT touch the file if there are no shadow fields
+    to strip (avoid pointless atomic-write churn on every boot)."""
+    data_dir = tmp_path / "d"
+    data_dir.mkdir()
+    clean = {
+        "1": {
+            "session_id": "s1",
+            "permission_mode_override": None,
+            "last_active": "2024-01-01T00:00:00+00:00",
+        }
+    }
+    path = data_dir / "sessions.json"
+    path.write_text(json.dumps(clean))
+    mtime_before = path.stat().st_mtime_ns
+
+    # Sleep-free: SessionStore._save uses atomic_write_json which
+    # rewrites the file; if migration didn't fire, mtime is unchanged.
+    SessionStore(data_dir=str(data_dir))
+    mtime_after = path.stat().st_mtime_ns
+    assert mtime_before == mtime_after, (
+        "clean sessions.json should not be rewritten on startup"
+    )


### PR DESCRIPTION
Closes #295. Strips system_prompt/project_path/model from sessions.json. permission_mode defaults to None (CLI settings take over). 1263 passed.