### PR TITLE
fix(#293): /agent /model /mcp list use SDK runtime APIs

### DIFF
--- a/docs/prd/fix-293-list-runtime.md
+++ b/docs/prd/fix-293-list-runtime.md
@@ -1,0 +1,25 @@
+# PRD — #293 /agent, /model, /mcp list use SDK runtime APIs
+
+**Issue**: #293 (bug, P1)
+**Branch**: `fix/293-list-runtime-api`
+**Status**: APPROVED
+
+## Fix
+3 list commands should query SDK runtime instead of local data.
+
+### /agent list
+- If active session: `bridge.get_server_info()` → agents list
+- Merge with `/agent create` local agents from data/agents.json
+- No session: read `.claude/agents/*.md` from project path + `~/.claude/agents/`
+
+### /model list
+- If active session: use bridge model info from SDK
+- Keep KNOWN_MODELS as fallback for no-session display
+
+### /mcp list
+- If active session: call `bridge.get_mcp_status()` (or similar SDK API)
+- Show all loaded servers (CLI + user + project)
+- No session: fallback to project_manager data
+
+## AC
+- AC1-AC6 per issue

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -365,6 +365,48 @@ class ClaudeBridge:
                 })
             raise
 
+    async def get_mcp_status(self) -> dict | None:
+        """Return live MCP server connection status, or ``None`` if not connected.
+
+        Public wrapper for ``_client.get_mcp_status()`` — parallel to
+        :meth:`get_server_info`. Used by ``/mcp list`` (#293) to display
+        the servers the CLI has actually loaded (project ``.mcp.json`` +
+        user settings + plugin-declared) instead of only the ones stored
+        in the bot's own project_manager JSON.
+
+        Returns the raw SDK ``McpStatusResponse`` dict (has key
+        ``"mcpServers"`` → list of ``{name, status, config, scope, ...}``).
+        A future SDK refactor could break that shape — callers should
+        still ``try/except`` and degrade gracefully.
+        """
+        client = self._client
+        if client is None or not self._active:
+            return None
+        log.debug("get_mcp_status -> requesting")
+        try:
+            result = await client.get_mcp_status()
+            log.debug(
+                "get_mcp_status -> %s (%d servers)",
+                "None" if result is None else "dict",
+                len((result or {}).get("mcpServers", []) or []),
+            )
+            if stream_logger.is_enabled():
+                stream_logger.log_event({
+                    "type": "ControlPlane",
+                    "method": "get_mcp_status",
+                    "server_count": len((result or {}).get("mcpServers", []) or []),
+                })
+            return result
+        except Exception:
+            log.warning("get_mcp_status failed", exc_info=True)
+            if stream_logger.is_enabled():
+                stream_logger.log_event({
+                    "type": "ControlPlane",
+                    "method": "get_mcp_status",
+                    "error": True,
+                })
+            raise
+
     async def get_context_usage(self) -> dict | None:
         """Return current context-window usage, or ``None`` if not connected.
 

--- a/src/clauded/cogs/agent.py
+++ b/src/clauded/cogs/agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -97,7 +98,7 @@ async def agent_create(
         description=f"Prompt: {prompt[:200]}{'…' if len(prompt) > 200 else ''}",
         color=COLOR_INFO,
     )
-    await interaction.response.send_message(embed=embed, ephemeral=True)
+    await interaction.followup.send(embed=embed, ephemeral=True)
 
 
 @agent_group.command(name="list", description="List available agents")
@@ -124,6 +125,8 @@ async def agent_list(interaction: discord.Interaction) -> None:
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
 
+    await interaction.response.defer(ephemeral=True)
+
     # {name: {description, source, prompt_preview?}}. ``source`` is one of
     # ``"sdk"``, ``"local"``, or ``"file"`` — used only to nudge the UI copy
     # (no user-visible tag today, but keeps merge-order deterministic).
@@ -138,7 +141,7 @@ async def agent_list(interaction: discord.Interaction) -> None:
     )
     if bridge is not None:
         try:
-            info = await bridge.get_server_info()
+            info = await asyncio.wait_for(bridge.get_server_info(), timeout=10)
         except Exception as exc:
             log.debug("/agent list: get_server_info failed: %r", exc)
             info = None
@@ -153,7 +156,7 @@ async def agent_list(interaction: discord.Interaction) -> None:
                 merged.setdefault(name, {"description": desc, "source": "sdk"})
 
     # --- Path B: filesystem fallback when no bridge -------------------
-    if bridge is None:
+    if bridge is None or not merged:  # E4: fallback if SDK returned no agents
         binding_id = resolve_channel_id(interaction)
         if binding_id is not None:
             cwd, is_bound = bot.project_manager.get_path_or_default(binding_id)
@@ -183,7 +186,7 @@ async def agent_list(interaction: discord.Interaction) -> None:
         }
 
     if not merged:
-        await interaction.response.send_message(
+        await interaction.followup.send(
             "No agents defined. Use `/agent create` or drop a `.md` file "
             "in `.claude/agents/`.",
             ephemeral=True,

--- a/src/clauded/cogs/agent.py
+++ b/src/clauded/cogs/agent.py
@@ -207,7 +207,8 @@ async def agent_list(interaction: discord.Interaction) -> None:
         if len(value) > 1024:
             value = value[:1020] + "…"
         embed.add_field(name=aname, value=value, inline=False)
-    await interaction.response.send_message(embed=embed, ephemeral=True)
+    _send = interaction.followup.send if _deferred else interaction.response.send_message
+    await _send(embed=embed, ephemeral=True)
 
 
 @agent_group.command(name="use", description="Use a custom agent in this thread")

--- a/src/clauded/cogs/agent.py
+++ b/src/clauded/cogs/agent.py
@@ -3,14 +3,70 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import discord
 from discord import app_commands
 
-from ._unbound import reject_if_unbound
+from ._unbound import reject_if_unbound, resolve_channel_id
 from ..discord_renderer import COLOR_INFO
 
 log = logging.getLogger("clauded.bot")
+
+
+def _parse_agent_md(path: Path) -> tuple[str, str] | None:
+    """Parse ``name`` + ``description`` from a ``.claude/agents/*.md`` frontmatter.
+
+    Returns ``(name, description)`` or ``None`` if the file has no readable
+    frontmatter. Best-effort — the Claude CLI's own parser is authoritative;
+    we just need enough to render the /agent list fallback when no live
+    session is available. #293.
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    # Frontmatter is delimited by leading ``---`` and a trailing ``---``.
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    if end < 0:
+        return None
+    fm = text[3:end]
+    name: str | None = None
+    desc: str | None = None
+    for line in fm.splitlines():
+        line = line.strip()
+        if not line or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip().lower()
+        value = value.strip().strip('"').strip("'")
+        if key == "name" and value:
+            name = value
+        elif key == "description" and value:
+            desc = value
+    fallback_name = path.stem
+    return (name or fallback_name, desc or "")
+
+
+def _read_agents_from_dir(dir_path: Path) -> dict[str, str]:
+    """Return ``{name: description}`` for every parseable ``.md`` under ``dir_path``.
+
+    Silent on I/O errors — this is best-effort fallback display (#293).
+    """
+    out: dict[str, str] = {}
+    try:
+        entries = list(dir_path.glob("*.md"))
+    except OSError:
+        return out
+    for p in entries:
+        parsed = _parse_agent_md(p)
+        if parsed is None:
+            continue
+        name, desc = parsed
+        out.setdefault(name, desc)
+    return out
 
 
 agent_group = app_commands.Group(
@@ -46,24 +102,105 @@ async def agent_create(
 
 @agent_group.command(name="list", description="List available agents")
 async def agent_list(interaction: discord.Interaction) -> None:
+    """List agents visible to the current channel (#293).
+
+    Precedence:
+
+    1. **Active session** (bridge exists): call ``bridge.get_server_info()``
+       and pull the ``agents`` list — this is what the CLI has actually
+       loaded (built-ins + project ``.claude/agents/`` + user
+       ``~/.claude/agents/``). Merge with local ``/agent create`` entries
+       from ``data/agents.json`` so runtime-created custom agents still
+       show up.
+    2. **No active session**: read ``.md`` files directly from the bound
+       project's ``.claude/agents/`` (when bound) plus
+       ``~/.claude/agents/``, and merge with ``data/agents.json``. This
+       satisfies AC1 (see ``pm-agent.md``) without spawning a transient
+       SDK client.
+    """
     from ..bot import ClaudedBot
     bot = interaction.client
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
-    agents = bot.agent_manager.list_all()
-    if not agents:
-        await interaction.response.send_message("No custom agents defined. Use `/agent create`.", ephemeral=True)
-        return
-    embed = discord.Embed(title="\U0001f916 Custom Agents", color=COLOR_INFO)
-    for aname, ainfo in agents.items():
-        desc = ainfo.get("description", "")
-        prompt_preview = ainfo.get("prompt", "")[:100]
-        embed.add_field(
-            name=aname,
-            value=f"{desc}\n`{prompt_preview}{'…' if len(ainfo.get('prompt', '')) > 100 else ''}`",
-            inline=False,
+
+    # {name: {description, source, prompt_preview?}}. ``source`` is one of
+    # ``"sdk"``, ``"local"``, or ``"file"`` — used only to nudge the UI copy
+    # (no user-visible tag today, but keeps merge-order deterministic).
+    merged: dict[str, dict[str, str]] = {}
+
+    # --- Path A: live bridge (best data) ------------------------------
+    session_id = interaction.channel_id
+    bridge = (
+        bot.session_manager.get_session(session_id)
+        if session_id is not None
+        else None
+    )
+    if bridge is not None:
+        try:
+            info = await bridge.get_server_info()
+        except Exception as exc:
+            log.debug("/agent list: get_server_info failed: %r", exc)
+            info = None
+        if info:
+            for entry in info.get("agents", []) or []:
+                if not isinstance(entry, dict):
+                    continue
+                name = entry.get("name") or ""
+                if not name:
+                    continue
+                desc = entry.get("description") or ""
+                merged.setdefault(name, {"description": desc, "source": "sdk"})
+
+    # --- Path B: filesystem fallback when no bridge -------------------
+    if bridge is None:
+        binding_id = resolve_channel_id(interaction)
+        if binding_id is not None:
+            cwd, is_bound = bot.project_manager.get_path_or_default(binding_id)
+            if is_bound:
+                project_dir = Path(cwd) / ".claude" / "agents"
+                for name, desc in _read_agents_from_dir(project_dir).items():
+                    merged.setdefault(name, {"description": desc, "source": "file"})
+        try:
+            user_dir = Path.home() / ".claude" / "agents"
+        except (RuntimeError, OSError):
+            user_dir = None
+        if user_dir is not None:
+            for name, desc in _read_agents_from_dir(user_dir).items():
+                merged.setdefault(name, {"description": desc, "source": "file"})
+
+    # --- Always merge: local /agent create entries --------------------
+    for name, info_dict in bot.agent_manager.list_all().items():
+        prompt = info_dict.get("prompt", "") or ""
+        desc = info_dict.get("description", "") or ""
+        prompt_preview = prompt[:100] + ("…" if len(prompt) > 100 else "")
+        # Local agents override so their prompt preview is visible even
+        # if the SDK returned a same-named entry with just a description.
+        merged[name] = {
+            "description": desc,
+            "source": "local",
+            "prompt_preview": prompt_preview,
+        }
+
+    if not merged:
+        await interaction.response.send_message(
+            "No agents defined. Use `/agent create` or drop a `.md` file "
+            "in `.claude/agents/`.",
+            ephemeral=True,
         )
+        return
+
+    embed = discord.Embed(title=f"\U0001f916 Agents ({len(merged)})", color=COLOR_INFO)
+    for aname, ainfo in sorted(merged.items()):
+        desc = ainfo.get("description", "")
+        value = desc or "_(no description)_"
+        preview = ainfo.get("prompt_preview")
+        if preview:
+            value = f"{value}\n`{preview}`" if desc else f"`{preview}`"
+        # Discord field value cap = 1024
+        if len(value) > 1024:
+            value = value[:1020] + "…"
+        embed.add_field(name=aname, value=value, inline=False)
     await interaction.response.send_message(embed=embed, ephemeral=True)
 
 

--- a/src/clauded/cogs/agent.py
+++ b/src/clauded/cogs/agent.py
@@ -98,7 +98,7 @@ async def agent_create(
         description=f"Prompt: {prompt[:200]}{'…' if len(prompt) > 200 else ''}",
         color=COLOR_INFO,
     )
-    await interaction.followup.send(embed=embed, ephemeral=True)
+    await interaction.response.send_message(embed=embed, ephemeral=True)
 
 
 @agent_group.command(name="list", description="List available agents")
@@ -125,7 +125,7 @@ async def agent_list(interaction: discord.Interaction) -> None:
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
 
-    await interaction.response.defer(ephemeral=True)
+    _deferred = False
 
     # {name: {description, source, prompt_preview?}}. ``source`` is one of
     # ``"sdk"``, ``"local"``, or ``"file"`` — used only to nudge the UI copy
@@ -140,6 +140,8 @@ async def agent_list(interaction: discord.Interaction) -> None:
         else None
     )
     if bridge is not None:
+        await interaction.response.defer(ephemeral=True)
+        _deferred = True
         try:
             info = await asyncio.wait_for(bridge.get_server_info(), timeout=10)
         except Exception as exc:
@@ -186,7 +188,8 @@ async def agent_list(interaction: discord.Interaction) -> None:
         }
 
     if not merged:
-        await interaction.followup.send(
+        _send = interaction.followup.send if _deferred else interaction.response.send_message
+        await _send(
             "No agents defined. Use `/agent create` or drop a `.md` file "
             "in `.claude/agents/`.",
             ephemeral=True,

--- a/src/clauded/cogs/mcp.py
+++ b/src/clauded/cogs/mcp.py
@@ -105,7 +105,7 @@ async def mcp_add(
         description=f"Type: stdio\nCommand: `{command}`" + (f"\nArgs: `{args}`" if args else ""),
         color=COLOR_INFO,
     )
-    await interaction.followup.send(embed=embed, ephemeral=True)
+    await interaction.response.send_message(embed=embed, ephemeral=True)
 
 
 @mcp_group.command(name="add-url", description="Add an HTTP MCP server")
@@ -157,7 +157,7 @@ async def mcp_list(interaction: discord.Interaction) -> None:
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
 
-    await interaction.response.defer(ephemeral=True)
+    _deferred = False
 
     # --- Path A: live bridge → SDK's mcp status -----------------------
     session_id = interaction.channel_id
@@ -167,6 +167,8 @@ async def mcp_list(interaction: discord.Interaction) -> None:
         else None
     )
     if bridge is not None:
+        await interaction.response.defer(ephemeral=True)
+        _deferred = True
         status: dict | None = None
         try:
             status = await asyncio.wait_for(bridge.get_mcp_status(), timeout=10)

--- a/src/clauded/cogs/mcp.py
+++ b/src/clauded/cogs/mcp.py
@@ -13,6 +13,61 @@ from ..discord_renderer import COLOR_INFO
 log = logging.getLogger("clauded.bot")
 
 
+# Emoji per connection status — keeps the /mcp list embed readable when
+# the CLI reports many servers with mixed health (#293).
+_STATUS_ICON = {
+    "connected": "🟢",
+    "pending": "🟡",
+    "needs-auth": "🔒",
+    "disabled": "⚪",
+    "failed": "🔴",
+}
+
+
+def _format_live_server(entry: dict) -> tuple[str, str]:
+    """Render a single ``McpServerStatus`` dict into an embed ``(name, value)`` pair.
+
+    Best-effort — the SDK's schema may add keys over time; we just show
+    what we recognize (name, status, scope, transport-specific config).
+    """
+    name = str(entry.get("name") or "?")
+    status = str(entry.get("status") or "?")
+    scope = str(entry.get("scope") or "")
+    icon = _STATUS_ICON.get(status, "•")
+    header = f"{icon} {status}"
+    if scope:
+        header += f" · {scope}"
+
+    config = entry.get("config") or {}
+    stype = str(config.get("type") or "stdio")
+    detail_lines: list[str] = []
+    if stype == "http" or stype == "sse":
+        url = config.get("url", "N/A")
+        detail_lines.append(f"URL: `{url}`")
+    elif stype == "stdio":
+        cmd = config.get("command", "?")
+        args = config.get("args") or []
+        sargs = " ".join(str(a) for a in args)
+        detail_lines.append(f"Command: `{cmd}`")
+        if sargs:
+            detail_lines.append(f"Args: `{sargs}`")
+    else:
+        detail_lines.append(f"Type: `{stype}`")
+
+    err = entry.get("error")
+    if status == "failed" and err:
+        # Keep error short and back-tick-safe (mirror /model current #210 defense).
+        safe_err = str(err).replace("`", "'")[:200]
+        detail_lines.append(f"⚠️ {safe_err}")
+
+    tools = entry.get("tools") or []
+    if isinstance(tools, list) and tools:
+        detail_lines.append(f"Tools: {len(tools)}")
+
+    value = header + "\n" + "\n".join(detail_lines) if detail_lines else header
+    return (f"{name} ({stype})", value)
+
+
 mcp_group = app_commands.Group(
     name="mcp",
     description="Manage MCP servers for Claude.",
@@ -82,11 +137,62 @@ async def mcp_add_url(interaction: discord.Interaction, name: str, url: str) -> 
 
 @mcp_group.command(name="list", description="List configured MCP servers")
 async def mcp_list(interaction: discord.Interaction) -> None:
+    """List MCP servers the CLI has loaded for this channel (#293).
+
+    Precedence:
+
+    1. **Active session** — call ``bridge.get_mcp_status()`` and render
+       the live ``mcpServers`` array (project ``.mcp.json`` + user
+       settings + plugin-declared + our own ``clauded-scheduler``, with
+       connection state).
+    2. **No active session** (or SDK call fails) — fall back to the
+       previous behavior of listing the bot's own stored configuration
+       via ``project_manager.get_mcp_servers``. Unbound channels are
+       still refused up-front (unchanged Group-A policy).
+    """
     from ..bot import ClaudedBot
     bot = interaction.client
     if not isinstance(bot, ClaudedBot):
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
+
+    # --- Path A: live bridge → SDK's mcp status -----------------------
+    session_id = interaction.channel_id
+    bridge = (
+        bot.session_manager.get_session(session_id)
+        if session_id is not None
+        else None
+    )
+    if bridge is not None:
+        status: dict | None = None
+        try:
+            status = await bridge.get_mcp_status()
+        except Exception as exc:
+            log.debug("/mcp list: get_mcp_status failed: %r", exc)
+            status = None
+        if status is not None:
+            servers = status.get("mcpServers") or []
+            if not servers:
+                await interaction.response.send_message(
+                    "No MCP servers loaded by the current session.",
+                    ephemeral=True,
+                )
+                return
+            embed = discord.Embed(
+                title=f"\U0001f50c MCP Servers ({len(servers)})",
+                color=COLOR_INFO,
+            )
+            for entry in servers:
+                if not isinstance(entry, dict):
+                    continue
+                field_name, field_value = _format_live_server(entry)
+                if len(field_value) > 1024:
+                    field_value = field_value[:1020] + "…"
+                embed.add_field(name=field_name, value=field_value, inline=False)
+            await interaction.response.send_message(embed=embed, ephemeral=True)
+            return
+
+    # --- Path B: no live session → fall back to stored config ---------
     if await reject_if_unbound(interaction, bot):
         return
     binding_id = resolve_binding_id(interaction)
@@ -95,7 +201,11 @@ async def mcp_list(interaction: discord.Interaction) -> None:
         return
     servers = bot.project_manager.get_mcp_servers(binding_id)
     if not servers:
-        await interaction.response.send_message("No MCP servers configured.", ephemeral=True)
+        await interaction.response.send_message(
+            "No MCP servers configured. "
+            "-# Start a session to see all servers loaded by the CLI.",
+            ephemeral=True,
+        )
         return
     embed = discord.Embed(title="\U0001f50c MCP Servers", color=COLOR_INFO)
     for sname, sconfig in servers.items():
@@ -107,6 +217,11 @@ async def mcp_list(interaction: discord.Interaction) -> None:
             sargs = " ".join(sconfig.get("args", []))
             detail = f"Command: `{cmd}`" + (f"\nArgs: `{sargs}`" if sargs else "")
         embed.add_field(name=f"{sname} ({stype})", value=detail, inline=False)
+    # Footer nudge — stored config is a subset of what the CLI will load.
+    embed.set_footer(
+        text="Showing bot-configured servers only. "
+        "Start a session to see everything the CLI loaded (project + user + plugins)."
+    )
     await interaction.response.send_message(embed=embed, ephemeral=True)
 
 

--- a/src/clauded/cogs/mcp.py
+++ b/src/clauded/cogs/mcp.py
@@ -178,7 +178,8 @@ async def mcp_list(interaction: discord.Interaction) -> None:
         if status is not None:
             servers = status.get("mcpServers") or []
             if not servers:
-                await interaction.response.send_message(
+                _send = interaction.followup.send if _deferred else interaction.response.send_message
+                await _send(
                     "No MCP servers loaded by the current session.",
                     ephemeral=True,
                 )
@@ -194,7 +195,8 @@ async def mcp_list(interaction: discord.Interaction) -> None:
                 if len(field_value) > 1024:
                     field_value = field_value[:1020] + "…"
                 embed.add_field(name=field_name, value=field_value, inline=False)
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            _send = interaction.followup.send if _deferred else interaction.response.send_message
+            await _send(embed=embed, ephemeral=True)
             return
 
     # --- Path B: no live session → fall back to stored config ---------
@@ -202,11 +204,13 @@ async def mcp_list(interaction: discord.Interaction) -> None:
         return
     binding_id = resolve_binding_id(interaction)
     if binding_id is None:
-        await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
+        _send = interaction.followup.send if _deferred else interaction.response.send_message
+        await _send(NO_CHANNEL_MESSAGE, ephemeral=True)
         return
     servers = bot.project_manager.get_mcp_servers(binding_id)
     if not servers:
-        await interaction.response.send_message(
+        _send = interaction.followup.send if _deferred else interaction.response.send_message
+        await _send(
             "No MCP servers configured. "
             "-# Start a session to see all servers loaded by the CLI.",
             ephemeral=True,
@@ -227,7 +231,8 @@ async def mcp_list(interaction: discord.Interaction) -> None:
         text="Showing bot-configured servers only. "
         "Start a session to see everything the CLI loaded (project + user + plugins)."
     )
-    await interaction.response.send_message(embed=embed, ephemeral=True)
+    _send = interaction.followup.send if _deferred else interaction.response.send_message
+    await _send(embed=embed, ephemeral=True)
 
 
 @mcp_group.command(name="remove", description="Remove an MCP server")

--- a/src/clauded/cogs/mcp.py
+++ b/src/clauded/cogs/mcp.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import discord
@@ -104,7 +105,7 @@ async def mcp_add(
         description=f"Type: stdio\nCommand: `{command}`" + (f"\nArgs: `{args}`" if args else ""),
         color=COLOR_INFO,
     )
-    await interaction.response.send_message(embed=embed, ephemeral=True)
+    await interaction.followup.send(embed=embed, ephemeral=True)
 
 
 @mcp_group.command(name="add-url", description="Add an HTTP MCP server")
@@ -156,6 +157,8 @@ async def mcp_list(interaction: discord.Interaction) -> None:
         await interaction.response.send_message("Bot not ready.", ephemeral=True)
         return
 
+    await interaction.response.defer(ephemeral=True)
+
     # --- Path A: live bridge → SDK's mcp status -----------------------
     session_id = interaction.channel_id
     bridge = (
@@ -166,7 +169,7 @@ async def mcp_list(interaction: discord.Interaction) -> None:
     if bridge is not None:
         status: dict | None = None
         try:
-            status = await bridge.get_mcp_status()
+            status = await asyncio.wait_for(bridge.get_mcp_status(), timeout=10)
         except Exception as exc:
             log.debug("/mcp list: get_mcp_status failed: %r", exc)
             status = None

--- a/src/clauded/cogs/model.py
+++ b/src/clauded/cogs/model.py
@@ -160,6 +160,18 @@ async def model_switch(interaction: discord.Interaction, name: str) -> None:
 
 @model_group.command(name="list", description="List available models + show current")
 async def model_list(interaction: discord.Interaction) -> None:
+    """List models the SDK reports as available for the current session (#293).
+
+    Precedence:
+
+    1. **Active session** — call ``bridge.get_server_info()`` and use its
+       ``models`` array (CLI-authoritative). Fall back to ``KNOWN_MODELS``
+       only if the SDK call fails or returns nothing.
+    2. **No active session** — display ``KNOWN_MODELS`` as before, but
+       clearly flagged as static reference data.
+
+    ``current`` marker resolution unchanged (``bridge.model`` chain).
+    """
     from ..bot import ClaudedBot
     bot = interaction.client
     if not isinstance(bot, ClaudedBot):
@@ -167,26 +179,71 @@ async def model_list(interaction: discord.Interaction) -> None:
         return
     current = _current_model_for_thread(bot, interaction.channel)
     bridge = _resolve_session_bridge(bot, interaction.channel)
-    # Build the rendered list
-    lines = []
-    for alias, info in KNOWN_MODELS.items():
-        ctx = _fmt_context(info["context"])
-        tier = info["tier"]
-        model_id = info["id"]
-        # Mark currently-active model (match alias OR id)
-        marker = "🟢 " if current and (current == alias or current == model_id) else "• "
-        lines.append(f"{marker}**{alias}** (`{model_id}`) - {tier}, {ctx} context")
+
+    sdk_models: list[dict] = []
+    if bridge is not None:
+        try:
+            info = await bridge.get_server_info()
+        except Exception as exc:
+            log.debug("/model list: get_server_info failed: %r", exc)
+            info = None
+        if info:
+            raw = info.get("models") or []
+            if isinstance(raw, list):
+                sdk_models = [m for m in raw if isinstance(m, dict)]
+
+    lines: list[str] = []
+    if sdk_models:
+        for m in sdk_models:
+            value = str(m.get("value") or "").strip()
+            display_name = str(m.get("displayName") or value or "?").strip()
+            description = str(m.get("description") or "").strip()
+            # Enrich with KNOWN_MODELS context/tier when we recognize the alias
+            # so the display keeps its familiar shape without re-hardcoding.
+            enrich = KNOWN_MODELS.get(value)
+            ctx_suffix = ""
+            if enrich is not None:
+                ctx_suffix = f" — {enrich['tier']}, {_fmt_context(enrich['context'])} context"
+            marker = (
+                "🟢 " if current and (current == value or (enrich and current == enrich["id"]))
+                else "• "
+            )
+            # Cap description to keep the embed under Discord's 4096 char
+            # limit on description; ``models`` typically returns 5 entries
+            # so the total stays well under.
+            desc_short = description[:120] + ("…" if len(description) > 120 else "")
+            row = f"{marker}**{display_name}** (`{value}`){ctx_suffix}"
+            if desc_short:
+                row += f"\n  {desc_short}"
+            lines.append(row)
+    else:
+        for alias, meta in KNOWN_MODELS.items():
+            ctx = _fmt_context(meta["context"])
+            tier = meta["tier"]
+            model_id = meta["id"]
+            marker = "🟢 " if current and (current == alias or current == model_id) else "• "
+            lines.append(f"{marker}**{alias}** (`{model_id}`) - {tier}, {ctx} context")
+
     desc = "\n".join(lines)
     if current:
         header = f"**Current**: `{current}`\n\n**Available models**:\n"
     elif bridge is not None:
-        # Session exists but model not yet determined (pre-first-turn)
         header = "**Current**: _(unset - will use CLI default)_\n\n**Available models**:\n"
     else:
         header = "_No active session. Run inside a thread to see current model._\n\n**Available models**:\n"
+
+    footer_note = (
+        "\n\nUse `/model switch <name>` to switch.\n"
+        "-# Switching resets the conversation context."
+    )
+    if not sdk_models:
+        footer_note += (
+            "\n-# ⚠️ Static reference — start a session to see the CLI's actual models."
+        )
+
     embed = discord.Embed(
         title="🤖 Model Selection",
-        description=header + desc + "\n\nUse `/model switch <name>` to switch.\n-# Switching resets the conversation context.",
+        description=header + desc + footer_note,
         color=COLOR_INFO,
     )
     await interaction.response.send_message(embed=embed)


### PR DESCRIPTION
Closes #293. All 3 list commands query SDK runtime with proper fallbacks. 1262 passed.