### PR TITLE
refactor(#294): align /agent /mcp with CLI native config

### DIFF
--- a/.claude/agents/cool.md
+++ b/.claude/agents/cool.md
@@ -1,0 +1,5 @@
+---
+name: "cool"
+description: ""
+---
+be cool

--- a/.claude/agents/dup.md
+++ b/.claude/agents/dup.md
@@ -1,0 +1,5 @@
+---
+name: "dup"
+description: ""
+---
+first

--- a/.claude/agents/test-agent.md
+++ b/.claude/agents/test-agent.md
@@ -1,0 +1,5 @@
+---
+name: "test-agent"
+description: ""
+---
+You are a test helper.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "test-mcp": {
+      "type": "stdio",
+      "command": "echo hello"
+    },
+    "remote-mcp": {
+      "type": "http",
+      "url": "https://example.com/mcp"
+    }
+  }
+}

--- a/docs/prd/refactor-294-cli-native.md
+++ b/docs/prd/refactor-294-cli-native.md
@@ -1,0 +1,32 @@
+# PRD — #294 align /agent /mcp with CLI native config
+
+**Issue**: #294 (epic, P1)
+**Branch**: `refactor/294-cli-native-config`
+**Status**: APPROVED
+
+## Summary
+Replace shadow config (data/agents.json + data/projects.json mcp_servers) with CLI-native storage (.claude/agents/*.md + .mcp.json).
+
+## Subtask 1: /agent create → write .claude/agents/<name>.md
+- Parse prompt + description into frontmatter + body format
+- Write to `{project_path}/.claude/agents/<name>.md`
+- Delete from data/agents.json if exists
+
+## Subtask 2: /agent delete → remove .claude/agents/<name>.md
+- Remove the .md file from project dir
+
+## Subtask 3: /mcp add → write .mcp.json
+- Read existing .mcp.json (or create new)
+- Add server entry to mcpServers dict
+- Write back atomically
+
+## Subtask 4: /mcp remove → edit .mcp.json
+- Remove server entry from mcpServers dict
+
+## Subtask 5: Migration script
+- On startup: migrate data/agents.json → .claude/agents/*.md
+- On startup: migrate projects.json mcp_servers → .mcp.json
+- After migration, stop writing to old locations
+
+## AC
+- AC1-AC8 per issue

--- a/src/clauded/_cli_native.py
+++ b/src/clauded/_cli_native.py
@@ -47,8 +47,17 @@ _FILE_LOCK = threading.RLock()
 
 
 def agent_md_path(project_path: Path | str, name: str) -> Path:
-    """Return the canonical path for an agent's ``.md`` under a project."""
-    return Path(project_path) / ".claude" / "agents" / f"{name}.md"
+    """Return the canonical path for an agent's ``.md`` under a project.
+
+    Raises ValueError if name contains path separators or traversal sequences.
+    """
+    # C1 guard: reject path-separator / traversal in name
+    if any(c in name for c in ("/", "\\", "\x00")) or ".." in name:
+        raise ValueError(f"Agent name contains invalid characters: {name!r}")
+    safe_name = name.strip().replace(" ", "-")
+    if not safe_name:
+        raise ValueError("Agent name is empty after sanitization")
+    return Path(project_path) / ".claude" / "agents" / f"{safe_name}.md"
 
 
 def write_agent_md(
@@ -72,11 +81,14 @@ def write_agent_md(
     target.parent.mkdir(parents=True, exist_ok=True)
 
     desc_line = (description or "").replace("\r", " ").replace("\n", " ")
+    # C2: YAML-escape name and description to prevent frontmatter injection
+    safe_name = name.replace('"', '\\"')
+    safe_desc = desc_line.replace('"', '\\"')
     body = prompt or ""
     # Ensure trailing newline so ``cat`` / editors behave.
     if body and not body.endswith("\n"):
         body = body + "\n"
-    content = f"---\nname: {name}\ndescription: {desc_line}\n---\n{body}"
+    content = f'---\nname: "{safe_name}"\ndescription: "{safe_desc}"\n---\n{body}'
 
     tmp = target.with_suffix(f".{os.getpid()}.{secrets.token_hex(4)}.tmp")
     try:

--- a/src/clauded/_cli_native.py
+++ b/src/clauded/_cli_native.py
@@ -81,14 +81,15 @@ def write_agent_md(
     target.parent.mkdir(parents=True, exist_ok=True)
 
     desc_line = (description or "").replace("\r", " ").replace("\n", " ")
-    # C2: YAML-escape name and description to prevent frontmatter injection
-    safe_name = name.replace('"', '\\"')
-    safe_desc = desc_line.replace('"', '\\"')
+    # C2: YAML-safe quoting via json.dumps (handles \, ", etc.)
+    import json
+    safe_name = json.dumps(name)  # produces "name" with proper escapes
+    safe_desc = json.dumps(desc_line)
     body = prompt or ""
     # Ensure trailing newline so ``cat`` / editors behave.
     if body and not body.endswith("\n"):
         body = body + "\n"
-    content = f'---\nname: "{safe_name}"\ndescription: "{safe_desc}"\n---\n{body}'
+    content = f'---\nname: {safe_name}\ndescription: {safe_desc}\n---\n{body}'
 
     tmp = target.with_suffix(f".{os.getpid()}.{secrets.token_hex(4)}.tmp")
     try:

--- a/src/clauded/_cli_native.py
+++ b/src/clauded/_cli_native.py
@@ -1,0 +1,191 @@
+"""Helpers for reading/writing CLI-native config (#294).
+
+``.claude/agents/<name>.md`` and ``.mcp.json`` are the Claude CLI's own
+canonical storage. This module centralises the I/O so ``cogs/agent.py``,
+``cogs/mcp.py``, and the one-time startup migration all agree on the
+layout, atomicity, and locking.
+
+Two write paths:
+
+- :func:`write_agent_md` — YAML frontmatter (``name`` / ``description``)
+  followed by the prompt body. Parseable by the CLI *and* by our own
+  ``cogs/agent._parse_agent_md`` fallback.
+- :func:`add_mcp_server` / :func:`remove_mcp_server` — atomic
+  read-modify-write of the project's ``.mcp.json`` (mcpServers dict).
+
+All writes go through :func:`_json_store.atomic_write_json` (for
+``.mcp.json``) or a similar unique-tmp + ``os.replace`` idiom (for
+``.md``) so a torn write can never leave a half-file on disk.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import threading
+from pathlib import Path
+from typing import Any
+
+from ._json_store import atomic_write_json
+
+log = logging.getLogger("clauded.cli_native")
+
+# One module-level lock guards every ``.mcp.json`` and every
+# ``.claude/agents/*.md`` write across every project. Per-project locking
+# would be nicer but Discord's slash-command dispatch is already
+# effectively serial per interaction and these writes are microseconds —
+# a single lock is more than enough to prevent concurrent tmp-file
+# collisions.
+_FILE_LOCK = threading.RLock()
+
+
+# ---------------------------------------------------------------------------
+# .claude/agents/<name>.md
+# ---------------------------------------------------------------------------
+
+
+def agent_md_path(project_path: Path | str, name: str) -> Path:
+    """Return the canonical path for an agent's ``.md`` under a project."""
+    return Path(project_path) / ".claude" / "agents" / f"{name}.md"
+
+
+def write_agent_md(
+    project_path: Path | str,
+    name: str,
+    prompt: str,
+    description: str = "",
+) -> Path:
+    """Write ``.claude/agents/<name>.md`` atomically.
+
+    Frontmatter is a minimal 2-key YAML block (``name`` + ``description``);
+    ``description`` is single-lined (any embedded ``\\n`` / ``\\r`` is
+    replaced with a space) so the naive line-based parser in
+    ``cogs/agent._parse_agent_md`` round-trips cleanly. The prompt body
+    follows the frontmatter verbatim.
+
+    The write is atomic: content is first written to a unique
+    ``.<pid>.<rand>.tmp`` sibling and ``os.replace``-d into place.
+    """
+    target = agent_md_path(project_path, name)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    desc_line = (description or "").replace("\r", " ").replace("\n", " ")
+    body = prompt or ""
+    # Ensure trailing newline so ``cat`` / editors behave.
+    if body and not body.endswith("\n"):
+        body = body + "\n"
+    content = f"---\nname: {name}\ndescription: {desc_line}\n---\n{body}"
+
+    tmp = target.with_suffix(f".{os.getpid()}.{secrets.token_hex(4)}.tmp")
+    try:
+        with _FILE_LOCK:
+            with open(tmp, "w", encoding="utf-8") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, target)
+    finally:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+    return target
+
+
+def delete_agent_md(project_path: Path | str, name: str) -> bool:
+    """Delete ``.claude/agents/<name>.md``. Returns True iff a file was removed.
+
+    Idempotent — a missing file is not an error.
+    """
+    target = agent_md_path(project_path, name)
+    with _FILE_LOCK:
+        try:
+            target.unlink()
+            return True
+        except FileNotFoundError:
+            return False
+        except OSError as exc:
+            log.warning("delete_agent_md(%s): %s", target, exc)
+            return False
+
+
+# ---------------------------------------------------------------------------
+# .mcp.json
+# ---------------------------------------------------------------------------
+
+
+def mcp_json_path(project_path: Path | str) -> Path:
+    """Return the canonical path for a project's ``.mcp.json``."""
+    return Path(project_path) / ".mcp.json"
+
+
+def _load_mcp_json(path: Path) -> dict:
+    """Return the parsed ``.mcp.json`` payload, or an empty skeleton.
+
+    Any I/O or parse error is treated as "no file yet" and returns a
+    fresh skeleton — matching the CLI which auto-creates the file on
+    first server registration.
+    """
+    if not path.is_file():
+        return {"mcpServers": {}}
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning(".mcp.json (%s) unreadable: %s — starting fresh", path, exc)
+        return {"mcpServers": {}}
+    if not isinstance(data, dict):
+        return {"mcpServers": {}}
+    if "mcpServers" not in data or not isinstance(data.get("mcpServers"), dict):
+        data["mcpServers"] = {}
+    return data
+
+
+def add_mcp_server(
+    project_path: Path | str,
+    name: str,
+    config: dict[str, Any],
+) -> None:
+    """Add ``config`` under ``mcpServers[name]`` in the project's ``.mcp.json``.
+
+    Raises ``ValueError`` if a server with the same name already exists,
+    mirroring :meth:`ProjectManager.add_mcp_server` for consistent UX.
+    """
+    path = mcp_json_path(project_path)
+    with _FILE_LOCK:
+        data = _load_mcp_json(path)
+        servers = data.setdefault("mcpServers", {})
+        if name in servers:
+            raise ValueError(f"MCP server {name!r} already exists in .mcp.json.")
+        servers[name] = config
+        atomic_write_json(path, data, _FILE_LOCK)
+
+
+def remove_mcp_server(project_path: Path | str, name: str) -> bool:
+    """Remove ``mcpServers[name]`` from the project's ``.mcp.json``.
+
+    Returns True iff an entry was removed. Idempotent: missing file /
+    missing entry returns False without raising.
+    """
+    path = mcp_json_path(project_path)
+    with _FILE_LOCK:
+        data = _load_mcp_json(path)
+        servers = data.get("mcpServers") or {}
+        if name not in servers:
+            return False
+        del servers[name]
+        data["mcpServers"] = servers
+        atomic_write_json(path, data, _FILE_LOCK)
+        return True
+
+
+__all__ = [
+    "agent_md_path",
+    "write_agent_md",
+    "delete_agent_md",
+    "mcp_json_path",
+    "add_mcp_server",
+    "remove_mcp_server",
+]

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -36,6 +36,7 @@ from . import scheduler_mcp
 from .scheduler_mcp import set_ctx as _scheduler_set_ctx, get_ctx as _scheduler_get_ctx
 from .cost_tracker import CostTracker
 from .agent_manager import AgentManager
+from . import _cli_native
 from . import stream_logger
 from .cogs._unbound import UNBOUND_HINT_MESSAGE, UNBOUND_REFUSE_MESSAGE
 from .cogs._table_view import CopyTableTextView
@@ -317,6 +318,12 @@ class ClaudedBot(commands.Bot):
         self._start_time = time.time()
         self.cost_tracker = CostTracker()
         self.agent_manager = AgentManager()
+        # #294: one-shot migration from shadow config to CLI-native
+        # ``.claude/agents/`` + ``.mcp.json``. Runs after both managers
+        # have loaded their JSON so we have the full legacy view. Idempotent
+        # (skips agents/servers whose file/entry already exists) so process
+        # restarts are safe.
+        self._migrate_shadow_to_cli_native()
         self._claude_version: str = "unknown"
         self._debug_logging: bool = False
         # v1.18 #160: runtime-toggleable allow_unbound_fallback. Initialized
@@ -369,6 +376,120 @@ class ClaudedBot(commands.Bot):
         # bot is ready so missed-fire bookkeeping happens with a live event
         # loop (cannot be done from __init__).
         self._scheduler_catch_up_done = False
+
+    # ------------------------------------------------------------------ #294
+    # One-shot legacy → CLI-native migration
+    # ------------------------------------------------------------------
+    def _migrate_shadow_to_cli_native(self) -> None:
+        """Migrate legacy shadow config to CLI-native storage (#294).
+
+        Two shadow stores need porting to the Claude CLI's own file
+        layout so ``claude`` picks up the same agents / MCP servers that
+        our slash commands manage:
+
+        * ``data/agents.json`` (per-bot registry) → one
+          ``{project_path}/.claude/agents/<name>.md`` per bound project.
+          Every bound project gets a copy so channels sharing an agent
+          continue to work when the CLI is invoked outside our bridge.
+        * ``data/projects.json``'s ``mcp_servers`` field (per-channel) →
+          one ``{project_path}/.mcp.json`` merging every channel's
+          servers for that path.
+
+        Idempotent: skips agents whose ``.md`` file already exists and
+        MCP servers already present in ``.mcp.json`` (so a hand-edited
+        file wins). All exceptions are swallowed with a warning so a
+        broken filesystem can never brick bot startup — the shadow
+        stores stay authoritative until the file write succeeds on a
+        later boot.
+        """
+        # --- agents.json → .claude/agents/*.md ----------------------------
+        try:
+            legacy_agents = self.agent_manager.list_all()
+        except Exception:
+            log.exception("#294 migration: could not read agent_manager")
+            legacy_agents = {}
+
+        if legacy_agents:
+            # Collect every distinct bound project path once so we don't
+            # rewrite the same ``.md`` for N channels sharing a path.
+            project_paths: set[Path] = set()
+            for _cid, path, _mcps in self.project_manager.iter_mcp_bindings():
+                project_paths.add(Path(path))
+            # ``iter_mcp_bindings`` only returns bindings with mcp_servers;
+            # we also want bindings without any MCP config, so pull those
+            # from the raw project list.
+            try:
+                for key, entry in list(self.project_manager._projects.items()):
+                    path = entry.get("path")
+                    if path:
+                        project_paths.add(Path(path))
+            except Exception:
+                log.exception("#294 migration: could not scan projects for agent copy")
+
+            for project_path in project_paths:
+                for name, info_dict in legacy_agents.items():
+                    target = _cli_native.agent_md_path(project_path, name)
+                    if target.exists():
+                        # Idempotent — respect hand edits and rerun-safety.
+                        continue
+                    try:
+                        _cli_native.write_agent_md(
+                            project_path,
+                            name,
+                            info_dict.get("prompt", "") or "",
+                            info_dict.get("description", "") or "",
+                        )
+                        log.info(
+                            "#294 migration: wrote agent %r to %s",
+                            name,
+                            target,
+                        )
+                    except OSError:
+                        log.exception(
+                            "#294 migration: agent %r → %s failed", name, target
+                        )
+
+        # --- projects.json mcp_servers → .mcp.json ------------------------
+        try:
+            bindings = self.project_manager.iter_mcp_bindings()
+        except Exception:
+            log.exception("#294 migration: could not read project_manager")
+            bindings = []
+
+        # Multiple channels can share a project path; merge their server
+        # dicts into a single ``.mcp.json`` per path. Last channel wins
+        # on same-name collisions (rare — the shadow store rejects dupes
+        # per-channel but two channels can independently register the
+        # same-named server).
+        merged_by_path: dict[Path, dict] = {}
+        for _cid, path_str, mcps in bindings:
+            path = Path(path_str)
+            bucket = merged_by_path.setdefault(path, {})
+            for sname, sconfig in mcps.items():
+                bucket.setdefault(sname, sconfig)
+
+        for project_path, servers in merged_by_path.items():
+            for sname, sconfig in servers.items():
+                try:
+                    _cli_native.add_mcp_server(project_path, sname, sconfig)
+                    log.info(
+                        "#294 migration: wrote MCP %r → %s/.mcp.json",
+                        sname,
+                        project_path,
+                    )
+                except ValueError:
+                    # ``.mcp.json`` already lists the server — idempotent skip.
+                    log.debug(
+                        "#294 migration: MCP %r already present in %s/.mcp.json",
+                        sname,
+                        project_path,
+                    )
+                except OSError:
+                    log.exception(
+                        "#294 migration: MCP %r → %s/.mcp.json failed",
+                        sname,
+                        project_path,
+                    )
 
     async def setup_hook(self) -> None:
         """Register slash command groups and sync to Discord."""

--- a/src/clauded/cogs/agent.py
+++ b/src/clauded/cogs/agent.py
@@ -9,7 +9,8 @@ from pathlib import Path
 import discord
 from discord import app_commands
 
-from ._unbound import reject_if_unbound, resolve_channel_id
+from ._unbound import reject_if_unbound, resolve_binding_id, resolve_channel_id
+from .. import _cli_native
 from ..discord_renderer import COLOR_INFO
 
 log = logging.getLogger("clauded.bot")
@@ -88,10 +89,41 @@ async def agent_create(
         return
     if await reject_if_unbound(interaction, bot):
         return
+    # #294: primary storage is the CLI-native ``.claude/agents/<name>.md``.
+    # ``AgentManager.create`` still runs so the legacy in-memory registry
+    # (used by ``/agent use`` and autocomplete) stays populated and its
+    # duplicate-name validation gates the write. On success we ALSO drop
+    # the file so the Claude CLI itself picks the agent up (AC1). If the
+    # file write fails after the manager already recorded the entry, we
+    # roll back the manager state so the two stores can't diverge.
     try:
         bot.agent_manager.create(name, prompt, description)
     except ValueError as exc:
         await interaction.response.send_message(f"\u274c {exc}", ephemeral=True)
+        return
+    binding_id = resolve_binding_id(interaction)
+    project_path = (
+        bot.project_manager.get_path(binding_id) if binding_id is not None else None
+    )
+    if project_path is None:
+        # reject_if_unbound already covered the "no binding" case; a None
+        # here means the channel is bound but ``get_path`` returned None
+        # (partial entry). Fail closed and roll back the manager write so
+        # the shadow store doesn't drift.
+        bot.agent_manager.delete(name)
+        await interaction.response.send_message(
+            "\u274c Could not resolve project path for this channel.",
+            ephemeral=True,
+        )
+        return
+    try:
+        _cli_native.write_agent_md(project_path, name, prompt, description)
+    except OSError as exc:
+        bot.agent_manager.delete(name)
+        log.exception("write_agent_md failed for %s in %s", name, project_path)
+        await interaction.response.send_message(
+            f"\u274c Failed to write agent file: {exc}", ephemeral=True
+        )
         return
     embed = discord.Embed(
         title=f"\u2705 Agent `{name}` created",
@@ -249,7 +281,24 @@ async def agent_delete(interaction: discord.Interaction, name: str) -> None:
         return
     if await reject_if_unbound(interaction, bot):
         return
-    if bot.agent_manager.delete(name):
+    # #294: mirror /agent create — delete BOTH the CLI-native ``.md`` file
+    # AND the legacy AgentManager entry. Either store may be the only one
+    # holding the agent (migration in progress, or user hand-edited
+    # ``.claude/agents/``), so we consider the delete a success if either
+    # side removed something.
+    binding_id = resolve_binding_id(interaction)
+    project_path = (
+        bot.project_manager.get_path(binding_id) if binding_id is not None else None
+    )
+    file_removed = False
+    if project_path is not None:
+        try:
+            file_removed = _cli_native.delete_agent_md(project_path, name)
+        except OSError:
+            log.exception("delete_agent_md failed for %s in %s", name, project_path)
+            file_removed = False
+    manager_removed = bot.agent_manager.delete(name)
+    if file_removed or manager_removed:
         embed = discord.Embed(
             title=f"\U0001f5d1\ufe0f Agent `{name}` deleted",
             color=COLOR_INFO,

--- a/src/clauded/cogs/mcp.py
+++ b/src/clauded/cogs/mcp.py
@@ -9,6 +9,7 @@ import discord
 from discord import app_commands
 
 from ._unbound import NO_CHANNEL_MESSAGE, reject_if_unbound, resolve_binding_id
+from .. import _cli_native
 from ..discord_renderer import COLOR_INFO
 
 log = logging.getLogger("clauded.bot")
@@ -95,10 +96,38 @@ async def mcp_add(
     config: dict = {"type": "stdio", "command": command}
     if args:
         config["args"] = args.split()
+    # #294: primary storage is the CLI-native ``.mcp.json`` under the
+    # bound project. ``project_manager.add_mcp_server`` still runs so the
+    # legacy per-channel shadow store stays in sync (backwards compat +
+    # its name-validation gate). If the shadow write succeeds but the
+    # ``.mcp.json`` write fails, we roll back so the two stores agree.
     try:
         bot.project_manager.add_mcp_server(binding_id, name, config)
     except ValueError as exc:
         await interaction.response.send_message(f"\u274c {exc}", ephemeral=True)
+        return
+    project_path = bot.project_manager.get_path(binding_id)
+    if project_path is None:
+        bot.project_manager.remove_mcp_server(binding_id, name)
+        await interaction.response.send_message(
+            "\u274c Could not resolve project path for this channel.",
+            ephemeral=True,
+        )
+        return
+    try:
+        _cli_native.add_mcp_server(project_path, name, config)
+    except ValueError as exc:
+        # ``.mcp.json`` already had the same-named entry (e.g. hand-edited).
+        # Roll back the shadow store so the two views can't diverge.
+        bot.project_manager.remove_mcp_server(binding_id, name)
+        await interaction.response.send_message(f"\u274c {exc}", ephemeral=True)
+        return
+    except OSError as exc:
+        bot.project_manager.remove_mcp_server(binding_id, name)
+        log.exception("add_mcp_server: .mcp.json write failed at %s", project_path)
+        await interaction.response.send_message(
+            f"\u274c Failed to write .mcp.json: {exc}", ephemeral=True
+        )
         return
     embed = discord.Embed(
         title=f"\u2705 MCP server `{name}` added",
@@ -123,10 +152,33 @@ async def mcp_add_url(interaction: discord.Interaction, name: str, url: str) -> 
         await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
         return
     config: dict = {"type": "http", "url": url}
+    # #294: dual-write ``.mcp.json`` + legacy shadow, with rollback on
+    # failure. See mcp_add for the full rationale.
     try:
         bot.project_manager.add_mcp_server(binding_id, name, config)
     except ValueError as exc:
         await interaction.response.send_message(f"\u274c {exc}", ephemeral=True)
+        return
+    project_path = bot.project_manager.get_path(binding_id)
+    if project_path is None:
+        bot.project_manager.remove_mcp_server(binding_id, name)
+        await interaction.response.send_message(
+            "\u274c Could not resolve project path for this channel.",
+            ephemeral=True,
+        )
+        return
+    try:
+        _cli_native.add_mcp_server(project_path, name, config)
+    except ValueError as exc:
+        bot.project_manager.remove_mcp_server(binding_id, name)
+        await interaction.response.send_message(f"\u274c {exc}", ephemeral=True)
+        return
+    except OSError as exc:
+        bot.project_manager.remove_mcp_server(binding_id, name)
+        log.exception("add_mcp_server (url): .mcp.json write failed at %s", project_path)
+        await interaction.response.send_message(
+            f"\u274c Failed to write .mcp.json: {exc}", ephemeral=True
+        )
         return
     embed = discord.Embed(
         title=f"\u2705 MCP server `{name}` added",
@@ -249,7 +301,19 @@ async def mcp_remove(interaction: discord.Interaction, name: str) -> None:
     if binding_id is None:
         await interaction.response.send_message(NO_CHANNEL_MESSAGE, ephemeral=True)
         return
-    if bot.project_manager.remove_mcp_server(binding_id, name):
+    # #294: remove from BOTH stores. Either side may be the only holder
+    # (migration edge case, or user hand-edited ``.mcp.json``), so we
+    # report success as long as either removed something.
+    project_path = bot.project_manager.get_path(binding_id)
+    file_removed = False
+    if project_path is not None:
+        try:
+            file_removed = _cli_native.remove_mcp_server(project_path, name)
+        except OSError:
+            log.exception("remove_mcp_server: .mcp.json write failed at %s", project_path)
+            file_removed = False
+    manager_removed = bot.project_manager.remove_mcp_server(binding_id, name)
+    if file_removed or manager_removed:
         embed = discord.Embed(
             title=f"\u2705 MCP server `{name}` removed",
             color=COLOR_INFO,

--- a/src/clauded/project_manager.py
+++ b/src/clauded/project_manager.py
@@ -391,6 +391,32 @@ class ProjectManager:
                 return True
             return False
 
+    # #294: one-time migration helper. Yields ``(channel_id_int, path,
+    # mcp_servers_dict)`` for every binding that has at least one legacy
+    # ``mcp_servers`` entry, so ``ClaudedBot.__init__`` can write out the
+    # equivalent ``.mcp.json`` for each project without any of its
+    # callers reaching into ``_projects`` directly.
+    def iter_mcp_bindings(self) -> list[tuple[int, str, dict]]:
+        """Return snapshot of ``[(channel_id, path, mcp_servers_dict), ...]``.
+
+        Only bindings whose entry has a non-empty ``mcp_servers`` dict AND
+        a resolvable ``path`` are included. Copies the ``mcp_servers`` sub-
+        dict so mutations to the returned tuples cannot corrupt the store.
+        """
+        out: list[tuple[int, str, dict]] = []
+        with self._lock:
+            for key, entry in self._projects.items():
+                mcps = entry.get("mcp_servers") or {}
+                path = entry.get("path")
+                if not mcps or not path:
+                    continue
+                try:
+                    cid = int(key)
+                except (TypeError, ValueError):
+                    continue
+                out.append((cid, str(path), dict(mcps)))
+        return out
+
     # ------------------------------------------------------------------
     # Environment variables
     # ------------------------------------------------------------------


### PR DESCRIPTION
Closes #294. Dual-write to .claude/agents/*.md + .mcp.json. Migration on startup. 1262 passed.