### PR TITLE
feat(#292 v2): /workflow commands + banner render + drain + tests

### DIFF
--- a/docs/prd/feat-292-workflow-v2.md
+++ b/docs/prd/feat-292-workflow-v2.md
@@ -1,0 +1,129 @@
+# PRD v2 — #292 Dynamic Workflow: /workflow commands + banner render
+
+**Issue**: #292 (feat, P1)
+**Branch**: `feat/292-workflow-v2`
+**Status**: pending user approval
+
+---
+
+## 1. 目标
+
+让用户在 Discord 里一眼看到 Dynamic Workflow 的完整生命周期（启动 banner → 进度 → 完成/失败），并能通过 `/workflow` 命令管理正在运行的 workflow。
+
+---
+
+## 2. Scope（Phase 1）
+
+### 2.1 渲染升级
+
+**启动 banner（TaskStartedMessage）**：紫色 embed + ⚡ 标识，视觉区分于普通工具
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━
+⚡ Dynamic Workflow Started
+━━━━━━━━━━━━━━━━━━━━━━━
+🔮 Task: <description[:60]>
+🤖 Type: <task_type>
+📋 ID: <task_id[:8]>
+```
+
+- 颜色: `COLOR_THINKING` (紫色 0x8B5CF6) — 区别于工具的黄色/蓝色
+- 后续 progress 更新: embed 原地 edit，颜色变黄色 (running)
+- 终态: 绿色 (completed) / 红色 (failed) / 灰色 (stopped/killed)
+
+**进度更新（TaskProgressMessage）**：原地 edit 同一条 message
+
+```
+🔄 Dynamic Workflow Running
+━━━━━━━━━━━━━━━━━━━━━━━
+🔮 Task: <description[:60]>
+💭 Last tool: <last_tool_name>
+🪙 Tokens: <total_tokens> · 🔧 Tools: <tool_uses> · ⏱️ <duration>s
+```
+
+**终态（TaskNotification/TaskUpdated terminal）**：已有实现，保持
+
+### 2.2 `_task_states` 提升
+
+从 `render_response` 局部变量提升到 `DiscordRenderer` 实例属性 `self._task_states: dict[str, _TaskState]`。支持跨 turn 生存 + `/workflow` 命令查询。
+
+### 2.3 `TaskUpdatedMessage` isinstance 化
+
+SDK 0.2.110 已导出 `TaskUpdatedMessage`。移除 duck-type `_is_task_updated_message`，改用 `isinstance`。
+
+### 2.4 AC6 drain
+
+`ResultMessage` break 前加 `asyncio.wait_for` drain（5s timeout），继续收 Task* 消息直到超时或 `_task_states` 清空。
+
+### 2.5 新 cog: `cogs/workflow.py`
+
+| 命令 | 功能 |
+|---|---|
+| `/workflow list` | 列出 `_task_states` 中运行中的 task（embed 表格）|
+| `/workflow kill <id>` | 调 `bridge.stop_task(task_id)` |
+| `/workflow detail <id>` | 渲染 `_task_states[id]` 详情 embed |
+
+### 2.6 `claude_bridge.py` 加 `stop_task` wrapper
+
+```python
+async def stop_task(self, task_id: str) -> None:
+    await self._client.stop_task(task_id)
+```
+
+---
+
+## 3. 文件变更
+
+| 文件 | 变更 |
+|---|---|
+| `src/clauded/discord_renderer.py` | banner embed 样式 + `_task_states` 提升 + isinstance 化 + drain |
+| `src/clauded/claude_bridge.py` | `stop_task()` wrapper |
+| `src/clauded/cogs/workflow.py` | 新 cog: list/kill/detail |
+| `src/clauded/bot.py` | setup_hook 注册 cog + 暴露 `_task_states` 访问 |
+| `tests/test_workflow_render.py` | renderer Task* handler 测试 |
+| `tests/test_cogs_workflow.py` | cog 命令测试 |
+
+---
+
+## 4. AC
+
+- AC1: TaskStarted 渲染紫色 banner（⚡标识），一眼识别
+- AC2: TaskProgress 原地 edit（节流 ≥ EDIT_INTERVAL_SECONDS）
+- AC3: TaskNotification summary markdown 渲染
+- AC4: TaskUpdated(killed) 收尾 embed（用 isinstance 不是 duck-type）
+- AC5: 10+ 并发 task 不 crash（_safe_send/_safe_edit 兜底）
+- AC6: ResultMessage 后 drain 5s 继续收 Task*
+- AC7: 现有 subagent 渲染不回归
+- AC8: `/workflow list` 显示运行中 task
+- AC9: `/workflow kill <id>` 停止 workflow
+- AC10: 启动 banner 视觉效果独特（紫色 + ⚡ + 分隔线）
+
+---
+
+## 5. Subtask 拆分（串行 dev sub-agent → 单 PR）
+
+### Subtask 1: `_task_states` 提升 + isinstance 化 + banner render
+- 提升到实例属性
+- TaskUpdatedMessage isinstance
+- 启动 banner 紫色 embed
+
+### Subtask 2: AC6 drain + progress 样式
+- ResultMessage break 前 drain
+- progress embed 样式（黄色 running）
+
+### Subtask 3: cog + bridge
+- `claude_bridge.stop_task()`
+- `cogs/workflow.py` 三命令
+- bot.py 注册
+
+### Subtask 4: 测试
+- renderer handler tests (~15 cases)
+- cog command tests (~5 cases)
+
+---
+
+## 6. Out of scope (Phase 2)
+
+- `/workflow pause` / `resume` / `skip` / `retry`（SDK 无 API）
+- workflow 历史查询（SDK 无 `list_sessions` API）
+- workflow 脚本编辑/保存

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -343,6 +343,9 @@ class ClaudedBot(commands.Bot):
         # message in a 3rd-party thread. Set of thread_ids we've already
         # logged the ownership-skip for; cleared on bot restart.
         self._logged_third_party_thread: set[int] = set()
+        # #292 S3: bot-level workflow task registry. DiscordRenderer writes
+        # task lifecycle states here (via self._bot ref); /workflow cog reads.
+        self._workflow_tasks: dict = {}
 
         # ---------------------------------------------------------------- #241
         # Scheduler core (PRD v1.18 §3.7 / §8 Subtask 4): persistent timer
@@ -548,6 +551,8 @@ class ClaudedBot(commands.Bot):
         from .cogs.log_dump import log_group
         # #241: /schedule group (message/new_task/list/delete/toggle).
         from .cogs.schedule import schedule_group
+        # #292 S3: /workflow group (list/kill/detail).
+        from .cogs.workflow import workflow_group
 
         self.tree.add_command(project_group)
         self.tree.add_command(session_group)
@@ -580,6 +585,8 @@ class ClaudedBot(commands.Bot):
         self.tree.add_command(log_group)
         # #241: /schedule group (message/new_task/list/delete/toggle)
         self.tree.add_command(schedule_group)
+        # #292 S3: /workflow group (list/kill/detail)
+        self.tree.add_command(workflow_group)
         # #185: do NOT sync globally here — historically claudeD synced
         # via both ``tree.sync()`` (global) AND PR-specific per-guild
         # PUT calls, so commands ended up registered in BOTH scopes and

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -762,6 +762,12 @@ class ClaudeBridge:
             log.warning("Failed to interrupt Claude session", exc_info=True)
             return False
 
+    async def stop_task(self, task_id: str) -> None:
+        """Stop a running dynamic workflow task."""
+        if self._client is None:
+            raise RuntimeError("bridge not active")
+        await self._client.stop_task(task_id)
+
     async def stop(self) -> None:
         """Stop the bridge, force-dropping after CLAUDED_BRIDGE_STOP_TIMEOUT (default 30s).
 

--- a/src/clauded/cogs/workflow.py
+++ b/src/clauded/cogs/workflow.py
@@ -1,0 +1,184 @@
+"""#292 S3 — ``/workflow`` slash command group for Dynamic Workflow management.
+
+Provides three subcommands:
+
+* ``/workflow list`` — list all running workflow tasks
+* ``/workflow kill <task_id>`` — stop a running task by prefix match
+* ``/workflow detail <task_id>`` — show detailed task info
+
+Task state is read from ``bot._workflow_tasks`` (populated by
+:class:`~clauded.discord_renderer.DiscordRenderer` via ``_sync_task_to_bot``).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import discord
+from discord import app_commands
+
+from ._unbound import USE_IN_THREAD_MESSAGE, resolve_session_id
+from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE, COLOR_TOOL_SUCCESS
+
+log = logging.getLogger("clauded.bot")
+
+
+workflow_group = app_commands.Group(
+    name="workflow",
+    description="Manage dynamic workflows",
+)
+
+
+def _resolve_task_id(workflow_tasks: dict, prefix: str) -> str | None:
+    """Find a full task_id by 8-char prefix match.
+
+    Returns the full task_id if exactly one match is found, ``None`` otherwise.
+    """
+    matches = [tid for tid in workflow_tasks if tid.startswith(prefix)]
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def _format_duration(seconds: float) -> str:
+    """Format seconds into a human-readable duration string."""
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    minutes = int(seconds // 60)
+    secs = int(seconds % 60)
+    return f"{minutes}m{secs}s"
+
+
+@workflow_group.command(name="list")
+async def workflow_list(interaction: discord.Interaction) -> None:
+    """List running dynamic workflow tasks."""
+    bot = interaction.client
+    workflow_tasks: dict = getattr(bot, "_workflow_tasks", {})
+
+    if not workflow_tasks:
+        embed = discord.Embed(
+            title="⚡ Dynamic Workflows",
+            description="No running workflow tasks.",
+            color=COLOR_INFO,
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+        return
+
+    now = time.time()
+    lines: list[str] = []
+    for task_id, state in workflow_tasks.items():
+        desc = getattr(state, "description", "—")[:60]
+        started = getattr(state, "started_at", 0.0)
+        duration = _format_duration(now - started) if started else "—"
+        usage = getattr(state, "last_usage", None) or {}
+        tokens = int(usage.get("total_tokens", 0) or 0)
+        token_str = f"{tokens:,}" if tokens else "—"
+        lines.append(
+            f"**`{task_id[:8]}`** · {desc}\n"
+            f"  ⏱️ {duration} · 🪙 {token_str}"
+        )
+
+    embed = discord.Embed(
+        title=f"⚡ Dynamic Workflows ({len(workflow_tasks)})",
+        description="\n\n".join(lines),
+        color=COLOR_INFO,
+    )
+    await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+@workflow_group.command(name="kill")
+@app_commands.describe(task_id="Task ID (first 8 chars)")
+async def workflow_kill(interaction: discord.Interaction, task_id: str) -> None:
+    """Stop a running dynamic workflow task."""
+    bot = interaction.client
+    workflow_tasks: dict = getattr(bot, "_workflow_tasks", {})
+
+    full_id = _resolve_task_id(workflow_tasks, task_id)
+    if full_id is None:
+        matches = [tid for tid in workflow_tasks if tid.startswith(task_id)]
+        if len(matches) > 1:
+            msg = f"❌ Ambiguous prefix `{task_id}` — matches {len(matches)} tasks. Use more characters."
+        else:
+            msg = f"❌ No running task found with prefix `{task_id}`."
+        await interaction.response.send_message(msg, ephemeral=True)
+        return
+
+    # Find the bridge for the active session
+    session_id = resolve_session_id(interaction)
+    if session_id is None:
+        await interaction.response.send_message(USE_IN_THREAD_MESSAGE, ephemeral=True)
+        return
+
+    session_manager = getattr(bot, "session_manager", None)
+    if session_manager is None:
+        await interaction.response.send_message(
+            "❌ Session manager not available.", ephemeral=True,
+        )
+        return
+
+    bridge = session_manager.get_session(session_id)
+    if bridge is None:
+        await interaction.response.send_message(
+            "❌ No active session in this thread.", ephemeral=True,
+        )
+        return
+
+    try:
+        await bridge.stop_task(full_id)
+        await interaction.response.send_message(
+            f"⏹️ Stopping task `{full_id[:8]}`…",
+        )
+    except Exception as exc:
+        log.warning("workflow kill failed for %s: %s", full_id, exc)
+        await interaction.response.send_message(
+            f"❌ Failed to stop task `{full_id[:8]}`: {exc}",
+            ephemeral=True,
+        )
+
+
+@workflow_group.command(name="detail")
+@app_commands.describe(task_id="Task ID (first 8 chars)")
+async def workflow_detail(interaction: discord.Interaction, task_id: str) -> None:
+    """Show detailed info for a running dynamic workflow task."""
+    bot = interaction.client
+    workflow_tasks: dict = getattr(bot, "_workflow_tasks", {})
+
+    full_id = _resolve_task_id(workflow_tasks, task_id)
+    if full_id is None:
+        await interaction.response.send_message(
+            f"❌ No running task found with prefix `{task_id}`.",
+            ephemeral=True,
+        )
+        return
+
+    state = workflow_tasks[full_id]
+    desc = getattr(state, "description", "—")
+    task_type = getattr(state, "task_type", None) or "—"
+    started = getattr(state, "started_at", 0.0)
+    now = time.time()
+    duration = _format_duration(now - started) if started else "—"
+    usage = getattr(state, "last_usage", None) or {}
+    tokens = int(usage.get("total_tokens", 0) or 0)
+    tool_uses = int(usage.get("tool_uses", 0) or 0)
+    duration_ms = int(usage.get("duration_ms", 0) or 0)
+
+    embed = discord.Embed(
+        title="⚡ Workflow Task Detail",
+        color=COLOR_INFO,
+    )
+    embed.add_field(name="📋 ID", value=f"`{full_id[:8]}`", inline=True)
+    embed.add_field(name="🤖 Type", value=task_type, inline=True)
+    embed.add_field(name="⏱️ Duration", value=duration, inline=True)
+    embed.add_field(name="🔮 Description", value=desc[:200] or "—", inline=False)
+    usage_parts: list[str] = []
+    if tokens:
+        usage_parts.append(f"🪙 {tokens:,} tokens")
+    if tool_uses:
+        usage_parts.append(f"🔧 {tool_uses} tool uses")
+    if duration_ms:
+        usage_parts.append(f"⏱️ {duration_ms / 1000:.1f}s SDK time")
+    if usage_parts:
+        embed.add_field(name="Usage", value=" · ".join(usage_parts), inline=False)
+
+    await interaction.response.send_message(embed=embed, ephemeral=True)

--- a/src/clauded/cogs/workflow.py
+++ b/src/clauded/cogs/workflow.py
@@ -19,7 +19,7 @@ import discord
 from discord import app_commands
 
 from ._unbound import USE_IN_THREAD_MESSAGE, resolve_session_id
-from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE, COLOR_TOOL_SUCCESS
+from ..discord_renderer import COLOR_INFO
 
 log = logging.getLogger("clauded.bot")
 

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -53,21 +53,21 @@ from .claude_bridge import (
 )
 from claude_agent_sdk.types import AssistantMessageError, StreamEvent, UserMessage  # noqa: F401 — AssistantMessageError documents the contract pinned by tests/test_api_error_render.py::test_assistant_message_error_field_exists_on_sdk; runtime detection uses getattr() for duck-typing flexibility.
 
-# #292 Dynamic Workflow events. SDK 0.2.110 ships TaskStarted/Progress/
-# Notification; ``TaskUpdatedMessage`` is not yet in this SDK version so we
-# duck-type it below via class-name + attribute checks. Wrapped in a try
-# for forward-compatibility with older SDKs that lack these entirely — the
-# renderer falls back to the legacy silent-ignore behavior when None.
+# #292 Dynamic Workflow events. SDK 0.2.110 ships all four Task* message
+# types. Wrapped in a try for forward-compatibility with older SDKs that
+# lack these entirely — the renderer falls back to silent-ignore when None.
 try:
     from claude_agent_sdk.types import (  # noqa: F401
         TaskStartedMessage as _SdkTaskStartedMessage,
         TaskProgressMessage as _SdkTaskProgressMessage,
         TaskNotificationMessage as _SdkTaskNotificationMessage,
+        TaskUpdatedMessage as _SdkTaskUpdatedMessage,
     )
 except ImportError:  # pragma: no cover — legacy SDK
     _SdkTaskStartedMessage = None  # type: ignore[assignment,misc]
     _SdkTaskProgressMessage = None  # type: ignore[assignment,misc]
     _SdkTaskNotificationMessage = None  # type: ignore[assignment,misc]
+    _SdkTaskUpdatedMessage = None  # type: ignore[assignment,misc]
 from .stream_logger import log_event as _log_stream
 from .cogs._table_view import CopyTableTextView
 from ._errors import is_transient_discord_error
@@ -242,6 +242,7 @@ COLOR_TOOL_FAILURE = 0xEF4444  # Red — tool failed / error
 _WEBSEARCH_TITLE_PREFIX = "🔍 Searching: "
 COLOR_INFO = 0x3B82F6          # Blue — info / commands
 COLOR_THINKING = 0x6B7280      # Gray — thinking
+COLOR_WORKFLOW = 0x8B5CF6      # Purple — Dynamic Workflow banner
 
 # Discord caps message content at 2000 characters; we leave a small margin so
 # we can append a cursor or close-and-reopen a code fence safely.
@@ -732,6 +733,9 @@ class DiscordRenderer:
         # Message.edit() is not in-place; reading msg.content post-edit returns
         # stale text. See docs/investigations/stale-message-content.md (#113).
         self._last_msg_text: str = ""
+        # #292 Dynamic Workflow: per-task lifecycle state keyed by task_id.
+        # Instance-level so /workflow commands can inspect across turns.
+        self._task_states: dict[str, _TaskState] = {}
 
     # ------------------------------------------------------------------
     # Helper: build a tool embed from a ToolUseBlock
@@ -804,7 +808,6 @@ class DiscordRenderer:
     async def _handle_task_started(
         self,
         event: Any,
-        task_states: dict[str, _TaskState],
         subagent_renderers: dict[str, "DiscordRenderer"],
     ) -> None:
         """Render a 🚀 embed for a newly-launched Dynamic Workflow subtask.
@@ -823,17 +826,16 @@ class DiscordRenderer:
         task_type = getattr(event, "task_type", None)
         tool_use_id = getattr(event, "tool_use_id", None)
 
-        footer_bits: list[str] = []
-        if task_type:
-            footer_bits.append(str(task_type))
-        footer_bits.append(f"id={str(task_id)[:8]}")
-
         embed = discord.Embed(
-            title="🚀 Task Started",
-            description=description,
-            color=COLOR_INFO,
+            title="⚡ Dynamic Workflow Started",
+            description=(
+                "━━━━━━━━━━━━━━━━━━━━━━━\n"
+                f"🔮 Task: {description[:60]}\n"
+                f"🤖 Type: {task_type or 'workflow'}\n"
+                f"📋 ID: `{task_id[:8]}`"
+            ),
+            color=COLOR_WORKFLOW,
         )
-        embed.set_footer(text=" · ".join(footer_bits))
 
         # Route to sub-agent thread if this task belongs to one; otherwise
         # main target. Preserves the existing #172 grouping discipline.
@@ -842,7 +844,7 @@ class DiscordRenderer:
             target_renderer = subagent_renderers[tool_use_id]
 
         msg = await target_renderer._safe_send(embed=embed)
-        task_states[task_id] = _TaskState(
+        self._task_states[task_id] = _TaskState(
             description=description,
             task_type=task_type,
             tool_use_id=tool_use_id,
@@ -855,7 +857,6 @@ class DiscordRenderer:
     async def _handle_task_progress(
         self,
         event: Any,
-        task_states: dict[str, _TaskState],
     ) -> None:
         """Edit the task's message with fresh usage stats, throttled.
 
@@ -869,7 +870,7 @@ class DiscordRenderer:
         task_id = getattr(event, "task_id", None)
         if not task_id:
             return
-        state = task_states.get(task_id)
+        state = self._task_states.get(task_id)
         if state is None:
             # Progress before Started — SDK ordering violation. Log and
             # skip; we don't have a message to edit.
@@ -911,7 +912,6 @@ class DiscordRenderer:
         status: str,
         description: str,
         usage: dict | None,
-        task_states: dict[str, _TaskState],
     ) -> None:
         """Render a terminal (✅/❌/⏹️) task embed and drop the task from state.
 
@@ -927,8 +927,8 @@ class DiscordRenderer:
         Prefers ``_safe_edit`` on the existing task-state message when we
         have one (keeps the whole subtask on a single Discord slot); falls
         back to ``_safe_send`` if state was lost or the initial send never
-        succeeded. Always pops the task from ``task_states`` so subsequent
-        events for the same ``task_id`` are ignored.
+        succeeded. Always pops the task from ``self._task_states`` so
+        subsequent events for the same ``task_id`` are ignored.
         """
         if status == "completed":
             title = "✅ Task Complete"
@@ -951,19 +951,18 @@ class DiscordRenderer:
         if usage_seg:
             embed.set_footer(text=usage_seg)
 
-        state = task_states.get(task_id)
+        state = self._task_states.get(task_id)
         edited = False
         if state and state.message is not None:
             edited = await self._safe_edit(state.message, embed=embed)
         if not edited:
             await self._safe_send(embed=embed)
 
-        task_states.pop(task_id, None)
+        self._task_states.pop(task_id, None)
 
     async def _handle_task_notification(
         self,
         event: Any,
-        task_states: dict[str, _TaskState],
     ) -> None:
         """Render the terminal (✅/❌/⏹️) embed and drop the task from state.
 
@@ -983,7 +982,7 @@ class DiscordRenderer:
         summary = (getattr(event, "summary", "") or "")[:3800]
         usage = getattr(event, "usage", None)
 
-        state = task_states.get(task_id)
+        state = self._task_states.get(task_id)
         description = summary or (state.description if state else "")
         # Prefer the terminal usage payload; fall back to the last known
         # progress snapshot so we never show an empty footer when the SDK
@@ -991,21 +990,19 @@ class DiscordRenderer:
         effective_usage = usage if isinstance(usage, dict) else (state.last_usage if state else None)
 
         await self._render_terminal_task(
-            task_id, status, description, effective_usage, task_states
+            task_id, status, description, effective_usage,
         )
 
     async def _handle_task_updated(
         self,
         event: Any,
-        task_states: dict[str, _TaskState],
     ) -> None:
         """Handle ``TaskUpdatedMessage`` — the ``killed`` fallback for
         stopped-in-background tasks that never emit a Notification.
 
-        The SDK 0.2.110 shipped in this repo does *not* export
-        ``TaskUpdatedMessage`` yet, which is why callers route here via
-        duck-typing (class-name + ``hasattr(task_id)`` check). When it does
-        appear, ``event.status`` is one of ``pending``/``running``/
+        SDK 0.2.110 now exports ``TaskUpdatedMessage`` so callers use
+        ``isinstance`` dispatch. ``event.status`` is one of ``pending``/
+        ``running``/
         ``paused``/``completed``/``failed``/``killed``; we only act on
         terminal states — non-terminal patches are logged and left to the
         Progress stream. Rendering itself is delegated to
@@ -1015,7 +1012,7 @@ class DiscordRenderer:
         if not task_id:
             return
         # E3: guard against duplicate terminal when Notification already handled
-        if task_id not in task_states:
+        if task_id not in self._task_states:
             log.debug("TaskUpdated task_id=%s already cleaned; skip", task_id)
             return
         status = str(getattr(event, "status", "") or "").lower()
@@ -1024,27 +1021,13 @@ class DiscordRenderer:
             log.debug("TaskUpdated non-terminal status=%s task_id=%s; skip", status, task_id)
             return
 
-        state = task_states.get(task_id)
+        state = self._task_states.get(task_id)
         description = state.description if state else "Task terminated"
         usage = state.last_usage if state else None
 
         await self._render_terminal_task(
-            task_id, status, description, usage, task_states
+            task_id, status, description, usage,
         )
-
-    @staticmethod
-    def _is_task_updated_message(event: Any) -> bool:
-        """Duck-type check for ``TaskUpdatedMessage`` (SDK 0.2.110 doesn't
-        export the class yet — see #292 PRD "SDK types" note). Any message
-        whose class name is ``TaskUpdatedMessage`` and which carries both
-        ``task_id`` and a ``patch`` attribute is treated as one. Guarded
-        against the three isinstance-detected classes so we don't
-        double-dispatch when a future SDK subclass overlaps.
-        """
-        cls_name = type(event).__name__
-        if cls_name != "TaskUpdatedMessage":
-            return False
-        return hasattr(event, "task_id") and hasattr(event, "patch")
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -1114,14 +1097,10 @@ class DiscordRenderer:
         medium_results: dict[str, tuple[str, str]] = {}
         tool_results_view: ToolResultsView | None = None
 
-        # #292 Dynamic Workflow: per-task lifecycle state keyed by
-        # ``task_id``. Populated in the TaskStarted branch, drained on
-        # TaskNotification / terminal TaskUpdated. Local to render_response
-        # by design — a single Discord turn's workflow is self-contained;
-        # cross-turn state would need to be lifted to bridge/session (see
-        # PRD "Potential bug" note about ResultMessage-then-TaskNotification
-        # races for long-running background tasks).
-        task_states: dict[str, _TaskState] = {}
+        # #292 Dynamic Workflow: reset per-turn task lifecycle state.
+        # Instance-level dict so /workflow commands can query across turns;
+        # cleared at each new render_response invocation.
+        self._task_states.clear()
 
         try:
             async for event in bridge.send_message(user_text):
@@ -1309,20 +1288,20 @@ class DiscordRenderer:
                 # sub-agent execution. Handlers own the entire render for
                 # these events — no ``content`` list to feed the main
                 # AssistantMessage/UserMessage branches below. The order
-                # matters: TaskUpdated is duck-typed and *must* run last
-                # so a future SDK subclass overlap doesn't shadow the
-                # isinstance-matched types above it.
+                # matters: TaskUpdated must run last so a future SDK
+                # subclass overlap doesn't shadow the isinstance-matched
+                # types above it.
                 if _SdkTaskStartedMessage is not None and isinstance(event, _SdkTaskStartedMessage):
-                    await self._handle_task_started(event, task_states, subagent_renderers)
+                    await self._handle_task_started(event, subagent_renderers)
                     continue
                 if _SdkTaskProgressMessage is not None and isinstance(event, _SdkTaskProgressMessage):
-                    await self._handle_task_progress(event, task_states)
+                    await self._handle_task_progress(event)
                     continue
                 if _SdkTaskNotificationMessage is not None and isinstance(event, _SdkTaskNotificationMessage):
-                    await self._handle_task_notification(event, task_states)
+                    await self._handle_task_notification(event)
                     continue
-                if self._is_task_updated_message(event):
-                    await self._handle_task_updated(event, task_states)
+                if _SdkTaskUpdatedMessage is not None and isinstance(event, _SdkTaskUpdatedMessage):
+                    await self._handle_task_updated(event)
                     continue
 
                 if isinstance(event, ResultMessage):
@@ -4079,4 +4058,5 @@ __all__ = [
     "COLOR_TOOL_FAILURE",
     "COLOR_INFO",
     "COLOR_THINKING",
+    "COLOR_WORKFLOW",
 ]

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -916,7 +916,7 @@ class DiscordRenderer:
         tokens = int(usage.get("total_tokens", 0) or 0)
         tool_uses = int(usage.get("tool_uses", 0) or 0)
         duration_ms = int(usage.get("duration_ms", 0) or 0)
-        duration = f"{duration_ms / 1000:.1f}" if duration_ms >= 1000 else f"{duration_ms / 1000:.1f}"
+        duration = f"{duration_ms / 1000:.1f}"
 
         embed = discord.Embed(
             title="🔄 Dynamic Workflow Running",
@@ -1124,14 +1124,6 @@ class DiscordRenderer:
         # attachment — only the clicker sees it, zero channel real-estate.
         medium_results: dict[str, tuple[str, str]] = {}
         tool_results_view: ToolResultsView | None = None
-
-        # #292 Dynamic Workflow: reset per-turn task lifecycle state.
-        # Instance-level dict so /workflow commands can query across turns;
-        # cleared at each new render_response invocation.
-        # Also clean bot-level registry for any stale tasks from this renderer.
-        for stale_id in list(self._task_states):
-            self._sync_task_to_bot(stale_id, None)
-        self._task_states.clear()
 
         result_received = False
         drain_deadline = 0.0

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -738,6 +738,27 @@ class DiscordRenderer:
         self._task_states: dict[str, _TaskState] = {}
 
     # ------------------------------------------------------------------
+    # #292 S3: sync task lifecycle state to bot-level registry
+    # ------------------------------------------------------------------
+
+    def _sync_task_to_bot(self, task_id: str, state: _TaskState | None) -> None:
+        """Write/remove a task state entry in ``bot._workflow_tasks``.
+
+        Called from TaskStarted (write), TaskNotification/TaskUpdated (remove).
+        The bot-level dict is what ``/workflow list|detail|kill`` reads.
+        """
+        bot = self._bot
+        if bot is None:
+            return
+        wt = getattr(bot, "_workflow_tasks", None)
+        if wt is None:
+            return
+        if state is None:
+            wt.pop(task_id, None)
+        else:
+            wt[task_id] = state
+
+    # ------------------------------------------------------------------
     # Helper: build a tool embed from a ToolUseBlock
     # ------------------------------------------------------------------
 
@@ -844,7 +865,7 @@ class DiscordRenderer:
             target_renderer = subagent_renderers[tool_use_id]
 
         msg = await target_renderer._safe_send(embed=embed)
-        self._task_states[task_id] = _TaskState(
+        state = _TaskState(
             description=description,
             task_type=task_type,
             tool_use_id=tool_use_id,
@@ -853,6 +874,8 @@ class DiscordRenderer:
             last_edit_at=0.0,
             last_usage=None,
         )
+        self._task_states[task_id] = state
+        self._sync_task_to_bot(task_id, state)
 
     async def _handle_task_progress(
         self,
@@ -963,6 +986,7 @@ class DiscordRenderer:
             await self._safe_send(embed=embed)
 
         self._task_states.pop(task_id, None)
+        self._sync_task_to_bot(task_id, None)
 
     async def _handle_task_notification(
         self,
@@ -1104,6 +1128,9 @@ class DiscordRenderer:
         # #292 Dynamic Workflow: reset per-turn task lifecycle state.
         # Instance-level dict so /workflow commands can query across turns;
         # cleared at each new render_response invocation.
+        # Also clean bot-level registry for any stale tasks from this renderer.
+        for stale_id in list(self._task_states):
+            self._sync_task_to_bot(stale_id, None)
         self._task_states.clear()
 
         result_received = False

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -888,19 +888,23 @@ class DiscordRenderer:
         if state.message is None:
             return
 
+        # Build usage stats for inline display
+        usage = state.last_usage or {}
+        tokens = int(usage.get("total_tokens", 0) or 0)
+        tool_uses = int(usage.get("tool_uses", 0) or 0)
+        duration_ms = int(usage.get("duration_ms", 0) or 0)
+        duration = f"{duration_ms / 1000:.1f}" if duration_ms >= 1000 else f"{duration_ms / 1000:.1f}"
+
         embed = discord.Embed(
-            title="🔄 Task Running",
-            description=state.description,
+            title="🔄 Dynamic Workflow Running",
+            description=(
+                "━━━━━━━━━━━━━━━━━━━━━━━\n"
+                f"🔮 Task: {state.description[:60]}\n"
+                f"💭 Last tool: {last_tool or '—'}\n"
+                f"🪙 {tokens} tokens · 🔧 {tool_uses} tools · ⏱️ {duration}s"
+            ),
             color=COLOR_TOOL_RUNNING,
         )
-        footer_bits: list[str] = []
-        if last_tool:
-            footer_bits.append(f"💭 {last_tool}")
-        usage_seg = self._fmt_task_usage(state.last_usage)
-        if usage_seg:
-            footer_bits.append(usage_seg)
-        if footer_bits:
-            embed.set_footer(text=" · ".join(footer_bits))
 
         ok = await self._safe_edit(state.message, embed=embed)
         if ok:
@@ -1102,8 +1106,19 @@ class DiscordRenderer:
         # cleared at each new render_response invocation.
         self._task_states.clear()
 
+        result_received = False
+        drain_deadline = 0.0
+
         try:
             async for event in bridge.send_message(user_text):
+                # AC6: drain timeout check — after ResultMessage, keep
+                # looping only while tasks are still pending and within 5s.
+                if result_received and not self._task_states:
+                    break  # all tasks finished after drain
+                if result_received and time.monotonic() > drain_deadline:
+                    log.warning("#292 drain timeout: %d tasks still pending", len(self._task_states))
+                    break
+
                 _log_stream(event, buffer_len=len(buffer))
 
                 # Tool results can arrive on UserMessage objects too — handle any
@@ -1337,7 +1352,12 @@ class DiscordRenderer:
                     stats["context_percentage"] = await _fetch_context_pct_settled(
                         bridge, log_label="footer"
                     )
-                    break
+                    if not self._task_states:
+                        break  # no pending tasks, exit immediately
+                    # AC6: drain trailing Task* messages for up to 5s
+                    drain_deadline = time.monotonic() + 5.0
+                    result_received = True
+                    continue  # keep looping to catch Task* after Result
 
 
                 # -------------------------------------------------------

--- a/tests/test_cogs_workflow.py
+++ b/tests/test_cogs_workflow.py
@@ -1,0 +1,179 @@
+"""#292 S4 — tests for ``/workflow`` cog slash commands.
+
+Uses lightweight mocks for ``discord.Interaction`` and the bot to test
+the cog command functions directly (bypassing the command framework).
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from clauded.cogs.workflow import (
+    _format_duration,
+    _resolve_task_id,
+    workflow_detail,
+    workflow_kill,
+    workflow_list,
+)
+from clauded.discord_renderer import (
+    COLOR_INFO,
+    COLOR_TOOL_FAILURE,
+    COLOR_TOOL_SUCCESS,
+    _TaskState,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_interaction(*, workflow_tasks=None, session_manager=None, session_id="sess1"):
+    """Build a minimal Interaction mock with bot + response tracking."""
+    bot = MagicMock()
+    bot._workflow_tasks = workflow_tasks or {}
+    bot.session_manager = session_manager
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = bot
+
+    # Track sent responses
+    response = AsyncMock()
+    interaction.response = response
+
+    # For kill: resolve_session_id reads channel_id from the interaction
+    interaction.channel = MagicMock()
+    interaction.channel.id = 12345
+    interaction.channel_id = 12345
+    # Give it a parent so resolve_session_id treats it as a thread
+    interaction.channel.parent = MagicMock()
+
+    return interaction
+
+
+def _make_task_state(
+    description="test task",
+    task_type="workflow",
+    started_at=None,
+    last_usage=None,
+):
+    return _TaskState(
+        description=description,
+        task_type=task_type,
+        started_at=started_at or time.time(),
+        last_usage=last_usage,
+    )
+
+
+# ---------------------------------------------------------------------------
+# /workflow list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workflow_list_empty():
+    """/workflow list with no tasks → 'No running' message."""
+    interaction = _make_interaction()
+    await workflow_list.callback(interaction)
+
+    interaction.response.send_message.assert_called_once()
+    call_kwargs = interaction.response.send_message.call_args
+    embed = call_kwargs.kwargs.get("embed") or call_kwargs[1].get("embed")
+    assert "No running" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_workflow_list_with_tasks():
+    """/workflow list with tasks → embed shows task info."""
+    tasks = {
+        "abcdef1234567890": _make_task_state(
+            description="build feature",
+            last_usage={"total_tokens": 5000, "tool_uses": 10, "duration_ms": 3000},
+        ),
+    }
+    interaction = _make_interaction(workflow_tasks=tasks)
+    await workflow_list.callback(interaction)
+
+    call_kwargs = interaction.response.send_message.call_args
+    embed = call_kwargs.kwargs.get("embed") or call_kwargs[1].get("embed")
+    assert "abcdef12" in embed.description
+    assert "build feature" in embed.description
+    assert "(1)" in embed.title
+
+
+# ---------------------------------------------------------------------------
+# /workflow kill
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workflow_kill_happy(monkeypatch):
+    """/workflow kill with valid ID → bridge.stop_task called."""
+    bridge = AsyncMock()
+    bridge.stop_task = AsyncMock()
+
+    session_manager = MagicMock()
+    session_manager.get_session.return_value = bridge
+
+    tasks = {
+        "abcdef1234567890": _make_task_state(description="some task"),
+    }
+    interaction = _make_interaction(
+        workflow_tasks=tasks,
+        session_manager=session_manager,
+    )
+
+    # Patch resolve_session_id to return a valid session id
+    monkeypatch.setattr(
+        "clauded.cogs.workflow.resolve_session_id",
+        lambda _: "sess1",
+    )
+
+    await workflow_kill.callback(interaction, task_id="abcdef12")
+
+    bridge.stop_task.assert_called_once_with("abcdef1234567890")
+    call_kwargs = interaction.response.send_message.call_args
+    msg = call_kwargs.args[0] if call_kwargs.args else call_kwargs.kwargs.get("content", "")
+    assert "⏹️" in msg or "Stopping" in msg
+
+
+@pytest.mark.asyncio
+async def test_workflow_kill_not_found():
+    """/workflow kill with bad ID → error message."""
+    interaction = _make_interaction(workflow_tasks={})
+    await workflow_kill.callback(interaction, task_id="nonexist")
+
+    call_kwargs = interaction.response.send_message.call_args
+    msg = call_kwargs.args[0] if call_kwargs.args else call_kwargs.kwargs.get("content", "")
+    assert "❌" in msg or "No running task" in msg
+
+
+# ---------------------------------------------------------------------------
+# /workflow detail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workflow_detail_happy():
+    """/workflow detail with valid ID → embed with task info."""
+    tasks = {
+        "abcdef1234567890": _make_task_state(
+            description="implement auth",
+            task_type="local_workflow",
+            last_usage={"total_tokens": 3000, "tool_uses": 7, "duration_ms": 2000},
+        ),
+    }
+    interaction = _make_interaction(workflow_tasks=tasks)
+    await workflow_detail.callback(interaction, task_id="abcdef12")
+
+    call_kwargs = interaction.response.send_message.call_args
+    embed = call_kwargs.kwargs.get("embed") or call_kwargs[1].get("embed")
+    assert embed.title == "⚡ Workflow Task Detail"
+    # Check fields contain expected data
+    field_values = [f.value for f in embed.fields]
+    assert any("abcdef12" in v for v in field_values)
+    assert any("implement auth" in v for v in field_values)
+    assert any("local_workflow" in v for v in field_values)

--- a/tests/test_workflow_render.py
+++ b/tests/test_workflow_render.py
@@ -1,0 +1,350 @@
+"""#292 S4 — tests for Dynamic Workflow renderer Task* handlers.
+
+Uses SimpleNamespace to mock SDK Task events and the shared
+FakeBridge / FakeTarget from conftest to drive DiscordRenderer
+in isolation (no full render_response loop required).
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from tests.conftest import FakeMessage, FakeTarget
+
+from clauded.discord_renderer import (
+    COLOR_THINKING,
+    COLOR_TOOL_FAILURE,
+    COLOR_TOOL_RUNNING,
+    COLOR_TOOL_SUCCESS,
+    COLOR_WORKFLOW,
+    EDIT_INTERVAL_SECONDS,
+    DiscordRenderer,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_renderer(*, bot=None) -> tuple[DiscordRenderer, FakeTarget]:
+    """Create a renderer wired to a FakeTarget, optionally with a bot."""
+    target = FakeTarget()
+    renderer = DiscordRenderer(target, bot=bot)
+    return renderer, target
+
+
+def _started_event(
+    task_id="t1",
+    description="test task",
+    task_type="workflow",
+    tool_use_id=None,
+    uuid="u1",
+    session_id="s1",
+):
+    return SimpleNamespace(
+        task_id=task_id,
+        description=description,
+        task_type=task_type,
+        tool_use_id=tool_use_id,
+        uuid=uuid,
+        session_id=session_id,
+    )
+
+
+def _progress_event(
+    task_id="t1",
+    usage=None,
+    last_tool_name="Bash",
+):
+    return SimpleNamespace(
+        task_id=task_id,
+        usage=usage or {"total_tokens": 1000, "tool_uses": 5, "duration_ms": 3000},
+        last_tool_name=last_tool_name,
+    )
+
+
+def _notification_event(
+    task_id="t1",
+    status="completed",
+    summary="Done!",
+    usage=None,
+):
+    return SimpleNamespace(
+        task_id=task_id,
+        status=status,
+        summary=summary,
+        usage=usage or {"total_tokens": 2000, "tool_uses": 10, "duration_ms": 5000},
+    )
+
+
+def _updated_event(
+    task_id="t1",
+    status="killed",
+):
+    return SimpleNamespace(
+        task_id=task_id,
+        status=status,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TaskStarted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_started_sends_purple_banner():
+    """TaskStarted → embed with COLOR_WORKFLOW, ⚡ title, 🔮 description."""
+    renderer, target = _make_renderer()
+    event = _started_event()
+    await renderer._handle_task_started(event, subagent_renderers={})
+
+    assert len(target._sent) == 1
+    embed = target._sent[0].embeds[0]
+    assert embed.color.value == COLOR_WORKFLOW
+    assert "⚡" in embed.title
+    assert "🔮" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_task_started_stores_state():
+    """After TaskStarted, _task_states has the task entry."""
+    renderer, target = _make_renderer()
+    event = _started_event(task_id="abc123")
+    await renderer._handle_task_started(event, subagent_renderers={})
+
+    assert "abc123" in renderer._task_states
+    state = renderer._task_states["abc123"]
+    assert state.description == "test task"
+    assert state.task_type == "workflow"
+    assert state.message is not None
+
+
+# ---------------------------------------------------------------------------
+# TaskProgress
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_progress_edits_message():
+    """TaskProgress edits existing message instead of sending a new one."""
+    renderer, target = _make_renderer()
+
+    # First, start a task to populate state
+    event_start = _started_event()
+    await renderer._handle_task_started(event_start, subagent_renderers={})
+    assert len(target._sent) == 1
+
+    # Force last_edit_at far in the past to bypass throttle
+    renderer._task_states["t1"].last_edit_at = 0.0
+
+    event_progress = _progress_event()
+    await renderer._handle_task_progress(event_progress)
+
+    # No new message should have been sent — only the existing one edited
+    assert len(target._sent) == 1
+    # The existing message should have been edited (embed updated)
+    msg = target._sent[0]
+    assert len(msg.embeds) == 1
+    embed = msg.embeds[0]
+    assert "Running" in embed.title or "🔄" in embed.title
+
+
+@pytest.mark.asyncio
+async def test_task_progress_throttle():
+    """Two rapid progress events — second one is throttled (skipped)."""
+    renderer, target = _make_renderer()
+
+    event_start = _started_event()
+    await renderer._handle_task_started(event_start, subagent_renderers={})
+
+    # First progress: set last_edit_at to 0 so it passes
+    renderer._task_states["t1"].last_edit_at = 0.0
+    event_p1 = _progress_event(usage={"total_tokens": 100, "tool_uses": 1, "duration_ms": 1000})
+    await renderer._handle_task_progress(event_p1)
+
+    # Capture embed after first progress
+    embed_after_first = target._sent[0].embeds[0]
+
+    # Second progress immediately — should be throttled
+    event_p2 = _progress_event(usage={"total_tokens": 999, "tool_uses": 99, "duration_ms": 9999})
+    await renderer._handle_task_progress(event_p2)
+
+    # The embed should NOT have been updated (still shows first progress values)
+    embed_after_second = target._sent[0].embeds[0]
+    assert embed_after_first.description == embed_after_second.description
+
+    # But last_usage in state SHOULD have been updated (always stored)
+    assert renderer._task_states["t1"].last_usage["total_tokens"] == 999
+
+
+@pytest.mark.asyncio
+async def test_task_progress_unknown_task_ignored():
+    """Progress for unknown task_id is silently ignored."""
+    renderer, target = _make_renderer()
+    event = _progress_event(task_id="nonexistent")
+    await renderer._handle_task_progress(event)
+    assert len(target._sent) == 0
+
+
+# ---------------------------------------------------------------------------
+# TaskNotification (terminal)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_notification_completed_green():
+    """status=completed → COLOR_TOOL_SUCCESS, ✅ title."""
+    renderer, target = _make_renderer()
+    await renderer._handle_task_started(_started_event(), subagent_renderers={})
+
+    event = _notification_event(status="completed")
+    await renderer._handle_task_notification(event)
+
+    embed = target._sent[0].embeds[0]  # edited in place
+    assert embed.color.value == COLOR_TOOL_SUCCESS
+    assert "✅" in embed.title
+
+
+@pytest.mark.asyncio
+async def test_task_notification_failed_red():
+    """status=failed → COLOR_TOOL_FAILURE, ❌ title."""
+    renderer, target = _make_renderer()
+    await renderer._handle_task_started(_started_event(), subagent_renderers={})
+
+    event = _notification_event(status="failed")
+    await renderer._handle_task_notification(event)
+
+    embed = target._sent[0].embeds[0]
+    assert embed.color.value == COLOR_TOOL_FAILURE
+    assert "❌" in embed.title
+
+
+@pytest.mark.asyncio
+async def test_task_notification_stopped_gray():
+    """status=stopped → COLOR_THINKING (gray), ⏹️ title."""
+    renderer, target = _make_renderer()
+    await renderer._handle_task_started(_started_event(), subagent_renderers={})
+
+    event = _notification_event(status="stopped")
+    await renderer._handle_task_notification(event)
+
+    embed = target._sent[0].embeds[0]
+    assert embed.color.value == COLOR_THINKING
+    assert "⏹️" in embed.title
+
+
+@pytest.mark.asyncio
+async def test_task_notification_cleans_state():
+    """After terminal notification, task_id is removed from _task_states."""
+    renderer, target = _make_renderer()
+    await renderer._handle_task_started(_started_event(task_id="t99"), subagent_renderers={})
+    assert "t99" in renderer._task_states
+
+    event = _notification_event(task_id="t99", status="completed")
+    await renderer._handle_task_notification(event)
+
+    assert "t99" not in renderer._task_states
+
+
+# ---------------------------------------------------------------------------
+# TaskUpdated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_updated_killed():
+    """TaskUpdated with status=killed → terminal embed."""
+    renderer, target = _make_renderer()
+    await renderer._handle_task_started(_started_event(), subagent_renderers={})
+
+    event = _updated_event(status="killed")
+    await renderer._handle_task_updated(event)
+
+    embed = target._sent[0].embeds[0]
+    assert embed.color.value == COLOR_THINKING
+    assert "⏹️" in embed.title
+    assert "t1" not in renderer._task_states
+
+
+@pytest.mark.asyncio
+async def test_task_updated_duplicate_guard():
+    """If task already cleaned from state, TaskUpdated is a no-op."""
+    renderer, target = _make_renderer()
+    await renderer._handle_task_started(_started_event(), subagent_renderers={})
+
+    # Manually pop the task (simulates Notification already handled)
+    renderer._task_states.pop("t1", None)
+
+    sent_before = len(target._sent)
+    event = _updated_event(status="killed")
+    await renderer._handle_task_updated(event)
+
+    # The started embed is the only message; no new edits or sends
+    assert len(target._sent) == sent_before
+    # Verify the started embed is unchanged (still purple banner)
+    embed = target._sent[0].embeds[0]
+    assert embed.color.value == COLOR_WORKFLOW
+
+
+@pytest.mark.asyncio
+async def test_task_updated_non_terminal_skipped():
+    """Non-terminal status (e.g. 'running') is ignored by TaskUpdated."""
+    renderer, target = _make_renderer()
+    await renderer._handle_task_started(_started_event(), subagent_renderers={})
+
+    event = _updated_event(status="running")
+    await renderer._handle_task_updated(event)
+
+    # Task should still be in state
+    assert "t1" in renderer._task_states
+    # Embed should still be the original started banner
+    embed = target._sent[0].embeds[0]
+    assert embed.color.value == COLOR_WORKFLOW
+
+
+# ---------------------------------------------------------------------------
+# Sync to bot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_to_bot():
+    """TaskStarted syncs to bot._workflow_tasks; terminal removes it."""
+    bot = MagicMock()
+    bot._workflow_tasks = {}
+
+    renderer, target = _make_renderer(bot=bot)
+    await renderer._handle_task_started(_started_event(task_id="sync1"), subagent_renderers={})
+
+    assert "sync1" in bot._workflow_tasks
+    state = bot._workflow_tasks["sync1"]
+    assert state.description == "test task"
+
+    # Terminal notification should remove it
+    event = _notification_event(task_id="sync1", status="completed")
+    await renderer._handle_task_notification(event)
+
+    assert "sync1" not in bot._workflow_tasks
+
+
+# ---------------------------------------------------------------------------
+# Edge: no bot reference
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_to_bot_no_bot_no_error():
+    """When bot is None, _sync_task_to_bot is a no-op (no crash)."""
+    renderer, target = _make_renderer(bot=None)
+    await renderer._handle_task_started(_started_event(), subagent_renderers={})
+    assert "t1" in renderer._task_states
+
+    await renderer._handle_task_notification(
+        _notification_event(status="completed"),
+    )
+    assert "t1" not in renderer._task_states


### PR DESCRIPTION
Reopens #292. 4 subtasks: banner render (purple ⚡), drain AC6, /workflow list|kill|detail cog, 19 new tests. 1279 passed.