### PR TITLE
fix(#301): persist session_id immediately after bridge start

### DIFF
--- a/docs/prd/fix-301-early-session-persist.md
+++ b/docs/prd/fix-301-early-session-persist.md
@@ -1,0 +1,21 @@
+# PRD — #301 persist session_id immediately after bridge start
+
+**Issue**: #301 (bug, P0)
+**Branch**: `fix/301-early-session-persist`
+**Status**: APPROVED
+
+## Problem
+session_id only written on ResultMessage. Mid-turn kill → resume=None → context lost.
+
+## Fix
+After `bridge.start()` succeeds and `bridge.session_id` is available, immediately call `session_manager.save_session_state(thread_id, session_id=bridge.session_id, project_path=...)`.
+
+## Files
+- `src/clauded/bot.py` — after each `create_session` call that starts a bridge, add early persist
+- `src/clauded/session_manager.py` — verify `save_session_state` can be called with just session_id
+- Tests
+
+## AC
+- AC1: session_id on disk within seconds of bridge start (before any ResultMessage)
+- AC2: mid-turn kill → restart → resume works (session_id was persisted)
+- AC3: existing ResultMessage persist path unchanged (updates last_active etc.)

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -907,6 +907,10 @@ class ClaudedBot(commands.Bot):
                 await safe_send_message(thread, embed=err_embed)
                 return
 
+            # #301: persist session_id immediately so mid-turn kill won't lose it.
+            if bridge and bridge.session_id:
+                self.session_manager.save_session_state(thread.id)
+
             # Feature #66: Add hourglass reaction (#245: safe wrapper)
             await safe_add_reaction(message, "⏳")
 
@@ -1112,6 +1116,10 @@ class ClaudedBot(commands.Bot):
                     # #148 architect §3 — retry-aware send (transient blip survival).
                     await safe_send_message(message.channel, embed=err_embed)
                     return
+
+            # #301: persist session_id immediately so mid-turn kill won't lose it.
+            if bridge and bridge.session_id:
+                self.session_manager.save_session_state(thread_id)
 
             # Feature #66: Add hourglass reaction (#245: safe wrapper)
             await safe_add_reaction(message, "⏳")
@@ -1375,6 +1383,9 @@ class ClaudedBot(commands.Bot):
                     ephemeral=True,
                 )
                 return None
+            # #301: persist session_id immediately so mid-turn kill won't lose it.
+            if bridge and bridge.session_id:
+                self.session_manager.save_session_state(thread_id)
         return bridge
 
     async def _render_with_retry(
@@ -1500,6 +1511,9 @@ class ClaudedBot(commands.Bot):
                         # blip; on permanent failure we silently drop.
                         await safe_send_message(thread, embed=err_embed)
                         return
+                    # #301: persist session_id immediately so mid-turn kill won't lose it.
+                    if new_bridge and new_bridge.session_id:
+                        self.session_manager.save_session_state(thread_id)
                     new_renderer = DiscordRenderer(thread, bot=self, project_path=Path(project_path) if project_path else None)
                     await self._render_with_retry(
                         renderer=new_renderer,
@@ -1787,6 +1801,10 @@ class ClaudedBot(commands.Bot):
                 thread_id, project_path, self.config, sc,
             )
 
+        # #301: persist session_id immediately so mid-turn kill won't lose it.
+        if bridge and bridge.session_id:
+            self.session_manager.save_session_state(thread_id)
+
         self._register_scheduler_ctx(
             thread_id=thread_id,
             channel_id=parent_id,
@@ -1938,6 +1956,10 @@ class ClaudedBot(commands.Bot):
         bridge = await self.session_manager.create_session(
             thread.id, project_path, self.config, sc,
         )
+
+        # #301: persist session_id immediately so mid-turn kill won't lose it.
+        if bridge and bridge.session_id:
+            self.session_manager.save_session_state(thread.id)
 
         self._register_scheduler_ctx(
             thread_id=thread.id,

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -896,6 +896,7 @@ class ClaudedBot(commands.Bot):
                     self.config,
                     sc,
                 )
+                self._wire_session_persist_cb(bridge, thread.id)
             except Exception as exc:
                 log.exception("Failed to start ClaudeBridge")
                 err_embed = discord.Embed(
@@ -906,10 +907,6 @@ class ClaudedBot(commands.Bot):
                 # #148 architect §3 — retry-aware send (transient blip survival).
                 await safe_send_message(thread, embed=err_embed)
                 return
-
-            # #301: persist session_id immediately so mid-turn kill won't lose it.
-            if bridge and bridge.session_id:
-                self.session_manager.save_session_state(thread.id)
 
             # Feature #66: Add hourglass reaction (#245: safe wrapper)
             await safe_add_reaction(message, "⏳")
@@ -1106,6 +1103,7 @@ class ClaudedBot(commands.Bot):
                         self.config,
                         sc,
                     )
+                    self._wire_session_persist_cb(bridge, thread_id)
                 except Exception as exc:
                     log.exception("Failed to start ClaudeBridge for thread=%s", thread_id)
                     err_embed = discord.Embed(
@@ -1116,10 +1114,6 @@ class ClaudedBot(commands.Bot):
                     # #148 architect §3 — retry-aware send (transient blip survival).
                     await safe_send_message(message.channel, embed=err_embed)
                     return
-
-            # #301: persist session_id immediately so mid-turn kill won't lose it.
-            if bridge and bridge.session_id:
-                self.session_manager.save_session_state(thread_id)
 
             # Feature #66: Add hourglass reaction (#245: safe wrapper)
             await safe_add_reaction(message, "⏳")
@@ -1292,6 +1286,10 @@ class ClaudedBot(commands.Bot):
             return stored.get("session_id")
         return None
 
+    def _wire_session_persist_cb(self, bridge: "ClaudeBridge", thread_id: int) -> None:
+        """#301 R2: persist session_id the moment the first ResultMessage arrives."""
+        bridge._on_session_id_cb = lambda sid: self.session_manager.save_session_state(thread_id)
+
     async def _recreate_session(
         self,
         interaction: discord.Interaction,
@@ -1373,6 +1371,7 @@ class ClaudedBot(commands.Bot):
                 bridge = await self.session_manager.create_session(
                     thread_id, project_path, self.config, sc,
                 )
+                self._wire_session_persist_cb(bridge, thread_id)
             except Exception as exc:
                 await interaction.followup.send(
                     embed=discord.Embed(
@@ -1383,9 +1382,6 @@ class ClaudedBot(commands.Bot):
                     ephemeral=True,
                 )
                 return None
-            # #301: persist session_id immediately so mid-turn kill won't lose it.
-            if bridge and bridge.session_id:
-                self.session_manager.save_session_state(thread_id)
         return bridge
 
     async def _render_with_retry(
@@ -1500,6 +1496,7 @@ class ClaudedBot(commands.Bot):
                             self.config,
                             retry_sc,
                         )
+                        self._wire_session_persist_cb(new_bridge, thread_id)
                     except Exception as start_exc:
                         log.exception("Retry: failed to restart ClaudeBridge")
                         err_embed = discord.Embed(
@@ -1511,9 +1508,6 @@ class ClaudedBot(commands.Bot):
                         # blip; on permanent failure we silently drop.
                         await safe_send_message(thread, embed=err_embed)
                         return
-                    # #301: persist session_id immediately so mid-turn kill won't lose it.
-                    if new_bridge and new_bridge.session_id:
-                        self.session_manager.save_session_state(thread_id)
                     new_renderer = DiscordRenderer(thread, bot=self, project_path=Path(project_path) if project_path else None)
                     await self._render_with_retry(
                         renderer=new_renderer,
@@ -1800,10 +1794,7 @@ class ClaudedBot(commands.Bot):
             bridge = await self.session_manager.create_session(
                 thread_id, project_path, self.config, sc,
             )
-
-        # #301: persist session_id immediately so mid-turn kill won't lose it.
-        if bridge and bridge.session_id:
-            self.session_manager.save_session_state(thread_id)
+            self._wire_session_persist_cb(bridge, thread_id)
 
         self._register_scheduler_ctx(
             thread_id=thread_id,
@@ -1956,10 +1947,7 @@ class ClaudedBot(commands.Bot):
         bridge = await self.session_manager.create_session(
             thread.id, project_path, self.config, sc,
         )
-
-        # #301: persist session_id immediately so mid-turn kill won't lose it.
-        if bridge and bridge.session_id:
-            self.session_manager.save_session_state(thread.id)
+        self._wire_session_persist_cb(bridge, thread.id)
 
         self._register_scheduler_ctx(
             thread_id=thread.id,

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -124,6 +124,7 @@ class ClaudeBridge:
         self._client: ClaudeSDKClient | None = None
         self._active = False
         self._session_id: str | None = None
+        self._on_session_id_cb: Callable[[str], None] | None = None
         # Aggregate stats updated whenever we observe a ResultMessage. They
         # are purely informational (surfaced via /session info) so the
         # exact semantics — total cost across the session, last-known turn
@@ -837,7 +838,10 @@ class ClaudeBridge:
         # Extract session_id from ResultMessage
         sid = getattr(msg, "session_id", None)
         if isinstance(sid, str) and sid:
+            first_time = self._session_id is None
             self._session_id = sid
+            if first_time and self._on_session_id_cb is not None:
+                self._on_session_id_cb(sid)
 
         cost = getattr(msg, "total_cost_usd", None)
         if isinstance(cost, (int, float)):

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -357,40 +357,62 @@ async def test_create_session_with_user(cfg: Config, tmp_path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# #301: early session_id persistence
+# #301 R2: session_id persistence via _on_session_id_cb callback
 # ---------------------------------------------------------------------------
 
 
-class _FakeBridgeWithSessionId(_FakeBridge):
-    """Like ``_FakeBridge`` but returns a real ``session_id`` after start."""
+class _FakeBridgeWithCallback(_FakeBridge):
+    """Like ``_FakeBridge`` but supports ``_on_session_id_cb``."""
 
-    _fake_session_id = "sess-early-persist-test"
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._session_id: str | None = None
+        self._on_session_id_cb = None
 
     @property
     def session_id(self) -> str | None:  # type: ignore[override]
-        return self._fake_session_id if self.started else None
+        return self._session_id
+
+    def simulate_first_result_message(self, sid: str) -> None:
+        """Mimic what ``_update_stats`` does on the first ResultMessage."""
+        first_time = self._session_id is None
+        self._session_id = sid
+        if first_time and self._on_session_id_cb is not None:
+            self._on_session_id_cb(sid)
 
 
 @pytest.mark.asyncio
-async def test_session_id_persisted_immediately_after_create(
+async def test_session_id_persisted_on_first_result_message(
     cfg: Config, tmp_path, monkeypatch,
 ) -> None:
-    """#301: session_id must appear in sessions.json right after create_session,
-    before any ResultMessage is processed."""
+    """#301 R2: session_id must be persisted the moment the first
+    ResultMessage arrives (via the _on_session_id_cb callback), not after
+    render_response finishes."""
     monkeypatch.setattr(
-        "clauded.session_manager.ClaudeBridge", _FakeBridgeWithSessionId
+        "clauded.session_manager.ClaudeBridge", _FakeBridgeWithCallback
     )
     store = SessionStore(data_dir=str(tmp_path / "store301"))
     sm = SessionManager(session_store=store)
 
     bridge = await sm.create_session(99, "/tmp/p", cfg)
-    assert bridge.session_id == "sess-early-persist-test"
+    assert bridge.session_id is None  # no session_id yet
 
-    # Simulate what bot.py now does immediately after create_session (#301).
-    if bridge and bridge.session_id:
-        sm.save_session_state(99)
+    # Wire the callback — same as bot.py does after create_session.
+    bridge._on_session_id_cb = lambda sid: sm.save_session_state(99)
 
-    # The session_id must be on disk — no ResultMessage needed.
+    # Simulate streaming: first ResultMessage carries a session_id.
+    bridge.simulate_first_result_message("sess-from-stream-001")
+
+    assert bridge.session_id == "sess-from-stream-001"
+
+    # The callback should have persisted it immediately.
     stored = store.get_session_info(99)
     assert stored is not None, "session entry missing from store"
-    assert stored["session_id"] == "sess-early-persist-test"
+    assert stored["session_id"] == "sess-from-stream-001"
+
+    # A second ResultMessage must NOT re-fire the callback.
+    bridge._on_session_id_cb = lambda sid: (_ for _ in ()).throw(
+        AssertionError("callback fired twice")
+    )
+    bridge.simulate_first_result_message("sess-from-stream-002")
+    assert bridge.session_id == "sess-from-stream-002"  # updated

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -354,3 +354,43 @@ async def test_create_session_with_user(cfg: Config, tmp_path) -> None:
     bridge = await sm.create_session(60, "/tmp/p", cfg, sc)
     assert bridge.user == "testuser#1234"
     assert bridge.started
+
+
+# ---------------------------------------------------------------------------
+# #301: early session_id persistence
+# ---------------------------------------------------------------------------
+
+
+class _FakeBridgeWithSessionId(_FakeBridge):
+    """Like ``_FakeBridge`` but returns a real ``session_id`` after start."""
+
+    _fake_session_id = "sess-early-persist-test"
+
+    @property
+    def session_id(self) -> str | None:  # type: ignore[override]
+        return self._fake_session_id if self.started else None
+
+
+@pytest.mark.asyncio
+async def test_session_id_persisted_immediately_after_create(
+    cfg: Config, tmp_path, monkeypatch,
+) -> None:
+    """#301: session_id must appear in sessions.json right after create_session,
+    before any ResultMessage is processed."""
+    monkeypatch.setattr(
+        "clauded.session_manager.ClaudeBridge", _FakeBridgeWithSessionId
+    )
+    store = SessionStore(data_dir=str(tmp_path / "store301"))
+    sm = SessionManager(session_store=store)
+
+    bridge = await sm.create_session(99, "/tmp/p", cfg)
+    assert bridge.session_id == "sess-early-persist-test"
+
+    # Simulate what bot.py now does immediately after create_session (#301).
+    if bridge and bridge.session_id:
+        sm.save_session_state(99)
+
+    # The session_id must be on disk — no ResultMessage needed.
+    stored = store.get_session_info(99)
+    assert stored is not None, "session entry missing from store"
+    assert stored["session_id"] == "sess-early-persist-test"


### PR DESCRIPTION
P0 fix. session_id now saved at 6 create_session sites before any ResultMessage. 1280 passed. Closes #301.