### PR TITLE
feat(#304): /log dump includes CLI session transcript tail

### DIFF
--- a/docs/prd/feat-304-log-dump-transcript.md
+++ b/docs/prd/feat-304-log-dump-transcript.md
@@ -1,0 +1,16 @@
+# PRD — #304 /log dump includes CLI session transcript
+
+**Issue**: #304 (feat, P1)
+**Branch**: `feat/304-log-dump-transcript`
+**Status**: APPROVED
+
+## Fix
+Add CLI session transcript (tail 1MB) to /log dump bundle. Find transcript at `~/.claude/projects/<slug>/<session_id>.jsonl`.
+
+## Files
+- `src/clauded/diagnostics/bundle.py` — add transcript collection
+- Tests
+
+## AC
+- AC1: bundle contains transcripts/<session_id>.tail.jsonl
+- AC2: multiple active sessions → multiple transcripts included

--- a/src/clauded/diagnostics/bundle.py
+++ b/src/clauded/diagnostics/bundle.py
@@ -22,8 +22,8 @@ Bundle layout (per PRD §Bundle Contents):
     ├── runtime/
     │   ├── sessions-live.json
     │   └── bot-flags.json
-    └── diagnostics/
-        └── manifest.txt
+    └── transcripts/                 (#304)
+        └── <session_id>.tail.jsonl  (tail 1 MB)
 
 This module imports lazily — bundle generation should not pull in
 discord.py at module-load time.
@@ -52,6 +52,7 @@ log = logging.getLogger("clauded.diagnostics.bundle")
 BUNDLE_SIZE_BUDGET = 8 * 1024 * 1024  # 8 MB (T0 guild limit 10 MB - 20%)
 LOG_TAIL_BYTES = 1 * 1024 * 1024  # 1 MB per tailed log file
 STREAM_DEBUG_TAIL_BYTES = 5 * 1024 * 1024  # 5 MB jsonl tail
+TRANSCRIPT_TAIL_BYTES = 1 * 1024 * 1024  # 1 MB per session transcript
 
 # Directory where rotating logs land (matches _logging_setup._LOG_DIR).
 _LOG_DIR = Path.home() / "Library" / "Logs" / "clauded"
@@ -250,6 +251,52 @@ def _build_manifest(
 
 
 # ---------------------------------------------------------------------------
+# CLI session transcript collection (#304)
+# ---------------------------------------------------------------------------
+
+
+def _collect_transcripts(
+    zf: zipfile.ZipFile,
+    bot: Any,
+    data_dir: Path,
+) -> None:
+    """Collect CLI session transcripts from stored sessions.
+
+    For each session with a ``session_id``, compute the project slug from
+    ``project_path`` (replace ``/`` → ``-``, strip leading ``-``) and look
+    for ``~/.claude/projects/<slug>/<session_id>.jsonl``. If it exists,
+    tail 1 MB and add to the zip as ``transcripts/<session_id>.tail.jsonl``.
+    """
+    # Read stored sessions from data_dir/sessions.json
+    raw, found = _read_state_file(data_dir, "sessions.json")
+    if not found:
+        return
+    try:
+        sessions = json.loads(raw.decode("utf-8"))
+    except Exception:
+        return
+    if not isinstance(sessions, dict):
+        return
+
+    claude_projects = Path.home() / ".claude" / "projects"
+
+    for _thread_id, stored in sessions.items():
+        session_id = stored.get("session_id") if isinstance(stored, dict) else None
+        project_path = (stored.get("project_path") or "") if isinstance(stored, dict) else ""
+        if not session_id or not project_path:
+            continue
+
+        slug = project_path.replace("/", "-").lstrip("-")
+        transcript = claude_projects / slug / f"{session_id}.jsonl"
+        if not transcript.exists():
+            continue
+
+        tail = _tail_bytes(transcript, TRANSCRIPT_TAIL_BYTES)
+        if tail:
+            zf.writestr(f"transcripts/{session_id}.tail.jsonl", tail)
+
+
+# ---------------------------------------------------------------------------
 # Pipeline
 # ---------------------------------------------------------------------------
 
@@ -358,6 +405,9 @@ def generate_bundle(
                 "runtime/bot-flags.json",
                 json.dumps(_snapshot_bot_flags(bot), indent=2, ensure_ascii=False),
             )
+
+        # #304: CLI session transcripts (tail 1 MB each)
+        _collect_transcripts(zf, bot, data_dir)
 
         # #224 R1 simplicity: diagnostics/info.json had 2 fields
         # (python_executable + sys_path_len); merged into manifest.json's

--- a/src/clauded/diagnostics/bundle.py
+++ b/src/clauded/diagnostics/bundle.py
@@ -443,7 +443,7 @@ def _emergency_truncate(*, buf: io.BytesIO, out_path: Path, size_budget: int) ->
     out_buf = io.BytesIO()
     with zipfile.ZipFile(out_buf, "w", zipfile.ZIP_DEFLATED, compresslevel=9) as zf:
         for info in in_zip.infolist():
-            if info.filename.startswith("logs/"):
+            if info.filename.startswith("logs/") or info.filename.startswith("transcripts/"):
                 continue  # drop the bulk
             zf.writestr(info, in_zip.read(info.filename))
         zf.writestr(

--- a/src/clauded/diagnostics/bundle.py
+++ b/src/clauded/diagnostics/bundle.py
@@ -257,7 +257,6 @@ def _build_manifest(
 
 def _collect_transcripts(
     zf: zipfile.ZipFile,
-    bot: Any,
     data_dir: Path,
 ) -> None:
     """Collect CLI session transcripts from stored sessions.
@@ -293,7 +292,9 @@ def _collect_transcripts(
 
         tail = _tail_bytes(transcript, TRANSCRIPT_TAIL_BYTES)
         if tail:
-            zf.writestr(f"transcripts/{session_id}.tail.jsonl", tail)
+            # Apply path redaction (consistent with other bundle blobs)
+            redacted = redact.redact_text(tail.decode("utf-8", errors="replace"))
+            zf.writestr(f"transcripts/{session_id}.tail.jsonl", redacted.encode("utf-8"))
 
 
 # ---------------------------------------------------------------------------
@@ -407,7 +408,7 @@ def generate_bundle(
             )
 
         # #304: CLI session transcripts (tail 1 MB each)
-        _collect_transcripts(zf, bot, data_dir)
+        _collect_transcripts(zf, data_dir)
 
         # #224 R1 simplicity: diagnostics/info.json had 2 fields
         # (python_executable + sys_path_len); merged into manifest.json's

--- a/tests/test_log_dump_bundle.py
+++ b/tests/test_log_dump_bundle.py
@@ -684,6 +684,92 @@ def test_r1_bot_flags_includes_runtime_overrides():
     assert "permission_mode_override" in s
 
 
+# ---------------------------------------------------------------------------
+# #304 — CLI session transcript in bundle
+# ---------------------------------------------------------------------------
+
+
+def test_304_bundle_includes_session_transcript(tmp_path, monkeypatch):
+    """#304 AC1+AC2: bundle contains transcripts/<session_id>.tail.jsonl
+    for each stored session whose transcript file exists."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    # Plant sessions.json with two sessions
+    sessions = {
+        "42": {
+            "session_id": "sess-aaa",
+            "project_path": "/Users/alice/repo",
+        },
+        "99": {
+            "session_id": "sess-bbb",
+            "project_path": "/Users/alice/other-proj",
+        },
+    }
+    (data_dir / "sessions.json").write_text(json.dumps(sessions))
+
+    # Create fake transcript files under ~/.claude/projects/<slug>/
+    fake_home = tmp_path / "home"
+    claude_projects = fake_home / ".claude" / "projects"
+
+    slug_a = "Users-alice-repo"
+    slug_b = "Users-alice-other-proj"
+    (claude_projects / slug_a).mkdir(parents=True)
+    (claude_projects / slug_b).mkdir(parents=True)
+
+    transcript_a = claude_projects / slug_a / "sess-aaa.jsonl"
+    transcript_a.write_text('{"type":"assistant","content":"hello"}\n')
+
+    transcript_b = claude_projects / slug_b / "sess-bbb.jsonl"
+    transcript_b.write_text('{"type":"tool_use","name":"bash"}\n')
+
+    # Redirect Path.home() to our fake home
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+    out_path = bundle_mod.generate_bundle(
+        data_dir=data_dir,
+        out_dir=tmp_path,
+        log_dir=tmp_path / "fake-logs",
+    )
+
+    with zipfile.ZipFile(out_path) as z:
+        names = set(z.namelist())
+
+    assert "transcripts/sess-aaa.tail.jsonl" in names, (
+        "#304 AC1: transcript for sess-aaa missing from bundle"
+    )
+    assert "transcripts/sess-bbb.tail.jsonl" in names, (
+        "#304 AC2: transcript for sess-bbb missing from bundle"
+    )
+
+
+def test_304_missing_transcript_graceful_skip(tmp_path, monkeypatch):
+    """#304 AC3: missing transcript file does not crash — graceful skip."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    sessions = {
+        "42": {
+            "session_id": "sess-gone",
+            "project_path": "/Users/alice/repo",
+        },
+    }
+    (data_dir / "sessions.json").write_text(json.dumps(sessions))
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+    # No transcript file created — should not crash
+    out_path = bundle_mod.generate_bundle(
+        data_dir=data_dir,
+        out_dir=tmp_path,
+        log_dir=tmp_path / "fake-logs",
+    )
+    with zipfile.ZipFile(out_path) as z:
+        names = set(z.namelist())
+    assert "transcripts/sess-gone.tail.jsonl" not in names
+
+
 @pytest.mark.asyncio
 async def test_r1_log_dump_cog_runtime_dispatch(tmp_path, monkeypatch):
     """R1 tester: real-runtime test for the /log dump command.


### PR DESCRIPTION
Closes #304. Adds transcripts/<session_id>.tail.jsonl (1MB tail) to bundle. 2 new tests. 1282 passed.