### PR TITLE
fix(#306): Task* handlers only intercept workflow tasks, not normal subagents

### DIFF
--- a/docs/prd/fix-306-subagent-task-conflict.md
+++ b/docs/prd/fix-306-subagent-task-conflict.md
@@ -1,0 +1,29 @@
+# PRD — #306 subagent render conflict with Task* handlers
+
+**Issue**: #306 (bug, P0)
+**Branch**: `fix/306-subagent-task-conflict`
+**Status**: APPROVED
+
+## Root cause
+#292 Task* isinstance checks (L1328-1337) fire `continue` on TaskStartedMessage/TaskProgressMessage/TaskNotificationMessage. When SDK sends these for normal Agent tool_use (not just Dynamic Workflow), the v1.9 sub-thread creation path (L1600 `name in ("Task", "Agent")`) never executes.
+
+## Fix
+In the 4 Task* handler dispatch (L1328-1337), skip (don't handle) events whose `task_type` indicates a normal subagent (not a dynamic workflow). Let them fall through to the existing sub-thread path.
+
+```python
+# Before handling Task* messages, check if this is a Dynamic Workflow task
+# vs a normal subagent. Normal subagents should fall through to sub-thread path.
+if _SdkTaskStartedMessage is not None and isinstance(event, _SdkTaskStartedMessage):
+    if getattr(event, "task_type", "") in ("local_workflow", "remote_workflow", "workflow"):
+        await self._handle_task_started(event)
+        continue
+    # else: fall through to sub-thread path for normal Agent
+```
+
+Same filter for TaskProgress/TaskNotification/TaskUpdated.
+
+## AC
+- AC1: normal subagent content renders to sub-thread
+- AC2: subagent completion shows ✅ embed
+- AC3: Dynamic Workflow Task* still renders banner/progress
+- AC4: two paths coexist

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1326,17 +1326,29 @@ class DiscordRenderer:
                 # subclass overlap doesn't shadow the isinstance-matched
                 # types above it.
                 if _SdkTaskStartedMessage is not None and isinstance(event, _SdkTaskStartedMessage):
-                    await self._handle_task_started(event, subagent_renderers)
-                    continue
+                    task_type = getattr(event, "task_type", "") or ""
+                    if "workflow" in task_type.lower():
+                        await self._handle_task_started(event, subagent_renderers)
+                        continue
+                    # Normal subagent — fall through to sub-thread path
+
                 if _SdkTaskProgressMessage is not None and isinstance(event, _SdkTaskProgressMessage):
-                    await self._handle_task_progress(event)
-                    continue
+                    task_id = getattr(event, "task_id", "")
+                    if task_id in self._task_states:  # Only handle if we started tracking it (workflow)
+                        await self._handle_task_progress(event)
+                        continue
+
                 if _SdkTaskNotificationMessage is not None and isinstance(event, _SdkTaskNotificationMessage):
-                    await self._handle_task_notification(event)
-                    continue
+                    task_id = getattr(event, "task_id", "")
+                    if task_id in self._task_states:
+                        await self._handle_task_notification(event)
+                        continue
+
                 if _SdkTaskUpdatedMessage is not None and isinstance(event, _SdkTaskUpdatedMessage):
-                    await self._handle_task_updated(event)
-                    continue
+                    task_id = getattr(event, "task_id", "")
+                    if task_id in self._task_states:
+                        await self._handle_task_updated(event)
+                        continue
 
                 if isinstance(event, ResultMessage):
                     # Capture stats from the result.


### PR DESCRIPTION
P0 fix. Task* handlers now gate on task_type/task_id to avoid intercepting normal Agent tool_use events. 1282 passed. Closes #306.