### PR TITLE
fix(#311): flush buffer before subagent dispatch

### DIFF
--- a/docs/prd/fix-311-flush-before-subagent.md
+++ b/docs/prd/fix-311-flush-before-subagent.md
@@ -1,0 +1,23 @@
+# PRD — #311 flush buffer before subagent dispatch
+
+**Issue**: #311 (bug, P1)
+**Branch**: `fix/311-flush-before-subagent`
+**Status**: APPROVED
+
+## Root cause
+When Agent/Task tool_use triggers subagent creation, the main buffer (pending text) is not flushed. User sees the text only after subagent completes (minutes later).
+
+## Fix
+In `discord_renderer.py`, at the `if name in ("Task", "Agent"):` block (~L1600), flush the buffer BEFORE creating the sub-thread:
+
+```python
+if name in ("Task", "Agent"):
+    # #311: flush pending text so user sees it before subagent runs
+    if buffer.strip():
+        live_msg, buffer = await self._typewriter_tick(live_msg, buffer, force=True)
+    # ... existing sub-thread creation ...
+```
+
+## AC
+- AC1: text before Agent tool call is visible immediately
+- AC2: subagent starts after flush (user sees full context)

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1610,6 +1610,12 @@ class DiscordRenderer:
                                 })
 
                             if name in ("Task", "Agent"):
+                                # #311: flush pending text before subagent dispatch
+                                # so user sees claude's message immediately.
+                                if buffer.strip():
+                                    live_msg, buffer = await self._typewriter_tick(
+                                        live_msg, buffer
+                                    )
                                 task_depth += 1
                                 desc = block.input.get("description", "")[:200]
 


### PR DESCRIPTION
Closes #311. 1-line flush before subagent sub-thread creation. 1282 passed.