### PR TITLE
fix(#308): hold table in buffer during typewriter to enable PNG render

### DIFF
--- a/docs/prd/fix-308-table-render.md
+++ b/docs/prd/fix-308-table-render.md
@@ -1,0 +1,31 @@
+# PRD — #308 tables render as code blocks
+
+**Issue**: #308 (bug, P1)
+**Branch**: `fix/308-table-render`
+**Status**: APPROVED
+
+## Root cause
+typewriter tick splits buffer at 2000 chars without checking if a markdown table is in progress. Table gets split → finalize can't extract it → code block fallback.
+
+## Fix (Approach A)
+In `_typewriter_tick`, before splitting: detect if buffer ends with incomplete table lines (consecutive `|` lines). If so, split only the pre-table portion and keep the table in buffer for `_finalize_typewriter` to handle.
+
+## Helper needed
+```python
+def _find_table_start_in_tail(self, buffer: str) -> int:
+    """Return index where an in-progress table starts at buffer tail, or -1."""
+    lines = buffer.split("\n")
+    # Walk backwards from end finding consecutive | lines
+    table_start_idx = len(buffer)
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].strip().startswith("|"):
+            table_start_idx = sum(len(l) + 1 for l in lines[:i])
+        else:
+            break
+    return table_start_idx if table_start_idx < len(buffer) else -1
+```
+
+## AC
+- AC1: long response with table → PNG (not code block)
+- AC2: short response table still works
+- AC3: typewriter UX not degraded (table portion held in buffer briefly)

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -2687,6 +2687,38 @@ class DiscordRenderer:
         fresh = await self._safe_send(content=content)
         return fresh if fresh is not None else live_msg
 
+    @staticmethod
+    def _find_table_boundary(buffer: str) -> int:
+        """Return byte offset where a trailing table block starts, or -1.
+
+        A "trailing table" is a contiguous run of lines at the end of
+        *buffer* where each non-empty line starts with ``|``.  We require
+        at least 2 such lines (header + separator or data row) to consider
+        it a table in progress.
+        """
+        lines = buffer.split("\n")
+        # Walk backwards finding consecutive table lines.
+        table_line_count = 0
+        first_table_line_idx = len(lines)
+        for i in range(len(lines) - 1, -1, -1):
+            stripped = lines[i].strip()
+            if stripped.startswith("|"):
+                table_line_count += 1
+                first_table_line_idx = i
+            elif stripped == "":
+                # Allow trailing blank lines inside table block
+                if table_line_count > 0:
+                    first_table_line_idx = i
+                    continue
+                break
+            else:
+                break
+        if table_line_count < 2:
+            return -1
+        # Compute byte offset of line at first_table_line_idx.
+        offset = sum(len(lines[j]) + 1 for j in range(first_table_line_idx))
+        return offset
+
     async def _typewriter_tick(
         self, live_msg: discord.Message | None, buffer: str
     ) -> tuple[discord.Message | None, str]:
@@ -2703,6 +2735,18 @@ class DiscordRenderer:
 
         if len(buffer) <= soft_limit:
             return await self._typewriter_apply(live_msg, buffer + CURSOR), buffer
+
+        # #308: check if buffer tail has an in-progress table
+        table_start = self._find_table_boundary(buffer)
+        if table_start > 0:
+            # Split at table boundary — send pre-table, keep table in buffer
+            pre_table = buffer[:table_start]
+            if pre_table.strip():
+                chunks = self._smart_split(pre_table, limit=soft_limit)
+                for chunk in chunks[:-1]:
+                    await self._safe_send(content=chunk)
+                live_msg = await self._typewriter_apply(live_msg, chunks[-1])
+            return live_msg, buffer[table_start:]
 
         # Buffer too big for one message — split it.
         chunks = self._smart_split(buffer, limit=soft_limit)


### PR DESCRIPTION
Closes #308. Typewriter now detects in-progress tables and holds them in buffer for finalize → PNG. 1282 passed.