### PR TITLE
fix: turn-lifecycle, subagent notification & multi-angle review fixes

### DIFF
--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -8,6 +8,7 @@ messages to a per-thread :class:`ClaudeBridge` session.
 from __future__ import annotations
 
 import functools
+import json
 import logging
 import os
 import shutil
@@ -346,10 +347,23 @@ class ClaudedBot(commands.Bot):
         # #292 S3: bot-level workflow task registry. DiscordRenderer writes
         # task lifecycle states here (via self._bot ref); /workflow cog reads.
         self._workflow_tasks: dict = {}
-        # #310: bot-level subagent→thread mapping. Keyed by session_id of the
-        # bridge that spawned the subagent → thread_id where the notification
-        # should go. Survives renderer return so SubagentStop can notify.
-        self._subagent_threads: dict[str, int] = {}
+        # review A4/A5: per-subagent pending tracking. thread_id →
+        # {agent_id: agent_type}. Populated by the SubagentStart hook
+        # (_make_subagent_start_cb) and drained per-agent_id by SubagentStop.
+        # This REPLACES the old #310 ``_subagent_threads`` (session_id →
+        # thread_id) map, which had exactly one entry per session and so
+        # both (a) false-warned "1 subagent still running" on every normal
+        # turn and (b) got del'd after the FIRST subagent stopped, destroying
+        # the count for later parallel subagents. Routing no longer needs a
+        # map at all — the completion/start callbacks are built per-thread via
+        # _make_subagent_{start,stop}_cb(thread_id), so the closure already
+        # captures the correct thread_id.
+        #
+        # Robustness: if the SubagentStart hook does NOT fire in some CLI
+        # versions, this dict simply stays empty → pending count 0 → no
+        # warning at all (graceful degradation; still strictly better than
+        # the old guaranteed false positive).
+        self._pending_subagents: dict[int, dict[str, str]] = {}
 
         # ---------------------------------------------------------------- #241
         # Scheduler core (PRD v1.18 §3.7 / §8 Subtask 4): persistent timer
@@ -614,12 +628,24 @@ class ClaudedBot(commands.Bot):
                 to_remove.append(thread_id)
 
         async def _stop_one(tid: int) -> None:
-            try:
-                self.session_manager.save_session_state(tid)
-                await self.session_manager.stop_session(tid)
-                log.info("Auto-expired session for thread %s", tid)
-            except Exception:
-                log.exception("Auto-expire failed for thread %s", tid)
+            # review B2: never disconnect a bridge while a turn is in flight. A
+            # long max-effort turn doesn't refresh ``_last_activity`` mid-run,
+            # so it can look "idle" here; tearing down its client mid-stream
+            # races the renderer's ``receive_response()``. If the per-thread
+            # lock is held a turn is running → the session isn't really idle,
+            # so skip this cycle. Otherwise hold the lock across the stop so a
+            # turn can't start underneath us.
+            lock = self.session_manager.get_lock(tid)
+            if lock.locked():
+                log.debug("Auto-expire skipped (turn in flight) thread %s", tid)
+                return
+            async with lock:
+                try:
+                    self.session_manager.save_session_state(tid)
+                    await self.session_manager.stop_session(tid)
+                    log.info("Auto-expired session for thread %s", tid)
+                except Exception:
+                    log.exception("Auto-expire failed for thread %s", tid)
 
         if to_remove:
             # #146: stop sessions concurrently so one stuck bridge doesn't
@@ -878,10 +904,11 @@ class ClaudedBot(commands.Bot):
                     pass  # logged by bridge already
 
                 async def _stop_notify(input_data: dict) -> None:
-                    reason = input_data.get("stop_reason", "unknown")
-                    log.info("Session stopped: %s", reason)
+                    # review Finding 38: StopHookInput carries NO stop_reason
+                    # (only hook_event_name + stop_hook_active). Don't read it.
+                    log.info("Session stopped (thread=%d)", thread.id)
                     # #310: warn user if subagents still running
-                    await self._warn_pending_subagents(thread.id, reason)
+                    await self._warn_pending_subagents(thread.id)
 
                 env_vars = self.project_manager.get_env(channel.id)
                 _notify = self._notify_enabled.get(thread.id, self._pre_tool_notifications)
@@ -891,6 +918,7 @@ class ClaudedBot(commands.Bot):
                     on_pre_tool_use=_pre_tool_notify if _notify else None,
                     on_post_tool_use=_post_tool_notify,
                     on_stop=_stop_notify,
+                    on_subagent_start=self._make_subagent_start_cb(thread.id),
                     on_subagent_stop=self._make_subagent_stop_cb(thread.id),
                     add_dirs=extra_dirs or None,
                     mcp_servers=mcp_servers or None,
@@ -1085,10 +1113,10 @@ class ClaudedBot(commands.Bot):
                         pass  # logged by bridge already
 
                     async def _stop_notify_thread(input_data: dict) -> None:
-                        reason = input_data.get("stop_reason", "unknown")
-                        log.info("Session stopped: %s", reason)
+                        # review Finding 38: StopHookInput has NO stop_reason.
+                        log.info("Session stopped (thread=%s)", thread_id)
                         # #310: warn user if subagents still running
-                        await self._warn_pending_subagents(thread_id, reason)
+                        await self._warn_pending_subagents(thread_id)
 
                     env_vars = self.project_manager.get_env(parent_id)
                     _notify = self._notify_enabled.get(thread_id, self._pre_tool_notifications)
@@ -1101,6 +1129,7 @@ class ClaudedBot(commands.Bot):
                         on_pre_tool_use=_pre_tool_notify_thread if _notify else None,
                         on_post_tool_use=_post_tool_notify_thread,
                         on_stop=_stop_notify_thread,
+                        on_subagent_start=self._make_subagent_start_cb(thread_id),
                         on_subagent_stop=self._make_subagent_stop_cb(thread_id),
                         add_dirs=extra_dirs or None,
                         mcp_servers=mcp_servers or None,
@@ -1299,28 +1328,94 @@ class ClaudedBot(commands.Bot):
     def _wire_session_persist_cb(self, bridge: "ClaudeBridge", thread_id: int) -> None:
         """#301 R2: persist session_id the moment the first ResultMessage arrives.
 
-        #310: also register session_id → thread_id in ``_subagent_threads``
-        so the SubagentStop callback can look up where to send the notification.
+        review A4/A5: no longer registers a session_id → thread_id map. The
+        old #310 ``_subagent_threads[sid] = thread_id`` line lived here and
+        was the root of the per-session leak + false-warning bugs. Subagent
+        routing now comes from the per-thread closure in
+        _make_subagent_{start,stop}_cb, so nothing needs to be registered.
         """
+        # review A6 tail: this runs only when a FRESH bridge is created (reused
+        # live bridges skip it). A fresh session means any subagents left in
+        # this thread's pending bucket belong to a dead prior session — their
+        # SubagentStop can never arrive — so clear them now. Otherwise an
+        # orphaned entry (SubagentStart fired, session killed before
+        # SubagentStop) would produce a stale "N subagent(s) still running"
+        # warning on a later turn's stop.
+        self._pending_subagents.pop(thread_id, None)
+
         def _on_sid(sid: str) -> None:
             self.session_manager.save_session_state(thread_id)
-            # #310: register mapping so subagent completion can find the thread
-            self._subagent_threads[sid] = thread_id
         bridge._on_session_id_cb = _on_sid
 
+    @staticmethod
+    def _read_subagent_result(agent_transcript_path: str | None) -> str:
+        """review A6: best-effort extract the subagent's final result text.
 
-    async def _warn_pending_subagents(self, thread_id: int, reason: str) -> None:
-        """#310: send warning embed if subagents are still running when session stops."""
-        pending = sum(
-            1 for _sid, tid in self._subagent_threads.items()
-            if tid == thread_id
-        )
+        ``agent_transcript_path`` (from SubagentStopHookInput) points at a
+        JSONL transcript of the subagent's run. We read the TAIL and parse
+        the LAST assistant text block → the subagent's final answer, then
+        truncate to ~800 chars. Any problem (missing/unreadable/malformed
+        file) returns "" so the caller falls back to a generic message and
+        never crashes.
+        """
+        if not agent_transcript_path:
+            return ""
+        try:
+            p = Path(agent_transcript_path)
+            if not p.is_file():
+                return ""
+            # Read the tail only — transcripts can be large. 256 KiB is more
+            # than enough to hold the final assistant turn.
+            data = p.read_bytes()
+            tail = data[-262_144:]
+            text = tail.decode("utf-8", errors="replace")
+            last_text = ""
+            for line in text.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except (ValueError, TypeError):
+                    # Partial first line from the tail slice, or non-JSON. Skip.
+                    continue
+                # Transcript rows are typically {"type": "assistant",
+                # "message": {"content": [ {"type": "text", "text": ...}, ...]}}.
+                # Be liberal: also accept a top-level "content" list.
+                if obj.get("type") not in (None, "assistant"):
+                    continue
+                msg = obj.get("message", obj)
+                content = msg.get("content") if isinstance(msg, dict) else None
+                if isinstance(content, str):
+                    last_text = content
+                elif isinstance(content, list):
+                    parts = [
+                        b.get("text", "")
+                        for b in content
+                        if isinstance(b, dict) and b.get("type") == "text"
+                    ]
+                    joined = "\n".join(t for t in parts if t)
+                    if joined:
+                        last_text = joined
+            return last_text.strip()[:800]
+        except Exception:
+            log.debug("review A6: failed reading subagent transcript", exc_info=True)
+            return ""
+
+    async def _warn_pending_subagents(self, thread_id: int) -> None:
+        """#310 / review A4/A5: warn if subagents are still running on stop.
+
+        Counts real pending subagents for THIS thread via ``_pending_subagents``
+        (one entry per agent_id). On a normal turn with no subagents the count
+        is 0 → we send nothing (the old code always saw 1 stale session entry
+        and false-warned every turn).
+        """
+        pending = len(self._pending_subagents.get(thread_id, {}))
         if pending <= 0:
             return
         embed = discord.Embed(
             title="⏹️ Session ended",
             description=(
-                f"Reason: {reason}\n"
                 f"⚠️ {pending} subagent(s) still running in background "
                 f"— will notify when complete"
             ),
@@ -1335,62 +1430,89 @@ class ClaudedBot(commands.Bot):
         except Exception:
             log.debug("#310: failed to send pending-subagent warning", exc_info=True)
 
-    def _make_subagent_stop_cb(self, thread_id: int) -> Any:
-        """#310: build a callback that notifies Discord when a subagent completes.
+    def _make_subagent_start_cb(self, thread_id: int) -> Any:
+        """review A4/A5: build a SubagentStart callback that records a pending
+        subagent for this thread.
 
-        The callback is stored in SessionConfig.on_subagent_stop and invoked
-        by the SubagentStop hook in claude_bridge.py. It sends a ✅ embed to
-        the thread even if the main renderer has already returned.
+        Stored in SessionConfig.on_subagent_start, invoked by the SubagentStart
+        hook in claude_bridge.py. ``SubagentStartHookInput`` carries agent_id +
+        agent_type (and session_id from BaseHookInput). We key pending state by
+        agent_id so parallel subagents are counted independently and the
+        completion count survives after the first one stops.
+        """
+        async def _on_subagent_start(input_data: dict) -> None:
+            agent_id = input_data.get("agent_id")
+            agent_type = input_data.get("agent_type")
+            if not agent_id:
+                return
+            self._pending_subagents.setdefault(thread_id, {})[agent_id] = (
+                agent_type or "subagent"
+            )
+
+        return _on_subagent_start
+
+    def _make_subagent_stop_cb(self, thread_id: int) -> Any:
+        """#310 / review A3/A6: notify Discord when a subagent completes.
+
+        Stored in SessionConfig.on_subagent_stop, invoked by the SubagentStop
+        hook in claude_bridge.py. Sends a ✅ embed to the thread even if the
+        main renderer has already returned.
+
+        review A3: ``SubagentStopHookInput`` provides agent_id / agent_type /
+        agent_transcript_path — and NO stop_reason / summary / duration_ms.
+        The old code read those non-existent fields, so the embed was always
+        the contentless "Subagent finished." and the real output never reached
+        Discord.
+
+        review A6: we surface the subagent's real result to Discord by reading
+        the tail of agent_transcript_path. Re-injecting that result back into
+        Claude's own conversation is DEFERRED (was reverted in #310, needs a
+        separate design).
         """
         async def _on_subagent_stop(input_data: dict) -> None:
-            reason = input_data.get("stop_reason", "")
-            session_id = input_data.get("session_id", "")
-            # Try to compute duration from bridge start_time if available
-            duration_str = ""
-            if "duration_ms" in input_data:
-                ms = input_data["duration_ms"]
-                secs = int(ms / 1000)
-                if secs >= 60:
-                    duration_str = f"{secs // 60}m {secs % 60}s"
-                else:
-                    duration_str = f"{secs}s"
+            agent_id = input_data.get("agent_id")
+            agent_type = input_data.get("agent_type")
+            agent_transcript_path = input_data.get("agent_transcript_path")
 
-            # Build embed
-            desc_parts = []
-            summary = input_data.get("summary", "")
-            if summary:
-                desc_parts.append(f"📋 **Summary:** {summary[:500]}")
-            if duration_str:
-                desc_parts.append(f"⏱️ Duration: {duration_str}")
-            if reason and reason != "end_turn":
-                desc_parts.append(f"Reason: {reason}")
+            # review A4/A5: drain this agent_id from pending (guard both the
+            # thread bucket and the id — SubagentStart may not have fired).
+            bucket = self._pending_subagents.get(thread_id)
+            if bucket is not None:
+                bucket.pop(agent_id, None)
+                if not bucket:
+                    self._pending_subagents.pop(thread_id, None)
+
+            # review A6: surface the real result (Discord only).
+            result_text = self._read_subagent_result(agent_transcript_path)
+            label = agent_type or "subagent"
+            if result_text:
+                description = result_text
+            else:
+                description = f"✅ Subagent (`{label}`) completed"
 
             embed = discord.Embed(
-                title="✅ Subagent completed",
-                description="\n".join(desc_parts) if desc_parts else "Subagent finished.",
+                title=f"✅ Subagent completed ({label})",
+                description=description,
                 color=COLOR_INFO,
             )
 
-            # Find the thread to send to
-            target_thread_id = thread_id
-            # If there's a sub-thread for this session, prefer that
-            if session_id and session_id in self._subagent_threads:
-                target_thread_id = self._subagent_threads[session_id]
-
+            # Route to the closure thread_id — no session→thread map needed.
             try:
-                channel = self.get_channel(target_thread_id)
+                channel = self.get_channel(thread_id)
                 if channel is None:
-                    channel = await self.fetch_channel(target_thread_id)
+                    channel = await self.fetch_channel(thread_id)
                 if channel is not None:
                     await safe_send_message(channel, embed=embed)
                 else:
-                    log.warning("#310: could not find thread %d for subagent notification", target_thread_id)
+                    log.warning(
+                        "#310: could not find thread %d for subagent notification",
+                        thread_id,
+                    )
             except Exception:
-                log.warning("#310: failed to send subagent completion notification", exc_info=True)
-
-            # Clean up the mapping entry
-            if session_id and session_id in self._subagent_threads:
-                del self._subagent_threads[session_id]
+                log.warning(
+                    "#310: failed to send subagent completion notification",
+                    exc_info=True,
+                )
 
         return _on_subagent_stop
 
@@ -1453,10 +1575,10 @@ class ClaudedBot(commands.Bot):
             pass  # logged by bridge already
 
         async def _stop_notify(input_data: dict) -> None:
-            reason = input_data.get("stop_reason", "unknown")
-            log.info("Session stopped: %s", reason)
+            # review Finding 38: StopHookInput has NO stop_reason.
+            log.info("Session stopped (thread=%s)", thread_id)
             # #310: warn user if subagents still running
-            await self._warn_pending_subagents(thread_id, reason)
+            await self._warn_pending_subagents(thread_id)
 
         sc = SessionConfig(
             system_prompt=self.project_manager.get_system_prompt(parent_id),
@@ -1467,6 +1589,7 @@ class ClaudedBot(commands.Bot):
             on_pre_tool_use=pre_tool_cb,
             on_post_tool_use=_post_tool_notify,
             on_stop=_stop_notify,
+            on_subagent_start=self._make_subagent_start_cb(thread_id),
             on_subagent_stop=self._make_subagent_stop_cb(thread_id),
             **overrides,
         )
@@ -2082,12 +2205,13 @@ class ClaudedBot(commands.Bot):
         )
 
     async def _notify_schedule_expired(self, sched: dict) -> None:
-        """Notify the schedule's created channel that its max_lifetime fired.
+        """Notify the schedule's created channel that it was auto-disabled.
 
-        Called by :meth:`SchedulerManager._check_max_lifetime` once the
-        cumulative lifetime since first fire has elapsed (PRD §3.8). Best-
-        effort: failures are logged but never bubble — the schedule is
-        already disabled by the time we get here.
+        Called by :meth:`SchedulerManager._check_max_lifetime` (max_lifetime
+        reached) and, review E3, by :meth:`SchedulerManager._on_fire_terminal`
+        (retries exhausted / terminal Discord error). We branch on
+        ``state.last_error`` to pick the wording. Best-effort: failures are
+        logged but never bubble — the schedule is already disabled.
         """
         channel_id = sched.get("channel_id")
         if not channel_id:
@@ -2096,17 +2220,31 @@ class ClaudedBot(commands.Bot):
                 sched.get("schedule_id"),
             )
             return
+        sid = (sched.get("schedule_id", "") or "")[:8]
+        name = sched.get("name", "")
+        last_error = (sched.get("state") or {}).get("last_error") or ""
+        if last_error == "max_lifetime reached":
+            title = "⏰ Schedule expired"
+            description = (
+                f"Schedule `{sid}` (*{name}*) reached its max_lifetime "
+                f"and has been auto-disabled."
+            )
+        else:
+            # review E3: crash auto-disable (exhausted retries / terminal error).
+            title = "⚠️ Schedule auto-disabled"
+            description = (
+                f"Schedule `{sid}` (*{name}*) kept failing and has been "
+                f"auto-disabled after repeated attempts.\n"
+                f"Last error: `{last_error[:300]}`\n"
+                f"-# Fix the cause, then recreate/re-enable it."
+            )
         try:
             channel = self.get_channel(channel_id)
             if channel is None:
                 channel = await self.fetch_channel(channel_id)
             embed = discord.Embed(
-                title="⏰ Schedule expired",
-                description=(
-                    f"Schedule `{(sched.get('schedule_id','') or '')[:8]}` "
-                    f"(*{sched.get('name','')}*) reached its max_lifetime "
-                    f"and has been auto-disabled."
-                ),
+                title=title,
+                description=description,
                 color=COLOR_INFO,
             )
             await safe_send_message(channel, embed=embed)

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -569,6 +569,26 @@ class ClaudeBridge:
 
         _hooks_dict["SubagentStop"] = [HookMatcher(matcher=None, hooks=[_hook_subagent_stop])]
 
+        # --- SubagentStart hook: notified when a subagent starts ---
+        # #310 R2: SubagentStartHookInput carries session_id (BaseHookInput),
+        # agent_id and agent_type. The bot uses this to track pending
+        # subagents PER agent_id (not per session), so the completion count
+        # and routing survive multiple parallel subagents in one session.
+        async def _hook_subagent_start(
+            input_data: dict[str, Any],
+            tool_use_id: str | None,
+            context: HookContext,
+        ) -> dict[str, Any]:
+            log.info("Subagent started: %s", str(input_data)[:200])
+            if self._session_config.on_subagent_start:
+                try:
+                    await self._session_config.on_subagent_start(input_data)
+                except Exception:
+                    log.debug("on_subagent_start callback raised; ignoring", exc_info=True)
+            return {}
+
+        _hooks_dict["SubagentStart"] = [HookMatcher(matcher=None, hooks=[_hook_subagent_start])]
+
         # Always assign hooks dict (we now unconditionally register PreCompact etc.)
         hooks = _hooks_dict
 
@@ -714,6 +734,12 @@ class ClaudeBridge:
                 await self._client.query(_stream())
 
             async for msg in self._client.receive_response():
+                # review D2: capture + persist session_id from the EARLIEST
+                # message that carries it (the CLI's init SystemMessage), not
+                # just the terminal ResultMessage. A long fresh first turn that
+                # crashes before its ResultMessage used to leave sessions.json
+                # with no id at all → the whole turn was unresumable.
+                self._capture_session_id(msg)
                 if isinstance(msg, ResultMessage):
                     self._update_stats(msg)
                 yield msg
@@ -753,6 +779,73 @@ class ClaudeBridge:
                         "Error disconnecting ClaudeSDKClient after stream failure"
                     )
             raise
+
+    async def receive_pending(
+        self,
+        per_message_timeout: float | None = None,
+    ) -> AsyncIterator[object]:
+        """Drain SDK messages that arrive AFTER ``receive_response()`` returned.
+
+        ``ClaudeSDKClient.receive_response()`` (used by :meth:`send_message`)
+        terminates at the first ``ResultMessage``. Any messages the CLI emits
+        *after* that — e.g. a trailing ``TaskUpdatedMessage`` /
+        ``TaskNotificationMessage`` for a background/workflow subtask whose
+        terminal state lands just after the main turn's result — stay buffered
+        in the SDK's shared receive stream and are NOT delivered by that
+        ``receive_response()`` call. Without draining them, a workflow
+        subtask's ``⚡ Running`` embed never gets its terminal ✅/❌ and
+        ``_task_states`` leaks into the next turn (review finding A1 / #292).
+
+        Yields further raw SDK message objects, stopping as soon as no message
+        arrives within ``per_message_timeout`` seconds (the trailing burst has
+        drained) or the underlying stream ends. Best-effort: any error ends the
+        drain silently — the turn is already complete, so a failed drain must
+        never surface as a turn error. Callers should stop iterating once their
+        pending-work set is empty (they own the "how long / what to keep"
+        policy) so this only blocks for one ``per_message_timeout`` gap.
+
+        Safe because the SDK's background read task pumps every message into a
+        single shared anyio memory-object stream; a *second* ``receive_messages``
+        iterator continues draining that stream from where ``receive_response``
+        stopped. On the per-message timeout we let ``asyncio.wait_for`` cancel
+        the in-flight ``__anext__``, then STOP and discard the iterator (never
+        resume it), so cancellation happens at most once — anyio memory-stream
+        receives are cancellation-safe and the next turn's fresh
+        ``query()``/``receive_response()`` on the same client is unaffected.
+        """
+        client = self._client
+        if client is None or not self._active:
+            return
+        if per_message_timeout is None:
+            per_message_timeout = float(
+                os.environ.get("CLAUDED_DRAIN_MSG_TIMEOUT", "3.0")
+            )
+        it = client.receive_messages().__aiter__()
+        try:
+            while True:
+                try:
+                    msg = await asyncio.wait_for(
+                        it.__anext__(), timeout=per_message_timeout
+                    )
+                except (asyncio.TimeoutError, StopAsyncIteration):
+                    return
+                except Exception:
+                    log.debug(
+                        "receive_pending: drain read failed; stopping", exc_info=True
+                    )
+                    return
+                if isinstance(msg, ResultMessage):
+                    self._update_stats(msg)
+                yield msg
+        finally:
+            aclose = getattr(it, "aclose", None)
+            if aclose is not None:
+                try:
+                    await aclose()
+                except Exception:
+                    log.debug(
+                        "receive_pending: iterator aclose failed", exc_info=True
+                    )
 
     async def interrupt(self) -> bool:
         """Interrupt the current Claude operation. Returns True if interrupted."""
@@ -829,6 +922,22 @@ class ClaudeBridge:
         # Auto-approve all other tools
         return PermissionResultAllow()
 
+    def _capture_session_id(self, msg: object) -> None:
+        """Persist the session_id from any SDK message that carries one.
+
+        review D2: called on EVERY message in the ``send_message`` stream so a
+        fresh session's id is saved as soon as the CLI reports it (its init
+        SystemMessage), not only when the terminal ResultMessage arrives. The
+        ``first_time`` guard means the ``_on_session_id_cb`` (which writes
+        sessions.json) fires exactly once, so hoisting it is free.
+        """
+        sid = getattr(msg, "session_id", None)
+        if isinstance(sid, str) and sid:
+            first_time = self._session_id is None
+            self._session_id = sid
+            if first_time and self._on_session_id_cb is not None:
+                self._on_session_id_cb(sid)
+
     def _update_stats(self, msg: ResultMessage) -> None:
         """Pull per-turn totals off a ``ResultMessage`` into instance state.
 
@@ -837,13 +946,10 @@ class ClaudeBridge:
         missing — newer/older SDKs may rename fields, and we'd rather
         surface partial stats than crash the stream.
         """
-        # Extract session_id from ResultMessage
-        sid = getattr(msg, "session_id", None)
-        if isinstance(sid, str) and sid:
-            first_time = self._session_id is None
-            self._session_id = sid
-            if first_time and self._on_session_id_cb is not None:
-                self._on_session_id_cb(sid)
+        # review D2: session_id capture moved to _capture_session_id (called on
+        # every message). Kept here too for direct callers/tests — idempotent
+        # via the first_time guard.
+        self._capture_session_id(msg)
 
         cost = getattr(msg, "total_cost_usd", None)
         if isinstance(cost, (int, float)):

--- a/src/clauded/cogs/ops.py
+++ b/src/clauded/cogs/ops.py
@@ -339,17 +339,23 @@ async def send_to_claude(interaction: discord.Interaction, message: discord.Mess
         except Exception as exc:
             await interaction.followup.send(f"❌ Failed to start session: `{exc}`", ephemeral=True)
             return
-    try:
-        renderer = DiscordRenderer(thread)
-        user_text = message.content or "Hello"
-        await renderer.render_response(bridge, user_text)
-    except Exception:
-        log.exception("send_to_claude render failed")
-        await bot.session_manager.stop_session(thread.id)
+        # review D1: persist the session_id from this context-menu turn so the
+        # conversation survives a restart (create_session alone doesn't wire it).
+        bot._wire_session_persist_cb(bridge, thread.id)
+        # review B1: keep the render INSIDE the lock — it used to run after the
+        # ``async with`` closed, leaving the render unserialized against a
+        # concurrent turn on the same ClaudeSDKClient.
         try:
-            await thread.send(embed=discord.Embed(title="❌ Error", description="Claude session failed", color=0xEF4444))
+            renderer = DiscordRenderer(thread)
+            user_text = message.content or "Hello"
+            await renderer.render_response(bridge, user_text)
         except Exception:
-            pass
+            log.exception("send_to_claude render failed")
+            await bot.session_manager.stop_session(thread.id)
+            try:
+                await thread.send(embed=discord.Embed(title="❌ Error", description="Claude session failed", color=0xEF4444))
+            except Exception:
+                pass
     await interaction.followup.send(f"✅ Sent to Claude in {thread.mention}", ephemeral=True)
 
 

--- a/src/clauded/cogs/project.py
+++ b/src/clauded/cogs/project.py
@@ -188,7 +188,11 @@ async def project_add_dir(interaction: discord.Interaction, path: str) -> None:
     # thread → parent so the extra dir attaches to the bound row, not the
     # (unbound) thread id. See #209.
     try:
-        resolved = bot.project_manager.add_extra_dir(binding_id, path)
+        # review E4: pass guild_id so the extra dir is confined to the guild's
+        # root (mirror of /project bind), not the global projects_root.
+        resolved = bot.project_manager.add_extra_dir(
+            binding_id, path, guild_id=interaction.guild_id
+        )
     except ValueError as exc:
         await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
         return

--- a/src/clauded/cogs/schedule.py
+++ b/src/clauded/cogs/schedule.py
@@ -150,9 +150,15 @@ async def _ensure_bridge(bot, thread_id: int, binding_id: int, user_name: str):
         env=bot.project_manager.get_env(binding_id) or None,
         user=user_name,
     )
-    return await bot.session_manager.create_session(
+    bridge = await bot.session_manager.create_session(
         thread_id, project_path, bot.config, sc,
     )
+    # review D1: wire the session-persist callback so the session_id produced
+    # by this slash-injected turn lands in sessions.json. Without it the whole
+    # /schedule conversation is unresumable after a restart (this path is
+    # outside the natural message handler that normally wires it).
+    bot._wire_session_persist_cb(bridge, thread_id)
+    return bridge
 
 
 def _resolve_full_schedule_id(bot, partial: str) -> tuple[str | None, str | None]:
@@ -222,45 +228,50 @@ async def schedule_message_cmd(
         ephemeral=False,
     )
 
-    try:
-        bridge = await _ensure_bridge(
-            bot, channel.id, parent_id, interaction.user.name,
-        )
-    except Exception as exc:
-        log.exception("/schedule message: failed to start bridge")
-        await channel.send(embed=discord.Embed(
-            title="❌ Failed to open session",
-            description=f"```\n{str(exc)[:500]}\n```",
-            color=COLOR_TOOL_FAILURE,
-        ))
-        return
-
-    bot._register_scheduler_ctx(
-        thread_id=channel.id,
-        channel_id=parent_id,
-        guild_id=getattr(channel.guild, "id", None),
-    )
-    full = _REMINDER_MESSAGE.format(user_text=text)
-    project_path = bot.project_manager.get_path(parent_id)
-    renderer = DiscordRenderer(
-        channel,
-        bot=bot,
-        project_path=Path(project_path) if project_path else None,
-    )
-    try:
-        await renderer.render_response(
-            bridge, full, author_id=interaction.user.id,
-        )
-    except Exception:
-        log.exception("/schedule message render failed")
+    # review B1: hold the per-thread lock across bridge get/create + render so
+    # this slash-injected turn can't race a concurrent @bot turn on the same
+    # ClaudeSDKClient (two receive_response iterators on one stream corrupt
+    # both renders). Same lock every other render_response call site holds.
+    async with bot.session_manager.get_lock(channel.id):
         try:
+            bridge = await _ensure_bridge(
+                bot, channel.id, parent_id, interaction.user.name,
+            )
+        except Exception as exc:
+            log.exception("/schedule message: failed to start bridge")
             await channel.send(embed=discord.Embed(
-                title="❌ Schedule injection failed",
-                description="See bot logs.",
+                title="❌ Failed to open session",
+                description=f"```\n{str(exc)[:500]}\n```",
                 color=COLOR_TOOL_FAILURE,
             ))
+            return
+
+        bot._register_scheduler_ctx(
+            thread_id=channel.id,
+            channel_id=parent_id,
+            guild_id=getattr(channel.guild, "id", None),
+        )
+        full = _REMINDER_MESSAGE.format(user_text=text)
+        project_path = bot.project_manager.get_path(parent_id)
+        renderer = DiscordRenderer(
+            channel,
+            bot=bot,
+            project_path=Path(project_path) if project_path else None,
+        )
+        try:
+            await renderer.render_response(
+                bridge, full, author_id=interaction.user.id,
+            )
         except Exception:
-            pass
+            log.exception("/schedule message render failed")
+            try:
+                await channel.send(embed=discord.Embed(
+                    title="❌ Schedule injection failed",
+                    description="See bot logs.",
+                    color=COLOR_TOOL_FAILURE,
+                ))
+            except Exception:
+                pass
 
 
 # --------------------------------------------------------------------------
@@ -353,9 +364,12 @@ async def schedule_new_task_cmd(
             project_path=Path(project_path) if project_path else None,
         )
         try:
-            await renderer.render_response(
-                bridge, full, author_id=interaction.user.id,
-            )
+            # review B1: serialize the render against any concurrent turn on
+            # this thread's ClaudeSDKClient.
+            async with bot.session_manager.get_lock(thread.id):
+                await renderer.render_response(
+                    bridge, full, author_id=interaction.user.id,
+                )
         except Exception:
             log.exception("/schedule new_task render failed (channel branch)")
         return
@@ -410,9 +424,12 @@ async def schedule_new_task_cmd(
         project_path=Path(project_path) if project_path else None,
     )
     try:
-        await renderer.render_response(
-            bridge, full, author_id=interaction.user.id,
-        )
+        # review B1: serialize the render against any concurrent turn on this
+        # thread's ClaudeSDKClient.
+        async with bot.session_manager.get_lock(thread.id):
+            await renderer.render_response(
+                bridge, full, author_id=interaction.user.id,
+            )
     except Exception:
         log.exception("/schedule new_task render failed")
 

--- a/src/clauded/cogs/tools.py
+++ b/src/clauded/cogs/tools.py
@@ -110,6 +110,12 @@ async def budget_set(interaction: discord.Interaction, amount: float) -> None:
     if amount <= 0:
         await interaction.response.send_message("Budget must be positive.", ephemeral=True)
         return
+    # review E2: guard unbound channels like the sibling /budget show does.
+    # Without this, an unbound invocation fell through to _recreate_session
+    # (and, on older schemas, set_budget's bound-assertion) with the
+    # interaction never answered → Discord's "application did not respond".
+    if await reject_if_unbound(interaction, bot):
+        return
     binding_id = resolve_binding_id(interaction)
     if binding_id is not None:
         bot.project_manager.set_budget(binding_id, amount)

--- a/src/clauded/diagnostics/bundle.py
+++ b/src/clauded/diagnostics/bundle.py
@@ -136,10 +136,14 @@ def _snapshot_bot_flags(bot: Any) -> dict:
         "_debug_logging",
         "_pre_tool_notifications",
         "_notify_enabled",
-        "_allow_unbound_fallback",
+        # review E7: the runtime unbound-fallback flag is ``allow_unbound_fallback``
+        # (NO leading underscore — see ClaudedBot.__init__ / #160). The old key
+        # ``_allow_unbound_fallback`` never matched, so the single most
+        # security-relevant flag was silently absent from every /log dump —
+        # exactly the state an operator opens the bundle to inspect.
+        "allow_unbound_fallback",
         "_start_time",
         "_claude_version",
-        "_stream_debug_enabled",
     ]
     out: dict = {}
     for k in keys:
@@ -156,6 +160,15 @@ def _snapshot_bot_flags(bot: Any) -> dict:
                     out[k] = str(v)
             except Exception:
                 out[k] = "<unrenderable>"
+    # review E7: stream-debug state is NOT a bot attribute (the old
+    # ``_stream_debug_enabled`` key never existed); it lives in the
+    # stream_logger module (env CLAUDED_STREAM_DEBUG or set_enabled override).
+    # Local import keeps bundle import-light and avoids any cycle.
+    try:
+        from .. import stream_logger
+        out["stream_debug_enabled"] = stream_logger.is_enabled()
+    except Exception:
+        pass
     return out
 
 

--- a/src/clauded/diagnostics/redact.py
+++ b/src/clauded/diagnostics/redact.py
@@ -215,12 +215,19 @@ def redact_projects_json(data: dict, *, username: str | None = None) -> dict:
             for path_key in ("path", "system_prompt_path"):
                 if path_key in redacted_v and isinstance(redacted_v[path_key], str):
                     redacted_v[path_key] = redact_path(redacted_v[path_key], username=username)
-            # add_dirs is list[str]
-            if "add_dirs" in redacted_v and isinstance(redacted_v["add_dirs"], list):
-                redacted_v["add_dirs"] = [
-                    redact_path(p, username=username) if isinstance(p, str) else p
-                    for p in redacted_v["add_dirs"]
-                ]
+            # review E1: extra directories are persisted under ``extra_dirs``
+            # (see ProjectManager.add_extra_dir / get_extra_dirs). The old
+            # code redacted ``add_dirs`` — a key projects.json never uses — so
+            # the absolute paths from ``/project add-dir`` (which embed the
+            # operator's username) leaked unredacted into every /log dump.
+            # Redact both: ``extra_dirs`` is the live key, ``add_dirs`` kept
+            # defensively for any older on-disk schema.
+            for dirs_key in ("extra_dirs", "add_dirs"):
+                if dirs_key in redacted_v and isinstance(redacted_v[dirs_key], list):
+                    redacted_v[dirs_key] = [
+                        redact_path(p, username=username) if isinstance(p, str) else p
+                        for p in redacted_v[dirs_key]
+                    ]
             out[k] = redacted_v
         else:
             out[k] = v

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -274,6 +274,17 @@ EDIT_INTERVAL_SECONDS = 1.2
 MAX_HTTP_RETRIES = 5
 _BACKOFF = (0.5, 1.0, 2.0, 4.0, 8.0)  # seconds, indexed by attempt
 
+# review A1: total wall-clock budget for the post-ResultMessage drain of
+# trailing workflow Task* messages. ``receive_response()`` returns at the
+# first ResultMessage, so a workflow subtask whose terminal
+# TaskNotification/TaskUpdated lands just after the result would otherwise
+# never be finalized (its ``⚡ Running`` embed stays forever + the
+# ``_task_states`` entry leaks into the next turn). We only enter this drain
+# when tasks are still pending, so normal turns pay ZERO latency. Env
+# ``CLAUDED_DRAIN_TOTAL_TIMEOUT`` overrides (default 8s). Per-message gap
+# timeout lives in ``ClaudeBridge.receive_pending`` (``CLAUDED_DRAIN_MSG_TIMEOUT``).
+DRAIN_TOTAL_SECONDS = float(os.environ.get("CLAUDED_DRAIN_TOTAL_TIMEOUT", "8.0"))
+
 # Threshold above which a code block is uploaded as a file attachment.
 CODE_FILE_UPLOAD_THRESHOLD = 3000
 
@@ -1168,6 +1179,67 @@ class DiscordRenderer:
         )
 
     # ------------------------------------------------------------------
+    # review A1: unified Task* dispatch (shared by main loop + drain)
+    # ------------------------------------------------------------------
+
+    async def _dispatch_task_event(
+        self,
+        event: Any,
+        subagent_renderers: dict[str, "DiscordRenderer"],
+    ) -> bool:
+        """Route a #292 Dynamic Workflow ``Task*`` message to its handler.
+
+        Returns ``True`` iff ``event`` was one of the four SDK ``Task*``
+        message types AND we handled it (i.e. the caller should treat it as
+        consumed and ``continue``). Returns ``False`` for any non-Task* event,
+        and also for Task* events we intentionally leave for the sub-thread
+        path (a ``TaskStartedMessage`` whose ``task_type`` is not a workflow —
+        that's a plain sub-agent, handled by the live ``parent_tool_use_id``
+        routing in the main loop) or that we aren't tracking (Progress /
+        Notification / Updated for a ``task_id`` not in ``_task_states``).
+
+        review A1: extracted verbatim from the inline block that used to live
+        in :meth:`render_response`'s main loop (the four ``isinstance(event,
+        _SdkTask*Message)`` checks plus their gates). Sharing one code path
+        means the post-ResultMessage drain (which runs
+        :meth:`ClaudeBridge.receive_pending`) finalizes trailing workflow
+        terminals with byte-for-byte the same behavior as the in-stream case.
+        The ordering matters: ``TaskUpdated`` must be checked last so a future
+        SDK subclass overlap doesn't shadow the isinstance-matched types above
+        it (same rationale as the original inline block).
+        """
+        if _SdkTaskStartedMessage is not None and isinstance(event, _SdkTaskStartedMessage):
+            task_type = getattr(event, "task_type", "") or ""
+            if "workflow" in task_type.lower():
+                await self._handle_task_started(event, subagent_renderers)
+                return True
+            # Normal subagent — fall through to sub-thread path (not handled here)
+            return False
+
+        if _SdkTaskProgressMessage is not None and isinstance(event, _SdkTaskProgressMessage):
+            task_id = getattr(event, "task_id", "")
+            if task_id in self._task_states:  # Only handle if we started tracking it (workflow)
+                await self._handle_task_progress(event)
+                return True
+            return False
+
+        if _SdkTaskNotificationMessage is not None and isinstance(event, _SdkTaskNotificationMessage):
+            task_id = getattr(event, "task_id", "")
+            if task_id in self._task_states:
+                await self._handle_task_notification(event)
+                return True
+            return False
+
+        if _SdkTaskUpdatedMessage is not None and isinstance(event, _SdkTaskUpdatedMessage):
+            task_id = getattr(event, "task_id", "")
+            if task_id in self._task_states:
+                await self._handle_task_updated(event)
+                return True
+            return False
+
+        return False
+
+    # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
 
@@ -1198,6 +1270,14 @@ class DiscordRenderer:
         last_edit = 0.0
         typewriter = False                        # have we entered typewriter mode?
         saw_text = False                          # any TextBlock seen?
+        # review C1: did streaming deltas deliver text for the CURRENT
+        # assistant message? Set in the ``content_block_delta`` text handler,
+        # consulted + reset when the matching AssistantMessage content list is
+        # processed. When a provider/proxy doesn't emit deltas (non-streaming
+        # gateway / LiteLLM / some Copilot bridges), this stays False and the
+        # AssistantMessage TextBlock branch renders the text as a fallback
+        # instead of dropping it to the "(no text response)" placeholder.
+        stream_text_seen = False
         # tool_use_id -> discord.Message
         tool_msgs: dict[str, discord.Message] = {}
         tool_names: dict[str, str] = {}
@@ -1235,19 +1315,15 @@ class DiscordRenderer:
         medium_results: dict[str, tuple[str, str]] = {}
         tool_results_view: ToolResultsView | None = None
 
+        # review A1: set True when the main loop breaks on ResultMessage.
+        # Gates the post-loop ``receive_pending()`` drain so it only runs on a
+        # normally-completed turn that still has pending workflow tasks (never
+        # on the transient/fatal-error paths, which ``return``/``raise`` before
+        # reaching the drain).
         result_received = False
-        drain_deadline = 0.0
 
         try:
             async for event in bridge.send_message(user_text):
-                # AC6: drain timeout check — after ResultMessage, keep
-                # looping only while tasks are still pending and within 5s.
-                if result_received and not self._task_states:
-                    break  # all tasks finished after drain
-                if result_received and time.monotonic() > drain_deadline:
-                    log.warning("#292 drain timeout: %d tasks still pending", len(self._task_states))
-                    break
-
                 _log_stream(event, buffer_len=len(buffer))
 
                 # Tool results can arrive on UserMessage objects too — handle any
@@ -1431,34 +1507,18 @@ class DiscordRenderer:
                 # types emitted during ``effort=xhigh/max`` parallel
                 # sub-agent execution. Handlers own the entire render for
                 # these events — no ``content`` list to feed the main
-                # AssistantMessage/UserMessage branches below. The order
-                # matters: TaskUpdated must run last so a future SDK
-                # subclass overlap doesn't shadow the isinstance-matched
-                # types above it.
-                if _SdkTaskStartedMessage is not None and isinstance(event, _SdkTaskStartedMessage):
-                    task_type = getattr(event, "task_type", "") or ""
-                    if "workflow" in task_type.lower():
-                        await self._handle_task_started(event, subagent_renderers)
-                        continue
-                    # Normal subagent — fall through to sub-thread path
-
-                if _SdkTaskProgressMessage is not None and isinstance(event, _SdkTaskProgressMessage):
-                    task_id = getattr(event, "task_id", "")
-                    if task_id in self._task_states:  # Only handle if we started tracking it (workflow)
-                        await self._handle_task_progress(event)
-                        continue
-
-                if _SdkTaskNotificationMessage is not None and isinstance(event, _SdkTaskNotificationMessage):
-                    task_id = getattr(event, "task_id", "")
-                    if task_id in self._task_states:
-                        await self._handle_task_notification(event)
-                        continue
-
-                if _SdkTaskUpdatedMessage is not None and isinstance(event, _SdkTaskUpdatedMessage):
-                    task_id = getattr(event, "task_id", "")
-                    if task_id in self._task_states:
-                        await self._handle_task_updated(event)
-                        continue
+                # AssistantMessage/UserMessage branches below.
+                # review A1: dispatch is now delegated to the shared
+                # :meth:`_dispatch_task_event` helper so the identical logic
+                # can be re-run by the post-ResultMessage drain below. It
+                # returns True iff it fully handled a Task* message (workflow
+                # TaskStarted, or a Progress/Notification/Updated for a
+                # tracked task); we ``continue`` then. A non-workflow
+                # TaskStarted returns False so it falls through to the
+                # sub-thread ``parent_tool_use_id`` routing that already ran
+                # above for its content, matching pre-A1 behavior.
+                if await self._dispatch_task_event(event, subagent_renderers):
+                    continue
 
                 if isinstance(event, ResultMessage):
                     # Capture stats from the result.
@@ -1493,12 +1553,15 @@ class DiscordRenderer:
                     stats["context_percentage"] = await _fetch_context_pct_settled(
                         bridge, log_label="footer"
                     )
-                    if not self._task_states:
-                        break  # no pending tasks, exit immediately
-                    # AC6: drain trailing Task* messages for up to 5s
-                    drain_deadline = time.monotonic() + 5.0
+                    # review A1: ``receive_response()`` returns at the first
+                    # ResultMessage, so there is nothing more to iterate here —
+                    # the old ``result_received=True; continue`` path was dead
+                    # code (the ``async for`` ended anyway). Break the main loop
+                    # unconditionally; the bounded ``receive_pending()`` drain
+                    # AFTER the loop is what now finalizes any trailing workflow
+                    # Task* terminals still pending in ``_task_states``.
                     result_received = True
-                    continue  # keep looping to catch Task* after Result
+                    break
 
 
                 # -------------------------------------------------------
@@ -1516,6 +1579,13 @@ class DiscordRenderer:
                             text = delta.get("text", "")
                             if text:
                                 saw_text = True
+                                # review C1: a real streaming text delta arrived
+                                # for the CURRENT assistant message, so the
+                                # trailing AssistantMessage TextBlock replay is
+                                # a duplicate and must be skipped. This flag is
+                                # consumed + reset when we process that
+                                # AssistantMessage's content list below.
+                                stream_text_seen = True
                                 buffer += text
 
                                 now = time.time()
@@ -1636,26 +1706,28 @@ class DiscordRenderer:
                             continue
 
                         if isinstance(block, TextBlock):
-                            # Skip: with include_partial_messages=True, all text
-                            # arrives via StreamEvent first. TextBlock is a duplicate.
+                            # review C1: normally a duplicate — with
+                            # ``include_partial_messages=True`` the text already
+                            # arrived via StreamEvent ``content_block_delta``
+                            # (which set ``stream_text_seen`` + appended
+                            # ``buffer``), so skip it to avoid double-rendering.
+                            # BUT some providers/proxies (non-streaming gateway,
+                            # LiteLLM, certain Copilot bridges) never emit those
+                            # deltas — the real answer arrives ONLY here. When no
+                            # stream text was seen for this assistant message and
+                            # the block carries real text, render it as a
+                            # fallback (append to ``buffer`` + set ``saw_text``)
+                            # so the normal finalize path shows it instead of the
+                            # "(Claude returned no text response)" placeholder.
+                            # Precedent: the #183 synthetic-error branch above
+                            # handles a sibling non-streaming AssistantMessage
+                            # case. Idempotency: gating on ``not
+                            # stream_text_seen`` is what prevents the streaming
+                            # case from rendering text twice.
+                            if not stream_text_seen and block.text.strip():
+                                saw_text = True
+                                buffer += block.text
                             continue
-
-                            now = time.time()
-                            if start_time is None:
-                                start_time = now
-
-                            # Enter typewriter mode once we've been streaming long enough.
-                            if not typewriter and (now - start_time) > FAST_PATH_SECONDS:
-                                typewriter = True
-                                live_msg, buffer = await self._typewriter_tick(
-                                    live_msg, buffer
-                                )
-                                last_edit = now
-                            elif typewriter and (now - last_edit) >= EDIT_INTERVAL_SECONDS:
-                                live_msg, buffer = await self._typewriter_tick(
-                                    live_msg, buffer
-                                )
-                                last_edit = now
 
                         elif isinstance(block, ToolUseBlock):
                             # Finalize any pending typewriter message before
@@ -2446,6 +2518,16 @@ class DiscordRenderer:
                                     if preserved_desc:
                                         result_embed.description = preserved_desc
                                 await self._safe_edit(orig_msg, embed=result_embed)
+                    # review C1: reset the per-message streaming flag at the
+                    # AssistantMessage boundary. Deltas for the NEXT assistant
+                    # message arrive AFTER this event, so clearing here (not at
+                    # the top of the branch) keeps the flag scoped to exactly
+                    # one assistant message. Gated on AssistantMessage because
+                    # UserMessage shares this content-list branch (it carries
+                    # tool results) and must not clear a flag set by the
+                    # assistant text that preceded it.
+                    if isinstance(event, AssistantMessage):
+                        stream_text_seen = False
         except Exception as exc:
             if is_transient_discord_error(exc):
                 # Discord blip — bridge is fine, just couldn't render. The
@@ -2472,6 +2554,23 @@ class DiscordRenderer:
                     await self._flush(live_msg, buffer, typewriter, saw_text, tool_msgs)
                 except Exception:  # noqa: BLE001
                     log.debug("transient-recovery flush also failed; deferring", exc_info=True)
+                # review C3: the blip outlasted our retry budget, so the tail of
+                # the response (and the cost footer) may not have landed — yet
+                # render_response returns normally, so the caller marks the turn
+                # ✅. Post a best-effort notice so the user isn't left with a
+                # misleading clean checkmark. Guarded: if the blip is ongoing
+                # this send just no-ops (it has its own retry budget).
+                try:
+                    await self._safe_send(embed=discord.Embed(
+                        description=(
+                            "⚠️ A Discord connectivity blip interrupted delivery — "
+                            "part of the response above may be missing. "
+                            "Resend your message if it looks truncated."
+                        ),
+                        color=COLOR_TOOL_FAILURE,
+                    ))
+                except Exception:  # noqa: BLE001
+                    log.debug("C3 partial-delivery notice failed", exc_info=True)
                 # Don't re-raise — caller (_render_with_retry) won't stop_session.
                 return
             log.exception("Renderer fatal error; tearing down bridge")
@@ -2482,6 +2581,37 @@ class DiscordRenderer:
             if live_msg is not None:
                 await self._safe_edit(live_msg, content=buffer[:DISCORD_MAX_LEN] or "…")
             raise
+
+        # review A1: bounded post-ResultMessage drain of trailing workflow
+        # Task* terminals. ``bridge.send_message`` streams from
+        # ``client.receive_response()``, which RETURNS at the first
+        # ResultMessage — so a workflow subtask whose terminal
+        # TaskNotification/TaskUpdated arrives just AFTER the main result never
+        # gets finalized by the main loop (its ``⚡ Running`` embed would stay
+        # forever + the ``_task_states`` entry would leak into the next turn).
+        # ``receive_pending()`` opens a SECOND iterator on the SDK's shared
+        # receive stream and drains whatever landed after
+        # ``receive_response()`` stopped. We ONLY enter this when tasks are
+        # still pending, so normal turns pay zero added latency and
+        # ``receive_pending`` is never even consumed. We stop as soon as the
+        # pending set empties (fast path) and hard-cap the total wall-clock at
+        # ``DRAIN_TOTAL_SECONDS`` so a subtask that never terminates can't hang
+        # the turn. Any drain error is swallowed inside ``receive_pending``
+        # (the turn is already complete). Task embeds are their own Discord
+        # messages, so finalizing them here — before the text flush + footer
+        # below — does not disturb the assistant-text ordering.
+        if result_received and self._task_states:
+            drain_deadline = time.monotonic() + DRAIN_TOTAL_SECONDS
+            async for event in bridge.receive_pending():
+                await self._dispatch_task_event(event, subagent_renderers)
+                if not self._task_states:
+                    break
+                if time.monotonic() > drain_deadline:
+                    log.warning(
+                        "review A1: drain timeout, %d task(s) still pending",
+                        len(self._task_states),
+                    )
+                    break
 
         # Stream finished cleanly. Flush whatever is left.
         await self._flush(live_msg, buffer, typewriter, saw_text, tool_msgs)
@@ -3109,6 +3239,17 @@ class DiscordRenderer:
             # can interleave text segments with PNG follow-ups (PRD R2.2).
             await self._finalize_typewriter(live_msg, buffer)
             return
+
+        # review C2: a whitespace-only buffer is not real content. Sending it
+        # hits Discord 50006 (cannot send an empty message), which logs a
+        # spurious ERROR-level "DROPPED" line, while the "(no text response)"
+        # placeholder below stays suppressed because ``saw_text`` is True (the
+        # whitespace arrived as a text delta). Blank both so we fall through to
+        # the placeholder and give the user a clean acknowledgement instead of
+        # silence + a false content-loss error.
+        if buffer and not buffer.strip():
+            buffer = ""
+            saw_text = False
 
         # Fast-path: split text from tables before send. If buffer is empty
         # the extractor is a no-op (returns ``("", [])``).

--- a/src/clauded/project_manager.py
+++ b/src/clauded/project_manager.py
@@ -295,8 +295,16 @@ class ProjectManager:
     # ------------------------------------------------------------------
     # Extra directories
     # ------------------------------------------------------------------
-    def add_extra_dir(self, channel_id: int, path: str) -> str:
-        """Add an extra directory. Validates and stores. Returns resolved path."""
+    def add_extra_dir(
+        self, channel_id: int, path: str, *, guild_id: int | None = None
+    ) -> str:
+        """Add an extra directory. Validates and stores. Returns resolved path.
+
+        review E4: ``guild_id`` selects the confinement root the same way
+        :meth:`bind` does. When omitted the check falls back to the global
+        ``projects_root`` (preserving the pre-fix behaviour for callers that
+        don't have a guild in scope).
+        """
         with self._lock:
             self._assert_bound(channel_id)
             raw_parts = Path(path).expanduser().parts
@@ -305,11 +313,16 @@ class ProjectManager:
             resolved = Path(path).expanduser().resolve(strict=True)
             if not resolved.is_dir():
                 raise ValueError(f"Not a directory: {path}")
+            # review E4: validate against the PER-GUILD root (mirror of bind()),
+            # not the global projects_root. Otherwise a guild confined via
+            # /project set-root could /project add-dir a path outside its
+            # subtree, defeating the confinement boundary.
+            effective_root = self.get_guild_root(guild_id)
             try:
-                resolved.relative_to(self.projects_root)
+                resolved.relative_to(effective_root)
             except ValueError:
                 raise ValueError(
-                    f"Path {resolved} is outside the allowed projects root {self.projects_root}."
+                    f"Path {resolved} is outside the allowed projects root {effective_root}."
                 ) from None
             key = str(channel_id)
             entry = self._projects.get(key, {})

--- a/src/clauded/scheduler.py
+++ b/src/clauded/scheduler.py
@@ -701,21 +701,28 @@ class SchedulerManager:
         with.
         """
         sid = sched.get("schedule_id")
-        async with self._inflight_sem:
-            kind = sched.get("kind")
-            if kind == "message":
-                lock_id = sched.get("target_thread_id")
-            else:
-                lock_id = sched.get("target_channel_id")
-            if lock_id is None:
-                # Defensive — would already have failed validation in create().
-                log.warning(
-                    "#241 _fire_one missing lock id schedule=%s kind=%s",
-                    sched.get("schedule_id"), kind,
-                )
+        kind = sched.get("kind")
+        if kind == "message":
+            lock_id = sched.get("target_thread_id")
+        else:
+            lock_id = sched.get("target_channel_id")
+        if lock_id is None:
+            # Defensive — would already have failed validation in create().
+            log.warning(
+                "#241 _fire_one missing lock id schedule=%s kind=%s",
+                sched.get("schedule_id"), kind,
+            )
+            async with self._inflight_sem:
                 await self._fire_with_retry(sched)
-                return
-            async with self.get_lock(lock_id):
+            return
+        # review B3: acquire the per-target lock BEFORE the global inflight
+        # semaphore. The old order (sem → lock) let a fire blocked on a busy
+        # per-target lock keep holding a scarce sem slot, so N fires to busy
+        # threads could occupy every slot and starve a fire to an idle target
+        # (head-of-line blocking). Waiting on the lock first means a blocked
+        # fire holds NO global slot, so idle-target fires still proceed.
+        async with self.get_lock(lock_id):
+            async with self._inflight_sem:
                 # M1+M9: re-read state under the lock so a delete/toggle
                 # that landed between dispatch and lock-acquire wins.
                 if sid is not None:
@@ -771,11 +778,14 @@ class SchedulerManager:
                     await asyncio.sleep(backoffs[attempts - 1])
                     continue
         # Retries exhausted — disable with the last exception captured.
+        # review E3: notify=True so the user is told their schedule kept
+        # failing and was auto-disabled (this is the "3 crash-retries" path).
         await self._on_fire_terminal(
             sched,
             last_exc if last_exc is not None else RuntimeError(
                 "fire failed without exception"
             ),
+            notify=True,
         )
 
     # --------------------------------------------- success / terminal
@@ -837,18 +847,27 @@ class SchedulerManager:
         self._check_max_lifetime(sched)
 
     async def _on_fire_terminal(
-        self, sched: dict, exc: BaseException
+        self, sched: dict, exc: BaseException, *, notify: bool = False
     ) -> None:
         """Disable a schedule that hit an unrecoverable fire failure.
 
         Used for both terminal Discord exceptions (NotFound / Forbidden)
         and for exhausted retry budgets. The error string lands in
         ``state.last_error`` so ``/schedule list`` can surface it.
+
+        review E3: when ``notify`` is True (the retries-exhausted path) we also
+        fire the expire-notify callback so the user proactively learns their
+        schedule died — previously that was only discoverable via
+        /schedule list. The terminal Discord-error path passes notify=False:
+        the target thread/channel is gone (NotFound) or unpostable (Forbidden),
+        so a notification would be futile.
         """
         state = sched.setdefault("state", {})
         state["enabled"] = False
         state["last_error"] = f"{type(exc).__name__}: {exc}"
         self.store.save(sched)
+        if notify and self.expire_notify_callback is not None:
+            asyncio.create_task(self.expire_notify_callback(sched))
         log.warning(
             "#241 fire terminal disable schedule=%s exc=%s",
             sched.get("schedule_id"),

--- a/src/clauded/scheduler_store.py
+++ b/src/clauded/scheduler_store.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import secrets
+import threading
 from pathlib import Path
+
+from ._json_store import atomic_write_json
 
 log = logging.getLogger(__name__)
 
@@ -29,6 +31,9 @@ class SchedulerStore:
         self._dir = Path(data_dir)
         self._path = self._dir / "schedules.json"
         self._schedules: dict[str, dict] = {}
+        # review E5: shared atomic-writer lock (#252) — serialises the whole
+        # write so in-memory state can't tear between json.dump and os.replace.
+        self._lock = threading.Lock()
         self._load()
 
     # ------------------------------------------------------------------ I/O
@@ -54,13 +59,12 @@ class SchedulerStore:
             self._schedules = {}
 
     def _save(self) -> None:
-        self._dir.mkdir(parents=True, exist_ok=True)
-        tmp = self._path.with_suffix(".tmp")
-        with open(tmp, "w") as f:
-            json.dump(self._schedules, f, indent=2, default=str)
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp, self._path)
+        # review E5: delegate to the shared atomic writer (#252) instead of a
+        # fixed ``schedules.tmp``. The old fixed-tmp name reintroduced exactly
+        # the shared-tmp clobber race #252 eliminated for every other store;
+        # atomic_write_json uses a unique ``.{pid}.{hex}.tmp`` + in-process
+        # lock + fsync + os.replace + stale-tmp cleanup.
+        atomic_write_json(self._path, self._schedules, self._lock, default=str)
 
     # ---------------------------------------------------------------- CRUD
 

--- a/src/clauded/session_config.py
+++ b/src/clauded/session_config.py
@@ -38,6 +38,7 @@ class SessionConfig:
     on_post_tool_use: Any = None  # callback
     on_stop: Any = None  # callback
     on_subagent_stop: Any = None  # callback: fired when a subagent stops
+    on_subagent_start: Any = None  # callback: fired when a subagent starts (#310 R2: per-subagent pending tracking)
 
 
 __all__ = ["SessionConfig"]

--- a/src/clauded/session_manager.py
+++ b/src/clauded/session_manager.py
@@ -81,14 +81,18 @@ class SessionManager:
         if bridge is None:
             return False
         await bridge.stop()
-        # Reap the lock entry if no one is currently waiting on it.
-        # Without this the dict grows unbounded over the bot's lifetime,
-        # one entry per thread we've ever served. Holding the lock means
-        # there's an in-flight render — leave the entry alone in that case
-        # and let the next stop_session sweep it up.
-        lock = self._locks.get(thread_id)
-        if lock is not None and not lock.locked():
-            self._locks.pop(thread_id, None)
+        # Reap idle lock entries so the dict doesn't grow unbounded over the
+        # bot's lifetime. review E6: sweep ALL currently-unlocked entries, not
+        # just this thread_id — ``get_lock`` is also called for scheduler
+        # lock_ids that never open a session and so never reach this reaper via
+        # their own thread_id (the original leak). A held lock (``locked()``)
+        # means an in-flight render, so we leave it; the next sweep collects it.
+        # Safe because callers acquire atomically — ``async with
+        # get_lock(tid):`` has no await between create and acquire (asyncio
+        # Lock's uncontended acquire is synchronous), so an unlocked entry has
+        # no paused acquirer that could be stranded on a stale lock object.
+        for tid in [t for t, lk in self._locks.items() if not lk.locked()]:
+            self._locks.pop(tid, None)
         log.info("Stopped session thread=%s", thread_id)
         return True
 

--- a/tests/test_api_error_render.py
+++ b/tests/test_api_error_render.py
@@ -92,16 +92,20 @@ async def test_api_error_overrides_no_text_placeholder():
 
 
 @pytest.mark.asyncio
-async def test_normal_textblock_still_skipped_when_error_is_none():
-    """Pin: legitimate streamed-text duplication still skips TextBlock
-    when error is None. Without this guard the API-error fix could
-    accidentally start rendering all assistant TextBlocks twice (once
-    via streaming, once via the AssistantMessage replay)."""
-    # Two TextBlocks on a normal AssistantMessage (error=None).
-    # The renderer's TextBlock branch skips them entirely; with no
-    # tools and no streaming text, saw_text stays False, so the
-    # placeholder DOES fire — proves the API-error early-out only
-    # activates when error is not None.
+async def test_normal_textblock_no_error_renders_via_c1_fallback():
+    """error=None non-streamed TextBlock renders its text (review C1),
+    and NO ``❌ Provider error`` embed fires (the #183 early-out is gated
+    on ``error is not None``).
+
+    Behavior change (review C1): before C1 this exact scenario (error=None,
+    a TextBlock, and NO StreamEvent deltas) dropped to the
+    "(Claude returned no text response)" placeholder — the real answer was
+    lost for non-streaming providers/proxies. Now the TextBlock branch is a
+    fallback: with no stream text seen for the message, the block text is
+    rendered normally. This test still pins the #183 invariant that the
+    red provider-error embed only appears when ``error`` is set — it never
+    fires for a legitimate ``error=None`` message.
+    """
     events = [
         AssistantMessage(
             content=[TextBlock(text="Normal model output")],
@@ -119,22 +123,28 @@ async def test_normal_textblock_still_skipped_when_error_is_none():
     renderer = DiscordRenderer(target)
     await renderer.render_response(FakeBridge(events), "hello")
 
-    # No red error embed
+    # No red error embed — the #183 early-out stays gated on error != None.
     error_embeds = [
         m for m in target._sent
         if m.embeds and (m.embeds[0].title or "").startswith("❌ Provider error")
     ]
     assert not error_embeds, "Should NOT render error embed when error is None"
-    # Placeholder DOES fire (because TextBlock is skipped as a streaming
-    # duplicate and no real stream event came through in this test)
+    # review C1: the placeholder must NOT fire — the real text is rendered.
     placeholder_msgs = [
         m for m in target._sent
         if "no text response" in (m.content or "")
     ]
-    assert placeholder_msgs, (
-        "Without streamed text, the placeholder MUST still fire for "
-        "non-error AssistantMessages (existing behavior pin)"
+    assert not placeholder_msgs, (
+        "review C1: non-streamed TextBlock text must render, not fall through "
+        "to the '(no text response)' placeholder"
     )
+    # The actual answer reached Discord.
+    text_msgs = [m for m in target._sent if "Normal model output" in (m.content or "")]
+    assert text_msgs, (
+        f"Expected 'Normal model output' to reach Discord; "
+        f"got contents: {[m.content[:60] for m in target._sent if m.content]}"
+    )
+
 
 
 @pytest.mark.asyncio

--- a/tests/test_cleanup_deadlock.py
+++ b/tests/test_cleanup_deadlock.py
@@ -110,6 +110,14 @@ async def test_cleanup_concurrent_one_stuck_two_healthy(
 
     bot.session_manager.list_sessions = MagicMock(return_value=sessions)
     bot.session_manager.save_session_state = MagicMock()
+    # review B2: _cleanup_task now checks ``get_lock(tid).locked()`` and holds
+    # the lock across the stop (so it never disconnects a bridge mid-turn).
+    # Model it with real, unlocked asyncio.Locks so these idle sessions are
+    # eligible for reaping (a bare MagicMock's .locked() is truthy → skipped).
+    _locks: dict[int, asyncio.Lock] = {}
+    bot.session_manager.get_lock = MagicMock(
+        side_effect=lambda tid: _locks.setdefault(tid, asyncio.Lock())
+    )
 
     stopped: list[int] = []
 

--- a/tests/test_review_subagent_notify.py
+++ b/tests/test_review_subagent_notify.py
@@ -1,0 +1,339 @@
+"""review A3/A4/A5/A6 — subagent-completion notification chain (bot.py).
+
+Pins the fixed behavior of the per-subagent pending tracking + the
+transcript-result surfacing, at the callback level (the same layer the
+SubagentStart / SubagentStop hooks in claude_bridge.py invoke).
+
+Bugs these tests lock down:
+  A4/A5: pending tracking used to key a session→thread map with ONE entry
+         per session, so `_warn_pending_subagents` false-warned "1 subagent
+         still running" on EVERY normal turn, and the map got del'd after
+         the FIRST subagent stopped (destroying the count + routing for
+         later parallel subagents). Now keyed per agent_id in
+         `_pending_subagents[thread_id]`.
+  A3/A6: `_on_subagent_stop` used to read stop_reason / summary /
+         duration_ms — none of which SubagentStopHookInput provides — so
+         the embed was always the contentless "Subagent finished." Now it
+         reads agent_id / agent_type / agent_transcript_path and surfaces
+         the subagent's real final assistant text.
+
+We bind the real (unbound) ClaudedBot methods onto a lightweight fake so
+we exercise the production code paths without the full constructor cost
+(mirrors tests/test_bot_fire_callbacks.py's approach).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from clauded.bot import ClaudedBot
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeMsg:
+    content: str = ""
+    embeds: list = field(default_factory=list)
+
+
+class _FakeChannel:
+    """Minimal discord channel/thread that records every send()."""
+
+    def __init__(self, cid: int) -> None:
+        self.id = cid
+        self.sent: list[_FakeMsg] = []
+
+    async def send(self, content=None, **kwargs):
+        msg = _FakeMsg(content=content or "")
+        if "embed" in kwargs and kwargs["embed"] is not None:
+            msg.embeds = [kwargs["embed"]]
+        self.sent.append(msg)
+        return msg
+
+
+class _FakeBot:
+    """Binds the real subagent methods from ClaudedBot onto a bare object.
+
+    Provides just the collaborators those methods touch: ``_pending_subagents``
+    and ``get_channel`` (so ``safe_send_message`` routes to a recorder). The
+    methods under test are otherwise self-contained.
+    """
+
+    def __init__(self) -> None:
+        self._pending_subagents: dict[int, dict[str, str]] = {}
+        self._channels: dict[int, _FakeChannel] = {}
+
+    def get_channel(self, cid: int):
+        return self._channels.get(cid)
+
+    async def fetch_channel(self, cid: int):  # pragma: no cover - not hit in tests
+        return self._channels.get(cid)
+
+    def channel_for(self, cid: int) -> _FakeChannel:
+        ch = self._channels.get(cid)
+        if ch is None:
+            ch = _FakeChannel(cid)
+            self._channels[cid] = ch
+        return ch
+
+    # Bind the real implementations.
+    _make_subagent_start_cb = ClaudedBot._make_subagent_start_cb
+    _make_subagent_stop_cb = ClaudedBot._make_subagent_stop_cb
+    _warn_pending_subagents = ClaudedBot._warn_pending_subagents
+    # Already a plain function on the class (it's a @staticmethod), so
+    # referencing it here rebinds it as a staticmethod on _FakeBot too.
+    _read_subagent_result = staticmethod(ClaudedBot._read_subagent_result)
+
+
+def _all_embeds(ch: _FakeChannel) -> list:
+    return [e for m in ch.sent for e in m.embeds]
+
+
+# ---------------------------------------------------------------------------
+# A4/A5 — pending tracking + no false warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_normal_turn_no_subagents_warns_nothing():
+    """review A4/A5: a normal turn (no SubagentStart fired) → pending count
+    is 0 → `_warn_pending_subagents` sends NOTHING. This was the guaranteed
+    false positive in the old code (stale session→thread entry counted as 1)."""
+    bot = _FakeBot()
+    thread_id = 111
+    ch = bot.channel_for(thread_id)
+
+    await bot._warn_pending_subagents(thread_id)
+
+    assert _all_embeds(ch) == [], "expected no warning embed on a no-subagent turn"
+
+
+@pytest.mark.asyncio
+async def test_two_parallel_starts_then_stops_decrement_count():
+    """review A4/A5: two SubagentStart (parallel) → pending == 2. One
+    SubagentStop → 1. Second SubagentStop → 0. The first stop must NOT wipe
+    the whole map (the old `del _subagent_threads[session_id]` bug)."""
+    bot = _FakeBot()
+    thread_id = 222
+    bot.channel_for(thread_id)
+
+    start_cb = bot._make_subagent_start_cb(thread_id)
+    stop_cb = bot._make_subagent_stop_cb(thread_id)
+
+    await start_cb({"agent_id": "a1", "agent_type": "general-purpose"})
+    await start_cb({"agent_id": "a2", "agent_type": "Explore"})
+    assert len(bot._pending_subagents[thread_id]) == 2
+
+    # First stop removes only a1.
+    await stop_cb({"agent_id": "a1", "agent_type": "general-purpose"})
+    assert len(bot._pending_subagents.get(thread_id, {})) == 1
+    assert "a2" in bot._pending_subagents[thread_id]
+
+    # Second stop removes a2 → bucket empties (and is pruned).
+    await stop_cb({"agent_id": "a2", "agent_type": "Explore"})
+    assert bot._pending_subagents.get(thread_id, {}) == {}
+
+
+@pytest.mark.asyncio
+async def test_warn_after_one_of_two_stops_reports_one():
+    """review A4/A5: with one of two subagents still pending, the warning
+    fires and reports exactly 1 (real count, not the old constant 1/0)."""
+    bot = _FakeBot()
+    thread_id = 333
+    ch = bot.channel_for(thread_id)
+
+    start_cb = bot._make_subagent_start_cb(thread_id)
+    stop_cb = bot._make_subagent_stop_cb(thread_id)
+    await start_cb({"agent_id": "a1", "agent_type": "t"})
+    await start_cb({"agent_id": "a2", "agent_type": "t"})
+    ch.sent.clear()  # drop the stop embed noise below
+
+    await stop_cb({"agent_id": "a1", "agent_type": "t"})
+    ch.sent.clear()  # only look at the warning, not the completion embed
+
+    await bot._warn_pending_subagents(thread_id)
+    embeds = _all_embeds(ch)
+    assert len(embeds) == 1
+    assert "1 subagent" in (embeds[0].description or "")
+
+
+@pytest.mark.asyncio
+async def test_start_without_agent_id_is_ignored():
+    """Defensive: a SubagentStart missing agent_id must not create a bogus
+    None-keyed pending entry (which would false-warn forever)."""
+    bot = _FakeBot()
+    thread_id = 444
+    start_cb = bot._make_subagent_start_cb(thread_id)
+    await start_cb({"agent_type": "t"})  # no agent_id
+    assert bot._pending_subagents.get(thread_id, {}) == {}
+
+
+@pytest.mark.asyncio
+async def test_stop_without_prior_start_does_not_crash():
+    """Graceful degradation: if SubagentStart never fired (CLI variance),
+    SubagentStop still routes a notification and raises nothing."""
+    bot = _FakeBot()
+    thread_id = 555
+    ch = bot.channel_for(thread_id)
+    stop_cb = bot._make_subagent_stop_cb(thread_id)
+
+    # No KeyError even though _pending_subagents has no bucket for this thread.
+    await stop_cb({"agent_id": "z9", "agent_type": "loner"})
+    embeds = _all_embeds(ch)
+    assert len(embeds) == 1
+    assert "loner" in (embeds[0].title or "")
+
+
+# ---------------------------------------------------------------------------
+# A3/A6 — surface the real transcript result (no stop_reason/summary reads)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_surfaces_transcript_result(tmp_path):
+    """review A6: a real agent_transcript_path JSONL with a final assistant
+    message → the embed description contains that result text (NOT the old
+    contentless 'Subagent finished.')."""
+    transcript = tmp_path / "agent.jsonl"
+    lines = [
+        {"type": "user", "message": {"content": "do the thing"}},
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "thinking", "thinking": "hmm"},
+                    {"type": "text", "text": "Intermediate step done."},
+                ]
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "FINAL RESULT: 42 files patched."},
+                ]
+            },
+        },
+    ]
+    transcript.write_text("\n".join(json.dumps(o) for o in lines), encoding="utf-8")
+
+    bot = _FakeBot()
+    thread_id = 666
+    ch = bot.channel_for(thread_id)
+    stop_cb = bot._make_subagent_stop_cb(thread_id)
+
+    await stop_cb(
+        {
+            "agent_id": "a1",
+            "agent_type": "general-purpose",
+            "agent_transcript_path": str(transcript),
+        }
+    )
+
+    embeds = _all_embeds(ch)
+    assert len(embeds) == 1
+    embed = embeds[0]
+    # A6: the LAST assistant text is surfaced, not an earlier one.
+    assert "FINAL RESULT: 42 files patched." in (embed.description or "")
+    assert "Intermediate step done." not in (embed.description or "")
+    # A3: title carries the agent_type.
+    assert "general-purpose" in (embed.title or "")
+
+
+@pytest.mark.asyncio
+async def test_stop_missing_transcript_falls_back_gracefully(tmp_path):
+    """review A6: a missing/unreadable agent_transcript_path must NOT crash
+    and must fall back to a concise completed message naming the agent_type."""
+    bot = _FakeBot()
+    thread_id = 777
+    ch = bot.channel_for(thread_id)
+    stop_cb = bot._make_subagent_stop_cb(thread_id)
+
+    missing = tmp_path / "does_not_exist.jsonl"
+    await stop_cb(
+        {
+            "agent_id": "a1",
+            "agent_type": "code-reviewer",
+            "agent_transcript_path": str(missing),
+        }
+    )
+
+    embeds = _all_embeds(ch)
+    assert len(embeds) == 1
+    desc = embeds[0].description or ""
+    assert "code-reviewer" in desc
+    assert "completed" in desc.lower()
+
+
+@pytest.mark.asyncio
+async def test_stop_with_no_transcript_path_key():
+    """review A6: agent_transcript_path entirely absent → fallback, no crash."""
+    bot = _FakeBot()
+    thread_id = 888
+    ch = bot.channel_for(thread_id)
+    stop_cb = bot._make_subagent_stop_cb(thread_id)
+
+    await stop_cb({"agent_id": "a1", "agent_type": "Plan"})
+    embeds = _all_embeds(ch)
+    assert len(embeds) == 1
+    assert "Plan" in (embeds[0].title or "")
+
+
+def test_read_subagent_result_truncates_to_800(tmp_path):
+    """review A6: an over-long final result is truncated to ~800 chars so a
+    verbose subagent can't blow the Discord embed limit."""
+    transcript = tmp_path / "big.jsonl"
+    big = "X" * 5000
+    transcript.write_text(
+        json.dumps(
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": big}]}}
+        ),
+        encoding="utf-8",
+    )
+    out = ClaudedBot._read_subagent_result(str(transcript))
+    assert len(out) == 800
+    assert set(out) == {"X"}
+
+
+def test_read_subagent_result_none_and_missing():
+    """review A6: None path and a nonexistent file both return '' (no raise)."""
+    assert ClaudedBot._read_subagent_result(None) == ""
+    assert ClaudedBot._read_subagent_result("/no/such/file/here.jsonl") == ""
+
+
+def test_read_subagent_result_accepts_string_content(tmp_path):
+    """review A6: some transcript rows carry content as a plain string, not a
+    list of blocks — handle both shapes."""
+    transcript = tmp_path / "strcontent.jsonl"
+    transcript.write_text(
+        json.dumps({"type": "assistant", "message": {"content": "plain answer"}}),
+        encoding="utf-8",
+    )
+    assert ClaudedBot._read_subagent_result(str(transcript)) == "plain answer"
+
+
+def test_read_subagent_result_malformed_lines_dont_crash(tmp_path):
+    """review A6: partial/garbage JSONL lines (e.g. a truncated tail slice)
+    are skipped; a valid final assistant line still wins."""
+    transcript = tmp_path / "mixed.jsonl"
+    content = "\n".join(
+        [
+            "{not valid json at all",
+            "",
+            json.dumps({"type": "system", "foo": "bar"}),
+            json.dumps(
+                {"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}}
+            ),
+            "}{ trailing garbage",
+        ]
+    )
+    transcript.write_text(content, encoding="utf-8")
+    assert ClaudedBot._read_subagent_result(str(transcript)) == "ok"

--- a/tests/test_subagent_threads.py
+++ b/tests/test_subagent_threads.py
@@ -898,3 +898,112 @@ async def test_subagent_footer_renders_from_user_message_tool_use_result():
     assert "850" in desc
     # 1.2k output tokens (1200 humanized)
     assert "1.2k" in desc
+
+
+# ---------------------------------------------------------------------------
+# review A3/A4/A5/A6 — bot-side subagent-completion notification chain.
+#
+# These pin the fix that REPLACED the old #310 ``_subagent_threads`` map
+# (session_id → thread_id) with per-agent_id ``_pending_subagents``
+# (thread_id → {agent_id: agent_type}). The old map (a) always held exactly
+# one entry per session — so `_warn_pending_subagents` false-warned on every
+# normal turn — and (b) was del'd after the FIRST subagent stopped, wiping
+# routing + the count for later parallel subagents.
+#
+# The exhaustive callback-level coverage lives in
+# tests/test_review_subagent_notify.py; here we pin the single most important
+# regression invariant (routing/count survives the first stop) inside the
+# canonical subagent test file.
+# ---------------------------------------------------------------------------
+
+
+class _NotifyChannel:
+    def __init__(self, cid: int) -> None:
+        self.id = cid
+        self.embeds: list = []
+
+    async def send(self, content=None, **kwargs):
+        if kwargs.get("embed") is not None:
+            self.embeds.append(kwargs["embed"])
+        return FakeMessage(id=len(self.embeds))
+
+
+class _NotifyBot:
+    """Binds the real subagent notification methods off ClaudedBot."""
+
+    def __init__(self) -> None:
+        from clauded.bot import ClaudedBot as _CB
+
+        self._pending_subagents: dict[int, dict[str, str]] = {}
+        self._chan: dict[int, _NotifyChannel] = {}
+        self._make_subagent_start_cb = _CB._make_subagent_start_cb.__get__(self)
+        self._make_subagent_stop_cb = _CB._make_subagent_stop_cb.__get__(self)
+        self._warn_pending_subagents = _CB._warn_pending_subagents.__get__(self)
+        # _read_subagent_result is a @staticmethod — bind it as a plain
+        # callable attribute so ``self._read_subagent_result(...)`` works.
+        self._read_subagent_result = _CB._read_subagent_result
+
+    def get_channel(self, cid: int):
+        return self._chan.setdefault(cid, _NotifyChannel(cid))
+
+    async def fetch_channel(self, cid: int):
+        return self.get_channel(cid)
+
+
+@pytest.mark.asyncio
+async def test_subagent_routing_survives_first_stop():
+    """review A4/A5 regression: after the FIRST of two parallel subagents
+    stops, the second is STILL tracked (old code del'd the whole map) and a
+    second completion notification still routes to the same thread."""
+    bot = _NotifyBot()
+    thread_id = 4242
+    ch = bot.get_channel(thread_id)
+
+    start = bot._make_subagent_start_cb(thread_id)
+    stop = bot._make_subagent_stop_cb(thread_id)
+
+    await start({"agent_id": "s1", "agent_type": "general-purpose"})
+    await start({"agent_id": "s2", "agent_type": "Explore"})
+    assert len(bot._pending_subagents[thread_id]) == 2
+
+    await stop({"agent_id": "s1", "agent_type": "general-purpose"})
+    # Routing/count for s2 is intact — this is the core of the old bug.
+    assert list(bot._pending_subagents[thread_id]) == ["s2"]
+    # And a warning at this point reports exactly the 1 remaining subagent.
+    await bot._warn_pending_subagents(thread_id)
+    warn_embeds = [e for e in ch.embeds if "still running" in (e.description or "")]
+    assert len(warn_embeds) == 1
+    assert "1 subagent" in (warn_embeds[0].description or "")
+
+    # Second stop drains to empty; its completion embed still reached the thread.
+    n_before = len(ch.embeds)
+    await stop({"agent_id": "s2", "agent_type": "Explore"})
+    assert bot._pending_subagents.get(thread_id, {}) == {}
+    assert len(ch.embeds) == n_before + 1  # the s2 completion embed
+
+
+@pytest.mark.asyncio
+async def test_subagent_stop_no_attributeerror_from_removed_fields():
+    """review A3: the SubagentStop callback must not touch stop_reason /
+    summary / duration_ms (SubagentStopHookInput has none). Feed a payload
+    with ONLY the real fields and assert no AttributeError/KeyError and a
+    single embed lands."""
+    bot = _NotifyBot()
+    thread_id = 4343
+    ch = bot.get_channel(thread_id)
+    stop = bot._make_subagent_stop_cb(thread_id)
+
+    # Real SubagentStopHookInput shape — no stop_reason/summary/duration_ms.
+    await stop(
+        {
+            "hook_event_name": "SubagentStop",
+            "stop_hook_active": False,
+            "agent_id": "only",
+            "agent_type": "code-reviewer",
+            "agent_transcript_path": "/nonexistent/path.jsonl",
+            "session_id": "sess-x",
+        }
+    )
+    assert len(ch.embeds) == 1
+    assert "code-reviewer" in (ch.embeds[0].title or "")
+


### PR DESCRIPTION
## Summary

A comprehensive multi-agent review of this Discord⇄Claude bridge, focused on the **SDK message-turn lifecycle** and **subagent / background / subtask** handling (whether Claude turns run correctly and actually reach Discord), plus a multi-angle hardening sweep. This PR fixes every confirmed finding.

## 🔴 Core: turn lifecycle & subagent notification

- **A1 — dead drain loop.** `send_message` streams from `client.receive_response()`, which the SDK terminates at the **first `ResultMessage`**. The post-result "drain" loop for trailing workflow `Task*` terminals lived *inside* that same `async for`, so it was **structurally unreachable** — background/workflow subtask terminals never rendered (embeds stuck on "Running") and `_task_states` leaked into the next turn. Fix: new `ClaudeBridge.receive_pending()` (bounded drain of the shared SDK stream via a second iterator) + a shared `_dispatch_task_event` helper, run **after** the main loop and only when tasks are pending (zero added latency on normal turns).
- **C1 — non-streaming text dropped.** The `TextBlock` branch unconditionally skipped, assuming `include_partial_messages` deltas always arrive. On non-streaming providers/proxies the real answer arrived only in the `AssistantMessage` and was discarded as `(Claude returned no text response)`. Fix: idempotent fallback via a `stream_text_seen` flag.
- **A3–A6 — subagent notification chain.** The completion callback read `stop_reason`/`summary`/`duration_ms` — fields `SubagentStopHookInput` **doesn't provide** (it carries `agent_id` / `agent_type` / `agent_transcript_path`), so the embed was always a contentless "Subagent finished." and `_subagent_threads` (keyed by the **main** session_id, deleted after the first subagent) broke routing and made `_warn_pending_subagents` **false-warn "N subagent(s) still running" on every normal turn**. Fix: wire a `SubagentStart` hook, track pending per `agent_id`, surface the real result to Discord by reading the transcript tail, and count real pending subagents. (Re-injecting results back into Claude's conversation remains deferred — it was reverted in #310 and needs separate design.)

## Concurrency

- **B1** — hold the per-thread lock across `/schedule message`, `/schedule new_task`, and the **Send to Claude** context menu render (they raced user turns on one `ClaudeSDKClient`).
- **B2** — idle cleanup no longer disconnects a bridge mid-turn (skips when the lock is held / holds it across the stop).
- **B3** — the scheduler acquires the per-target lock **before** the global inflight semaphore, fixing head-of-line blocking that could starve fires to idle targets.

## Delivery & session

- **C2** — whitespace-only turns show a clean placeholder instead of a spurious Discord `50006` "DROPPED" error.
- **C3** — best-effort partial-delivery notice on transient-exhaustion (so a `✅` isn't the only, misleading signal).
- **D1** — persist `session_id` for `/schedule` and context-menu turns (were unresumable after a restart).
- **D2** — capture `session_id` from the earliest message, not only the terminal `ResultMessage`.

## Hardening

| | Fix |
|---|---|
| **E1** | `/log dump` now redacts `extra_dirs` (the never-used `add_dirs` key leaked absolute paths + username) |
| **E2** | `/budget set` guards unbound channels (was an uncaught `ValueError` → "application did not respond") |
| **E3** | notify the user when a schedule is auto-disabled after crash-retries (was only in `/schedule list`) |
| **E4** | `/project add-dir` validates against the per-guild root like `bind()` (confinement consistency) |
| **E5** | `scheduler_store` uses the shared `atomic_write_json` (unique tmp, no clobber race) |
| **E6** | reap idle per-thread locks (scheduler lock-ids no longer leak unboundedly) |
| **E7** | correct the diagnostics bundle bot-flags attribute names (unbound-fallback state was silently omitted) |

## Deliberately skipped

- **A1 flush/drain reorder** — the current order is functionally correct (task embeds are separate messages); moving the drain past the footer risks the footer's `_last_msg` attachment logic in a 4000-line hot path. Not worth the regression surface for a rare cosmetic edge.

## Testing

- **494 curated regression tests pass** across every touched area (bridge, renderer, subagent, scheduler, session, project, diagnostics, cogs). Full `pytest tests/` was avoided during development due to memory pressure on the host; the curated set covers all changed code paths. `compileall` clean.
- Updated `test_cleanup_deadlock.py` (B2: model `get_lock` with real locks) and extended `test_subagent_threads.py`; added `test_review_subagent_notify.py`.

## Notes

- The running bot must be **restarted** to pick up these changes (no file-watch reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
