### PR TITLE
fix(resume): silent-resume-failure detection + crash/exit diagnosability

### DIFF
--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -6,6 +6,12 @@ RESTART_COUNTER="$HOME/Library/Caches/clauded/restart-count"
 ALERTS_LOG="$HOME/Library/Logs/clauded/alerts.log"
 HEALTHCHECK_LOG="$HOME/Library/Logs/clauded/healthcheck.log"
 STALE_THRESHOLD_SECS=120
+# T2-D: longer grace window while a turn is in flight. The bot writes the
+# in-flight-turn count as the heartbeat file CONTENT; a transient event-loop
+# stall UNDER a turn (memory-pressure thrash) then gets this bigger budget
+# instead of a hard kickstart -k that would drop the not-yet-persisted
+# session_id and force a cold resume next message (the T2 resume bug).
+ACTIVE_TURN_THRESHOLD_SECS=300
 
 mkdir -p "$(dirname "$HEARTBEAT")" "$(dirname "$ALERTS_LOG")"
 
@@ -45,14 +51,25 @@ fi
 # Stale heartbeat check
 if [ ! -f "$HEARTBEAT" ]; then
     AGE=99999
+    ACTIVE_TURNS=0
 else
     HEARTBEAT_MTIME=$(stat -f %m "$HEARTBEAT")
     AGE=$((NOW - HEARTBEAT_MTIME))
+    # T2-D: heartbeat CONTENT is the in-flight-turn count (integer). Empty or
+    # legacy (mtime-only) files parse to 0, preserving the original 120s path.
+    ACTIVE_TURNS=$(tr -dc '0-9' < "$HEARTBEAT" 2>/dev/null)
+    [ -z "$ACTIVE_TURNS" ] && ACTIVE_TURNS=0
 fi
 
-if [ "$AGE" -gt "$STALE_THRESHOLD_SECS" ]; then
-    log_line "heartbeat stale ($AGE s); kickstarting com.hxy.clauded"
-    echo "$(date '+%F %T') heartbeat stale ($AGE s); kickstarting com.hxy.clauded" >> "$ALERTS_LOG"
+# T2-D: pick the grace window based on whether a turn is actively rendering.
+THRESHOLD=$STALE_THRESHOLD_SECS
+if [ "$ACTIVE_TURNS" -gt 0 ]; then
+    THRESHOLD=$ACTIVE_TURN_THRESHOLD_SECS
+fi
+
+if [ "$AGE" -gt "$THRESHOLD" ]; then
+    log_line "heartbeat stale (${AGE}s > ${THRESHOLD}s, active_turns=${ACTIVE_TURNS}); kickstarting com.hxy.clauded"
+    echo "$(date '+%F %T') heartbeat stale (${AGE}s, active_turns=${ACTIVE_TURNS}); kickstarting com.hxy.clauded" >> "$ALERTS_LOG"
     launchctl kickstart -k "gui/$(id -u)/com.hxy.clauded" 2>/dev/null || true
 
     # Track restart count in rolling 5-min window via /tmp file (per-day rotating)
@@ -74,5 +91,5 @@ if [ "$AGE" -gt "$STALE_THRESHOLD_SECS" ]; then
 else
     # Healthy run — emit a log line so operators can confirm the
     # healthcheck IS firing (was zero-output before #168).
-    log_line "ok — heartbeat age ${AGE}s (threshold ${STALE_THRESHOLD_SECS}s)"
+    log_line "ok — heartbeat age ${AGE}s (threshold ${THRESHOLD}s, active_turns=${ACTIVE_TURNS})"
 fi

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -220,6 +220,29 @@ def _touch_heartbeat() -> None:
         )
 
 
+def _write_heartbeat_state(active_turns: int) -> None:
+    """Write the in-flight-turn count to the heartbeat file (also refreshes mtime).
+
+    T2-D: the external watchdog reads this value to grant a longer grace window
+    while a turn is active, so a transient event-loop stall UNDER a turn (e.g.
+    memory-pressure thrash) doesn't hard-kill the bot mid-turn — which would
+    drop the session_id before it persisted and force a cold resume on the next
+    message (the T2 resume bug). Darwin-only; ``OSError`` swallowed like
+    :func:`_touch_heartbeat`. Content is a plain integer so the shell watchdog
+    can parse it; writing also refreshes mtime, preserving the legacy
+    liveness-by-mtime check.
+    """
+    if sys.platform != "darwin":
+        return
+    try:
+        _HEARTBEAT_PATH.write_text(str(int(active_turns)))
+    except OSError as exc:
+        log.warning(
+            "_write_heartbeat_state failed; LaunchAgent health may be misled: %s",
+            exc,
+        )
+
+
 def _cleanup_tmp_dir(tmp_dir: Path | None) -> None:
     """Best-effort cleanup of an attachment temp directory.
 
@@ -364,6 +387,10 @@ class ClaudedBot(commands.Bot):
         # warning at all (graceful degradation; still strictly better than
         # the old guaranteed false positive).
         self._pending_subagents: dict[int, dict[str, str]] = {}
+        # T2-D: number of turns currently rendering. Written into the heartbeat
+        # file so the external watchdog grants a longer grace window while a
+        # turn is in flight (see _write_heartbeat_state + health-check.sh).
+        self._active_turns: int = 0
 
         # ---------------------------------------------------------------- #241
         # Scheduler core (PRD v1.18 §3.7 / §8 Subtask 4): persistent timer
@@ -669,8 +696,11 @@ class ClaudedBot(commands.Bot):
         start so the healthcheck has a fresh file even before Discord login
         completes (otherwise a bad token → ``wait_until_ready`` hangs → stale
         heartbeat → kickstart loop bounded only by ``ThrottleInterval``).
+
+        T2-D: writes the in-flight-turn count as the file content so the
+        watchdog can be lenient while a turn is active.
         """
-        _touch_heartbeat()
+        _write_heartbeat_state(self._active_turns)
 
     async def on_ready(self) -> None:  # type: ignore[override]
         user = self.user
@@ -1347,6 +1377,34 @@ class ClaudedBot(commands.Bot):
             self.session_manager.save_session_state(thread_id)
         bridge._on_session_id_cb = _on_sid
 
+        # T2-B: surface a silent resume failure. When we asked the CLI to
+        # resume a stored session but it started a fresh one instead (session
+        # GC'd / cwd mismatch / prior turn killed mid-flight before it could
+        # finish), the user's context is gone. Post a subtle one-line notice so
+        # "it opened a new session and I don't know why" becomes explicit. The
+        # bridge fires this callback synchronously from inside the (async) send
+        # loop, so schedule the Discord send as a task.
+        def _on_resume_failed(requested_id: str, actual_id: str) -> None:
+            async def _notify() -> None:
+                try:
+                    channel = self.get_channel(thread_id) or await self.fetch_channel(thread_id)
+                    if channel is not None:
+                        await safe_send_message(
+                            channel,
+                            content=(
+                                "-# ⚠️ Couldn't resume the previous conversation — "
+                                "started a fresh session (the prior one may have ended "
+                                "abnormally or been cleaned up)."
+                            ),
+                        )
+                except Exception:
+                    log.debug("T2-B: resume-failed notice send failed", exc_info=True)
+            try:
+                asyncio.get_running_loop().create_task(_notify())
+            except RuntimeError:
+                log.debug("T2-B: no running loop for resume-failed notice", exc_info=True)
+        bridge._on_resume_failed_cb = _on_resume_failed
+
     @staticmethod
     def _read_subagent_result(agent_transcript_path: str | None) -> str:
         """review A6: best-effort extract the subagent's final result text.
@@ -1648,7 +1706,14 @@ class ClaudedBot(commands.Bot):
                 ),
                 guild_id=getattr(getattr(thread, "guild", None), "id", None),
             )
-            await renderer.render_response(bridge, user_text, author_id=author_id)
+            # T2-D: mark a turn in-flight so the heartbeat tells the watchdog
+            # to be lenient (a stall UNDER a turn shouldn't hard-kill the bot
+            # and drop the not-yet-persisted session_id).
+            self._active_turns += 1
+            try:
+                await renderer.render_response(bridge, user_text, author_id=author_id)
+            finally:
+                self._active_turns = max(0, self._active_turns - 1)
         except Exception as exc:
             if is_transient_discord_error(exc):
                 # Render gave up (rare — _retry_http exhausted), but bridge is
@@ -1921,7 +1986,12 @@ class ClaudedBot(commands.Bot):
         bundle dispatch happens regardless.
         """
         try:
-            await renderer.render_response(bridge, what)
+            # T2-D: scheduled fires are turns too — count them in-flight.
+            self._active_turns += 1
+            try:
+                await renderer.render_response(bridge, what)
+            finally:
+                self._active_turns = max(0, self._active_turns - 1)
         except Exception as exc:
             if is_transient_discord_error(exc):
                 # _retry_http exhausted at the lower layer; let the
@@ -2350,9 +2420,40 @@ def main() -> None:
     _ensure_runtime_dirs()
     _touch_heartbeat()
     _configure_logging()
+
+    # T2-A: make restart/crash causes DIAGNOSABLE. Investigation found the bot
+    # restarts far too often (crash-loops throttled to launchd's 30s
+    # ThrottleInterval), and the cause was invisible: StandardErrorPath is unset
+    # (#168) and only INFO+ logging reaches clauded.log. We now capture:
+    #   - uncaught Python exceptions (excepthook → clauded.log CRITICAL)
+    #   - C-level faults / segfaults (faulthandler → its own file that survives)
+    # plus a boot marker (pid) and a "main() exiting" marker below, so a
+    # *graceful* shutdown (SIGTERM from a watchdog kickstart, which unwinds
+    # cleanly) is distinguishable from a hard crash / OOM-kill (SIGKILL, which
+    # leaves NEITHER marker — the tell-tale of an out-of-memory death).
+    import faulthandler
+
+    def _log_uncaught(exc_type, exc_value, exc_tb):
+        if issubclass(exc_type, KeyboardInterrupt):
+            sys.__excepthook__(exc_type, exc_value, exc_tb)
+            return
+        log.critical(
+            "UNCAUGHT top-level exception — process exiting",
+            exc_info=(exc_type, exc_value, exc_tb),
+        )
+
+    sys.excepthook = _log_uncaught
+    try:
+        faulthandler.enable(open(_LOG_DIR / "faulthandler.log", "a"))
+    except Exception:
+        log.debug("faulthandler enable failed", exc_info=True)
+
     # The in-loop _heartbeat_task takes over once setup_hook fires and
     # refreshes mtime every 30 s thereafter.
-    log.info("claudeD starting (launchd label: %s)", _LAUNCHD_LABEL)
+    log.info(
+        "claudeD starting (launchd label: %s) pid=%s",
+        _LAUNCHD_LABEL, os.getpid(),
+    )
 
     # Resolve and log the operator's Claude CLI so it's visible at boot time.
     from .cli_paths import resolve_claude_cli
@@ -2389,6 +2490,17 @@ def main() -> None:
         bot2.agent_manager = bot.agent_manager
         bot2._start_time = bot._start_time
         bot2.run(config.discord_bot_token, log_handler=None)
+    except Exception:
+        # T2-A: a crash inside bot.run() (outside discord.py's own handling)
+        # now leaves a CRITICAL breadcrumb instead of a silent 30s relaunch.
+        log.critical("bot.run() terminated with an exception", exc_info=True)
+        raise
+    finally:
+        # T2-A: reaching here means an ORDERLY shutdown (SIGTERM/graceful close
+        # unwound the stack). If clauded.log ever stops WITHOUT this line, the
+        # process was hard-killed — SIGKILL / OOM — which no in-process handler
+        # can catch; correlate with memory pressure.
+        log.info("claudeD main() exiting (pid=%s)", os.getpid())
 
 
 if __name__ == "__main__":

--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -125,6 +125,14 @@ class ClaudeBridge:
         self._active = False
         self._session_id: str | None = None
         self._on_session_id_cb: Callable[[str], None] | None = None
+        # T2-B: set True when a resume was REQUESTED but the CLI handed back a
+        # different session_id on the first message — i.e. the resume silently
+        # failed (session GC'd, cwd/project-hash mismatch, …) and the CLI
+        # started a FRESH conversation. Without this the bot captured the new
+        # id and moved on with zero signal, so users saw "it opened a new
+        # session and I don't know why". We log it + fire on_resume_failed.
+        self.resume_failed: bool = False
+        self._on_resume_failed_cb = sc.on_resume_failed
         # Aggregate stats updated whenever we observe a ResultMessage. They
         # are purely informational (surfaced via /session info) so the
         # exact semantics — total cost across the session, last-known turn
@@ -935,8 +943,31 @@ class ClaudeBridge:
         if isinstance(sid, str) and sid:
             first_time = self._session_id is None
             self._session_id = sid
-            if first_time and self._on_session_id_cb is not None:
-                self._on_session_id_cb(sid)
+            if first_time:
+                # T2-B: silent-resume-failure detection. A successful
+                # ``--resume S`` continues session S and reports session_id S
+                # on its first message; a DIFFERENT id means the CLI could not
+                # resume and quietly started fresh (context lost). ``fork_session``
+                # produces a new id ON PURPOSE, so exclude it.
+                if (
+                    self._resume_session_id
+                    and not self._fork_session
+                    and sid != self._resume_session_id
+                ):
+                    self.resume_failed = True
+                    log.warning(
+                        "resume MISMATCH: requested %s but CLI returned %s — "
+                        "prior conversation was NOT resumed (fresh session started)",
+                        self._resume_session_id,
+                        sid,
+                    )
+                    if self._on_resume_failed_cb is not None:
+                        try:
+                            self._on_resume_failed_cb(self._resume_session_id, sid)
+                        except Exception:
+                            log.debug("on_resume_failed callback raised; ignoring", exc_info=True)
+                if self._on_session_id_cb is not None:
+                    self._on_session_id_cb(sid)
 
     def _update_stats(self, msg: ResultMessage) -> None:
         """Pull per-turn totals off a ``ResultMessage`` into instance state.

--- a/src/clauded/session_config.py
+++ b/src/clauded/session_config.py
@@ -39,6 +39,7 @@ class SessionConfig:
     on_stop: Any = None  # callback
     on_subagent_stop: Any = None  # callback: fired when a subagent stops
     on_subagent_start: Any = None  # callback: fired when a subagent starts (#310 R2: per-subagent pending tracking)
+    on_resume_failed: Any = None  # callback(requested_id, actual_id): T2-B, fired when a requested resume silently started a fresh session
 
 
 __all__ = ["SessionConfig"]

--- a/tests/test_resume_detection.py
+++ b/tests/test_resume_detection.py
@@ -1,0 +1,81 @@
+"""T2-B: silent-resume-failure detection in ClaudeBridge._capture_session_id.
+
+When a resume was requested but the CLI hands back a different session_id on
+the first message, the resume didn't take (CLI started fresh). The bridge must
+flag ``resume_failed`` + fire ``on_resume_failed`` so the bot can surface it,
+instead of silently losing the user's conversation context.
+"""
+from __future__ import annotations
+
+from clauded.claude_bridge import ClaudeBridge
+from clauded.session_config import SessionConfig
+from clauded.config import Config
+
+
+def _cfg() -> Config:
+    return Config(
+        discord_bot_token="x",
+        claude_model=None,
+        claude_permission_mode="default",
+        projects_root="/tmp",
+    )
+
+
+class _Msg:
+    def __init__(self, sid: str) -> None:
+        self.session_id = sid
+
+
+def test_resume_mismatch_flags_and_fires_callback():
+    fired: list[tuple[str, str]] = []
+    b = ClaudeBridge(
+        "/tmp", _cfg(),
+        SessionConfig(resume_session_id="REQ-123",
+                      on_resume_failed=lambda r, a: fired.append((r, a))),
+    )
+    b._capture_session_id(_Msg("DIFFERENT-456"))
+    assert b.resume_failed is True
+    assert fired == [("REQ-123", "DIFFERENT-456")]
+
+
+def test_matching_resume_id_is_not_a_failure():
+    fired: list = []
+    b = ClaudeBridge(
+        "/tmp", _cfg(),
+        SessionConfig(resume_session_id="SAME",
+                      on_resume_failed=lambda r, a: fired.append(1)),
+    )
+    b._capture_session_id(_Msg("SAME"))
+    assert b.resume_failed is False
+    assert fired == []
+
+
+def test_fork_session_new_id_is_not_a_failure():
+    # fork_session intentionally produces a new session_id.
+    fired: list = []
+    b = ClaudeBridge(
+        "/tmp", _cfg(),
+        SessionConfig(resume_session_id="X", fork_session=True,
+                      on_resume_failed=lambda r, a: fired.append(1)),
+    )
+    b._capture_session_id(_Msg("Y"))
+    assert b.resume_failed is False
+    assert fired == []
+
+
+def test_cold_start_no_resume_requested_is_not_a_failure():
+    b = ClaudeBridge("/tmp", _cfg(), SessionConfig(resume_session_id=None))
+    b._capture_session_id(_Msg("fresh-id"))
+    assert b.resume_failed is False
+
+
+def test_callback_exception_is_swallowed():
+    def _boom(_r, _a):
+        raise RuntimeError("boom")
+    b = ClaudeBridge(
+        "/tmp", _cfg(),
+        SessionConfig(resume_session_id="REQ", on_resume_failed=_boom),
+    )
+    # Must not raise even though the callback throws.
+    b._capture_session_id(_Msg("OTHER"))
+    assert b.resume_failed is True


### PR DESCRIPTION
## Summary

Follow-up to #317, from an investigation into **"the bot sometimes can't resume a conversation after a restart and opens a new session instead."**

The resume logic itself is fine (persistence works — 111 sessions stored, atomic writes, early session_id capture). The real cause is **frequent process restarts interrupting a turn before its session_id persists**, which then cold-starts on the next message. This PR adds **visibility + a safety net**.

## What the log forensics actually showed

- ❌ **Not the watchdog** — the healthcheck fired `kickstart` exactly **once in 2 months** (18,554 "ok" vs 1 "stale").
- ❌ **Not OOM** — `log show` found **0 jetsam events** system-wide.
- ✅ The restart bursts are **episodic**, die **after "logging in" but before "Bot online"**, on a ~30s cadence (launchd `ThrottleInterval`), with **no traceback / no clean-exit marker** (SIGKILL-style), amid Discord `ClientConnectorError` / `ConnectionResetError`. They correlate with **network flakiness + system load** and self-recover when load drops.
- Also observed: **heavy child processes** spawned by the bot's own Claude session (pytest, workflows) can starve the event loop and drop the Discord gateway heartbeat → reconnect churn.

## Changes

**T2-B — resume-failure detection** *(the substantive fix)*
`ClaudeBridge` compares the CLI-reported `session_id` against the requested resume id on the first message. A mismatch (and not a deliberate `fork_session`) means the resume silently failed and a fresh session started → sets `resume_failed`, logs a WARN, fires `on_resume_failed`, and the bot posts a subtle notice. Silent context loss becomes explicit. New unit tests in `tests/test_resume_detection.py` (mismatch / match / fork / cold-start / callback-raises).

**T2-A — crash & exit diagnosability**
`sys.excepthook` logs uncaught exceptions; `faulthandler` captures C-level faults; boot (`pid=`) and `main() exiting` markers distinguish a graceful shutdown from a hard SIGKILL/OOM (which leaves neither). Chosen over re-adding `StandardErrorPath` (dropped in #168 to avoid log duplication). This will pin the exact restart mechanism next time.

**T2-D — watchdog leniency (defensive)**
The heartbeat file now carries the in-flight-turn count; `health-check.sh` grants a longer grace window (120s → 300s) while a turn is active, so a transient event-loop stall under load can't hard-kill the bot mid-turn. **Note:** the investigation found the watchdog was *not* the cause — this is a safety net, not the root fix.

## Testing

- `tests/test_resume_detection.py` added (T2-B); bridge/session unit tests pass; `bot.py` + `health-check.sh` syntax-clean.
- Full `pytest` was intentionally **not** run here: it starves this bot's event loop and drops the Discord connection (the very reconnect mechanism noted above).

## Not included

- Topic-1 workflow-UX optimizations (per-agent live panel, terminal summary) — separate follow-up.
- Definitive attribution of the SIGKILL source needs `sudo log show` of launchd internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
