### PR TITLE
feat(workflow): hook-driven live per-agent panel + richer embeds

### DIFF
--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -391,6 +391,14 @@ class ClaudedBot(commands.Bot):
         # file so the external watchdog grants a longer grace window while a
         # turn is in flight (see _write_heartbeat_state + health-check.sh).
         self._active_turns: int = 0
+        # T1-B: live per-agent roster for the workflow/subagent UX, keyed by
+        # thread_id → agent_id → {type, tool, started}. Fed by the
+        # SubagentStart / PreToolUse / SubagentStop hooks (all of which fire
+        # reliably), so the workflow progress embed can show real per-agent
+        # status even though the CLI's ``workflowProgress`` payload never
+        # arrives in practice (investigation: 0 occurrences in any log). The
+        # renderer reads this via ``bot._agent_roster``.
+        self._agent_roster: dict[int, dict[str, dict]] = {}
 
         # ---------------------------------------------------------------- #241
         # Scheduler core (PRD v1.18 §3.7 / §8 Subtask 4): persistent timer
@@ -925,6 +933,12 @@ class ClaudedBot(commands.Bot):
                 extra_dirs = self.project_manager.get_extra_dirs(channel.id)
                 mcp_servers = self.project_manager.get_mcp_servers(channel.id)
                 async def _pre_tool_notify(tool_name: str, input_data: dict) -> None:
+                    # T1-B: record the subagent's current tool in the live
+                    # roster (best-effort; only subagent tool calls carry an
+                    # agent_id via _SubagentContextMixin).
+                    aid = input_data.get("agent_id")
+                    if aid:
+                        self._roster_note_tool(thread.id, aid, tool_name)
                     try:
                         await thread.send(f"-# 🔮 Preparing: {tool_name}...", silent=True)
                     except Exception:
@@ -1134,6 +1148,11 @@ class ClaudedBot(commands.Bot):
                     _thread_target = message.channel
 
                     async def _pre_tool_notify_thread(tool_name: str, input_data: dict) -> None:
+                        # T1-B: record the subagent's current tool in the live
+                        # roster (best-effort; subagent tool calls carry agent_id).
+                        aid = input_data.get("agent_id")
+                        if aid:
+                            self._roster_note_tool(thread_id, aid, tool_name)
                         try:
                             await _thread_target.send(f"-# 🔮 Preparing: {tool_name}...", silent=True)
                         except Exception:
@@ -1488,6 +1507,35 @@ class ClaudedBot(commands.Bot):
         except Exception:
             log.debug("#310: failed to send pending-subagent warning", exc_info=True)
 
+    # ------------------------------------------------------------------
+    # T1-B: live per-agent roster (workflow / subagent UX)
+    # ------------------------------------------------------------------
+
+    def _roster_note_start(self, thread_id: int, agent_id: str, agent_type: str | None) -> None:
+        """Record a newly-started subagent in the live roster."""
+        self._agent_roster.setdefault(thread_id, {})[agent_id] = {
+            "type": agent_type or "subagent",
+            "tool": None,
+            "started": time.time(),
+        }
+
+    def _roster_note_tool(self, thread_id: int, agent_id: str, tool: str | None) -> None:
+        """Update the current tool a subagent is running (best-effort)."""
+        bucket = self._agent_roster.get(thread_id)
+        if bucket is None:
+            return
+        entry = bucket.get(agent_id)
+        if entry is not None:
+            entry["tool"] = tool
+
+    def _roster_clear(self, thread_id: int, agent_id: str) -> None:
+        """Drop a finished subagent from the roster; prune empty threads."""
+        bucket = self._agent_roster.get(thread_id)
+        if bucket is not None:
+            bucket.pop(agent_id, None)
+            if not bucket:
+                self._agent_roster.pop(thread_id, None)
+
     def _make_subagent_start_cb(self, thread_id: int) -> Any:
         """review A4/A5: build a SubagentStart callback that records a pending
         subagent for this thread.
@@ -1506,6 +1554,9 @@ class ClaudedBot(commands.Bot):
             self._pending_subagents.setdefault(thread_id, {})[agent_id] = (
                 agent_type or "subagent"
             )
+            # T1-B: seed the live roster so the workflow embed can show this
+            # agent (type + current tool + elapsed) even without workflowProgress.
+            self._roster_note_start(thread_id, agent_id, agent_type)
 
         return _on_subagent_start
 
@@ -1539,6 +1590,9 @@ class ClaudedBot(commands.Bot):
                 bucket.pop(agent_id, None)
                 if not bucket:
                     self._pending_subagents.pop(thread_id, None)
+            # T1-B: drop from the live roster too.
+            if agent_id:
+                self._roster_clear(thread_id, agent_id)
 
             # review A6: surface the real result (Discord only).
             result_text = self._read_subagent_result(agent_transcript_path)

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -938,15 +938,37 @@ class DiscordRenderer:
                 progress, tokens, tool_uses, duration, last_tool,
             )
         else:
-            # Fallback: simple format when no workflowProgress data
+            # T1-B/T1-E: the CLI's ``workflowProgress`` payload never arrives
+            # in practice (investigation: 0 occurrences in any log), so the old
+            # fallback was a flat one-liner. Build a real per-agent panel from
+            # the hook-fed roster (bot._agent_roster — populated by
+            # SubagentStart/PreToolUse/SubagentStop, which DO fire) plus elapsed
+            # wall-clock, so the user sees live agent status regardless.
+            elapsed = int(time.time() - state.started_at) if state.started_at else 0
+            roster: dict = {}
+            try:
+                tid = getattr(self.target, "id", None)
+                if tid is not None and self._bot is not None:
+                    roster = getattr(self._bot, "_agent_roster", {}).get(tid, {}) or {}
+            except Exception:
+                roster = {}
+            lines = [
+                "━━━━━━━━━━━━━━━━━━━━━━━",
+                f"🔮 Task: {state.description[:60]}",
+                f"⏱️ {elapsed}s elapsed",
+            ]
+            agent_lines = self._format_roster_lines(roster)
+            if agent_lines:
+                lines.append(f"🤖 Agents: {len(roster)} running")
+                lines.extend(agent_lines)
+            else:
+                lines.append(f"💭 Last tool: {last_tool or '—'}")
+            lines.append(
+                f"🪙 {tokens} tokens · 🔧 {tool_uses} tools · ⏱️ {duration}s"
+            )
             embed = discord.Embed(
                 title="🔄 Dynamic Workflow Running",
-                description=(
-                    "━━━━━━━━━━━━━━━━━━━━━━━\n"
-                    f"🔮 Task: {state.description[:60]}\n"
-                    f"💭 Last tool: {last_tool or '—'}\n"
-                    f"🪙 {tokens} tokens · 🔧 {tool_uses} tools · ⏱️ {duration}s"
-                ),
+                description="\n".join(lines),
                 color=COLOR_TOOL_RUNNING,
             )
 
@@ -1027,6 +1049,36 @@ class DiscordRenderer:
         )
 
     @staticmethod
+    def _format_roster_lines(roster: dict) -> list[str]:
+        """T1-B: format the hook-fed per-agent roster into embed lines.
+
+        ``roster`` is ``bot._agent_roster[thread_id]`` — a mapping of
+        ``agent_id -> {type, tool, started}`` maintained by the
+        SubagentStart / PreToolUse / SubagentStop hooks. Unlike
+        :meth:`_format_agent_lines` (which needs the CLI's ``workflowProgress``
+        payload that never arrives), this derives entirely from hook data that
+        reliably fires. Shows type + current tool + elapsed, folded past 10.
+        """
+        lines: list[str] = []
+        now = time.time()
+        items = sorted(roster.items())
+        for i, (_aid, info) in enumerate(items, 1):
+            if i > 10:
+                remaining = len(items) - 10
+                if remaining > 0:
+                    lines.append(f"  … {remaining} more …")
+                break
+            if not isinstance(info, dict):
+                continue
+            atype = (info.get("type") or "subagent")[:24]
+            tool = info.get("tool")
+            started = info.get("started") or now
+            elapsed = int(now - started)
+            tool_seg = f"🔧 {tool}" if tool else "💭 …"
+            lines.append(f"  🔄 #{i} {atype} · {tool_seg} · ⏱️ {elapsed}s")
+        return lines
+
+    @staticmethod
     def _format_agent_lines(
         agents: list[dict], last_tool: str | None,
     ) -> list[str]:
@@ -1095,11 +1147,18 @@ class DiscordRenderer:
             color = COLOR_INFO
 
         embed = discord.Embed(title=title, description=description, color=color)
+        state = self._task_states.get(task_id)
+        # T1-D: fold total wall-clock duration into the terminal footer so the
+        # completed/failed/stopped card summarizes how long the workflow ran,
+        # alongside the SDK usage (tokens/tool-uses/SDK-time).
         usage_seg = self._fmt_task_usage(usage)
+        if state is not None and getattr(state, "started_at", 0):
+            elapsed = int(time.time() - state.started_at)
+            dur_seg = f"⏱️ {elapsed}s total"
+            usage_seg = f"{usage_seg} · {dur_seg}" if usage_seg else dur_seg
         if usage_seg:
             embed.set_footer(text=usage_seg)
 
-        state = self._task_states.get(task_id)
         edited = False
         if state and state.message is not None:
             edited = await self._safe_edit(state.message, embed=embed)

--- a/tests/test_workflow_roster.py
+++ b/tests/test_workflow_roster.py
@@ -1,0 +1,76 @@
+"""T1-B: hook-fed live per-agent workflow roster.
+
+The CLI's ``workflowProgress`` payload never arrives in practice, so the
+workflow progress embed is built from ``bot._agent_roster`` — a roster
+maintained by the SubagentStart / PreToolUse / SubagentStop hooks. These tests
+cover the roster bookkeeping helpers and the renderer's line formatter without
+needing a live workflow.
+"""
+from __future__ import annotations
+
+import time
+
+from clauded.bot import ClaudedBot
+from clauded.discord_renderer import DiscordRenderer
+
+
+class _RosterHost:
+    """Minimal stand-in exposing just ``_agent_roster`` so the bound
+    ClaudedBot roster helpers can run without constructing a full bot."""
+
+    def __init__(self) -> None:
+        self._agent_roster: dict[int, dict[str, dict]] = {}
+
+
+def test_roster_start_tool_clear_lifecycle():
+    h = _RosterHost()
+    ClaudedBot._roster_note_start(h, 111, "a1", "code-reviewer")
+    ClaudedBot._roster_note_start(h, 111, "a2", "general-purpose")
+    assert set(h._agent_roster[111]) == {"a1", "a2"}
+    assert h._agent_roster[111]["a1"]["type"] == "code-reviewer"
+    assert h._agent_roster[111]["a1"]["tool"] is None
+
+    ClaudedBot._roster_note_tool(h, 111, "a1", "Read")
+    assert h._agent_roster[111]["a1"]["tool"] == "Read"
+
+    # tool update for an unknown agent/thread is a no-op (no crash)
+    ClaudedBot._roster_note_tool(h, 999, "zz", "Bash")
+    ClaudedBot._roster_note_tool(h, 111, "zz", "Bash")
+
+    ClaudedBot._roster_clear(h, 111, "a1")
+    assert set(h._agent_roster[111]) == {"a2"}
+    # clearing the last agent prunes the thread entry entirely
+    ClaudedBot._roster_clear(h, 111, "a2")
+    assert 111 not in h._agent_roster
+
+
+def test_format_roster_lines_shows_type_tool_elapsed():
+    now = time.time()
+    roster = {
+        "a1": {"type": "code-reviewer", "tool": "Read", "started": now - 5},
+        "a2": {"type": "general-purpose", "tool": None, "started": now - 2},
+    }
+    lines = DiscordRenderer._format_roster_lines(roster)
+    assert len(lines) == 2
+    assert "code-reviewer" in lines[0] and "🔧 Read" in lines[0]
+    # no tool yet → thinking marker
+    assert "general-purpose" in lines[1] and "💭" in lines[1]
+
+
+def test_format_roster_lines_folds_past_ten():
+    now = time.time()
+    roster = {f"a{i}": {"type": "t", "tool": None, "started": now} for i in range(15)}
+    lines = DiscordRenderer._format_roster_lines(roster)
+    # 10 agent lines + 1 "… N more …" fold line
+    assert len(lines) == 11
+    assert "more" in lines[-1]
+
+
+def test_format_roster_lines_empty_is_empty():
+    assert DiscordRenderer._format_roster_lines({}) == []
+
+
+def test_format_roster_lines_tolerates_bad_entries():
+    # A malformed entry must not crash the formatter.
+    lines = DiscordRenderer._format_roster_lines({"a1": "not-a-dict"})
+    assert lines == []


### PR DESCRIPTION
## Summary

Fixes the "SDK workflow scenario — progress / agent display isn't good enough" report.

**Root cause (from the investigation):** the bot already has a rich workflow-progress renderer (#309 — phases, agent summary, per-agent lines), but it only activates when the CLI emits a `workflowProgress` array in the raw event data. That payload **never arrives** — 0 occurrences across the production log *and* a 14 MB `stream-debug` capture. So users only ever saw the degraded fallback: a single flat `🔄 Running · Last tool: X · tokens·tools·time` line. The `#309` parsing was built on an unverified field assumption.

**Approach:** stop depending on `workflowProgress`. Derive per-agent status from hooks that **do** reliably fire (the same `SubagentStart`/`SubagentStop` hooks the #317 subagent-notification fix already uses).

## Changes

**T1-B — live per-agent roster**
The bot maintains `_agent_roster` (`thread_id → agent_id → {type, tool, started}`):
- `SubagentStart` → add agent (type)
- `PreToolUse` → set current tool (subagent tool calls carry `agent_id` via `_SubagentContextMixin`)
- `SubagentStop` → remove agent

The renderer reads `bot._agent_roster` and renders real per-agent lines (type · current tool · elapsed), folded past 10.

**T1-E — richer running embed**
The fallback embed (what users actually see) now shows the roster panel + elapsed wall-clock + usage instead of one "Last tool" line.

**T1-D — terminal summary**
Completed/failed/stopped cards now include total wall-clock duration alongside SDK usage.

## Testing

- `tests/test_workflow_roster.py` — roster lifecycle, line formatting, folding, malformed-entry tolerance.
- **Not run in-session:** pytest starves this bot's event loop and drops the Discord connection (see #318). Syntax-verified (`ast.parse`) instead; please run `pytest tests/test_workflow_roster.py` on a stable window.

## Follow-up (T1-A, not in this PR)

Set `CLAUDED_STREAM_DEBUG=1` and run a real workflow to capture the raw `Task*` stream and confirm what the SDK actually emits. The roster path here is independent of that, but the capture would let us also revive the CLI-native phase view if the real field name turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
