### PR TITLE
fix(tests): stop `pytest` from restarting the live bot via launchctl kickstart

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,14 @@ where = ["src"]
 
 [tool.setuptools.package-dir]
 "" = "src"
+
+[tool.pytest.ini_options]
+markers = [
+    "live_host: test mutates real host state (e.g. launchctl kickstart of the live LaunchAgent). Excluded by default so a plain `pytest` run can never restart a running clauded bot. Run explicitly with `-m live_host` (still safe — such tests shim the host binary).",
+]
+# Never touch the live host by default. The health-check kickstart tests are
+# marked `live_host`; excluding that marker keeps a plain `pytest` run from
+# hard-killing a running clauded — its `launchctl kickstart -k
+# gui/<uid>/com.hxy.clauded` targets a uid-scoped launchd domain that HOME
+# isolation cannot redirect. See tests/test_health_check_script.py.
+addopts = "-m 'not live_host'"

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -13,6 +13,11 @@ STALE_THRESHOLD_SECS=120
 # session_id and force a cold resume next message (the T2 resume bug).
 ACTIVE_TURN_THRESHOLD_SECS=300
 
+# Label of the LaunchAgent to kickstart when the heartbeat goes stale.
+# Overridable via env so tests / dry-run harnesses can target a dummy label
+# instead of the live service; the default preserves production behavior.
+LAUNCHD_LABEL="${CLAUDED_LAUNCHD_LABEL:-com.hxy.clauded}"
+
 mkdir -p "$(dirname "$HEARTBEAT")" "$(dirname "$ALERTS_LOG")"
 
 # #168 acceptance: every script invocation produces at least one log line
@@ -68,9 +73,9 @@ if [ "$ACTIVE_TURNS" -gt 0 ]; then
 fi
 
 if [ "$AGE" -gt "$THRESHOLD" ]; then
-    log_line "heartbeat stale (${AGE}s > ${THRESHOLD}s, active_turns=${ACTIVE_TURNS}); kickstarting com.hxy.clauded"
-    echo "$(date '+%F %T') heartbeat stale (${AGE}s, active_turns=${ACTIVE_TURNS}); kickstarting com.hxy.clauded" >> "$ALERTS_LOG"
-    launchctl kickstart -k "gui/$(id -u)/com.hxy.clauded" 2>/dev/null || true
+    log_line "heartbeat stale (${AGE}s > ${THRESHOLD}s, active_turns=${ACTIVE_TURNS}); kickstarting ${LAUNCHD_LABEL}"
+    echo "$(date '+%F %T') heartbeat stale (${AGE}s, active_turns=${ACTIVE_TURNS}); kickstarting ${LAUNCHD_LABEL}" >> "$ALERTS_LOG"
+    launchctl kickstart -k "gui/$(id -u)/${LAUNCHD_LABEL}" 2>/dev/null || true
 
     # Track restart count in rolling 5-min window via /tmp file (per-day rotating)
     DAY=$(date +%Y%m%d)

--- a/tests/test_health_check_script.py
+++ b/tests/test_health_check_script.py
@@ -23,11 +23,46 @@ pytestmark = pytest.mark.skipif(
 SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "health-check.sh"
 
 
+def _install_launchctl_shim(home: Path) -> Path:
+    """Put a fake ``launchctl`` on PATH so the script's ``kickstart -k`` is a
+    recorded no-op instead of hard-killing the developer's LIVE bot.
+
+    The launchd GUI domain (``gui/<uid>/...``) is keyed by uid, NOT by $HOME,
+    so pointing HOME at tmp_path does NOT stop ``launchctl kickstart -k
+    gui/$(id -u)/com.hxy.clauded`` from restarting the real running service.
+    Shadowing the ``launchctl`` binary on PATH is what actually makes these
+    tests safe on a box where clauded is active. Returns the call-log path the
+    shim appends each invocation's args to.
+    """
+    shim_dir = home / "shimbin"
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    calls_log = home / "launchctl-calls.log"
+    shim = shim_dir / "launchctl"
+    shim.write_text(
+        "#!/bin/bash\n"
+        f'printf "%s\\n" "$*" >> "{calls_log}"\n'
+        "exit 0\n"
+    )
+    shim.chmod(0o755)
+    return calls_log
+
+
 def _run_script(home: Path) -> tuple[int, str, str]:
-    """Run the healthcheck script with HOME pointed at tmp_path."""
+    """Run the healthcheck script with HOME pointed at tmp_path.
+
+    Always installs the ``launchctl`` shim (see :func:`_install_launchctl_shim`)
+    and prepends its dir to the subprocess PATH, so no invocation of the script
+    can touch the live LaunchAgent.
+    """
+    _install_launchctl_shim(home)
+    shim_dir = home / "shimbin"
     proc = subprocess.run(
         ["bash", str(SCRIPT)],
-        env={**os.environ, "HOME": str(home)},
+        env={
+            **os.environ,
+            "HOME": str(home),
+            "PATH": f"{shim_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+        },
         capture_output=True,
         text=True,
     )
@@ -68,11 +103,18 @@ def test_healthy_run_emits_ok_log_line(tmp_path: Path) -> None:
     assert "heartbeat age" in content
 
 
+@pytest.mark.live_host
 def test_stale_heartbeat_triggers_kickstart_log(tmp_path: Path) -> None:
-    """Stale heartbeat (>120s) → 'heartbeat stale … kickstarting' log line
-    in BOTH healthcheck.log AND alerts.log. Kickstart itself silently fails
-    in this test env (gui/$(id -u)/com.hxy.clauded not loaded under our
-    tmp HOME), which is fine — we only assert log shape, not real recovery.
+    """Stale heartbeat (>120s) → 'heartbeat stale … kickstarting' log line in
+    BOTH healthcheck.log AND alerts.log, plus a ``launchctl kickstart`` call.
+
+    Marked ``live_host`` (excluded from the default ``pytest`` run) AND run
+    against a shimmed ``launchctl`` (see ``_run_script``): the kickstart is
+    recorded to ``launchctl-calls.log`` as a no-op, exercising the stale-branch
+    logic WITHOUT restarting the developer's live bot. The old version of this
+    test claimed the kickstart "silently fails … not loaded under our tmp HOME"
+    — that was FALSE: the ``gui/<uid>`` launchd domain ignores $HOME, so it
+    hard-killed the running service. This marker + shim is the fix.
     """
     heartbeat = tmp_path / "Library" / "Caches" / "clauded" / "heartbeat"
     heartbeat.parent.mkdir(parents=True)
@@ -90,16 +132,29 @@ def test_stale_heartbeat_triggers_kickstart_log(tmp_path: Path) -> None:
     assert alerts_log.exists()
     assert "heartbeat stale" in health_log.read_text()
     assert "kickstarting com.hxy.clauded" in alerts_log.read_text()
+    # The kickstart hit the shim, NOT the real launchctl — proof the live
+    # service was never touched by this test.
+    calls = (tmp_path / "launchctl-calls.log").read_text()
+    assert "kickstart -k gui/" in calls
+    assert "com.hxy.clauded" in calls
 
 
+@pytest.mark.live_host
 def test_missing_heartbeat_treated_as_stale(tmp_path: Path) -> None:
-    """No heartbeat file at all → AGE=99999 → kickstart branch fires."""
+    """No heartbeat file at all → AGE=99999 → kickstart branch fires.
+
+    ``live_host`` + shimmed launchctl (see ``_run_script``) so the fired
+    kickstart is a recorded no-op, never a restart of the live bot.
+    """
     # Don't create the heartbeat file
     rc, _, _ = _run_script(tmp_path)
     assert rc == 0
     health_log = tmp_path / "Library" / "Logs" / "clauded" / "healthcheck.log"
     content = health_log.read_text()
-    assert "heartbeat stale (99999 s)" in content
+    # Script formats the age as "99999s" (T2-D appended "> <threshold>s, ...").
+    assert "heartbeat stale (99999s" in content
+    # Kickstart went to the shim, not the real service.
+    assert "kickstart -k gui/" in (tmp_path / "launchctl-calls.log").read_text()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Rank-1 (CRITICAL) finding of the stability audit — and the root cause of "running tests disconnects clauded"

Two health-check tests ran the **real** `scripts/health-check.sh`, whose stale-heartbeat branch executes:

```
launchctl kickstart -k "gui/$(id -u)/com.hxy.clauded"
```

The launchd **GUI domain is keyed by uid (501), not `$HOME`**, so the tests' tmp-HOME isolation could not redirect it. Every `pytest` run therefore hard-killed the running bot (KeepAlive relaunches it instantly → the "restarts often / gateway drop" churn). The old docstring falsely claimed the kickstart "silently fails … not loaded under our tmp HOME".

## Fix (defense in depth)
- **Shim** — `_run_script` installs a fake `launchctl` on the subprocess PATH; the kickstart becomes a recorded no-op (asserted via `launchctl-calls.log`) instead of touching the live LaunchAgent.
- **Marker** — register a `live_host` pytest marker + `addopts = -m 'not live_host'` so a plain `pytest` never even *collects* these host-mutating tests.
- **Configurable label** — `health-check.sh` reads `CLAUDED_LAUNCHD_LABEL` (default `com.hxy.clauded`); production behavior byte-identical.
- Fixed a stale assertion (`99999 s` → `99999s`) left by the T2-D format change.

## Verification (live bot running the whole time)
- `pytest tests/test_health_check_script.py --collect-only` → **2 deselected** (dangerous tests never run by default).
- `pytest -m live_host` → **2 passed** via the shim, **live bot PID unchanged** → no restart.

This makes it safe to run the suite on a box where clauded is live.