### PR TITLE
fix(session): per-thread lock in /session compact|security-review|stop + resume on /model switch

### DIFF
--- a/src/clauded/cogs/model.py
+++ b/src/clauded/cogs/model.py
@@ -145,15 +145,25 @@ async def model_switch(interaction: discord.Interaction, name: str) -> None:
         )
         return
 
-    # No active session — fall back to recreate (context starts fresh)
-    bridge = await bot._recreate_session(interaction, model_override=name)
+    # No active session — recreate. #audit(#7): pass resume_session_id so a
+    # dead/restarted session preserves prior context, matching every sibling
+    # recreate command (/effort, /max-turns, /fallback, /bare, /tools.*). Only
+    # the model choice is ephemeral (#210); the transcript is still resumed.
+    sid = bot._get_resume_session_id(thread_id)
+    bridge = await bot._recreate_session(
+        interaction, model_override=name, resume_session_id=sid
+    )
     if bridge:
+        context_note = (
+            "✅ Context preserved from the prior session."
+            if sid
+            else "⚠️ No prior context (no saved session for this thread)."
+        )
         await interaction.followup.send(
             embed=discord.Embed(
                 title=f"🔄 Switched to `{name}`",
                 description=(
-                    "✅ Model set for new session.\n"
-                    "⚠️ No prior context (session was not active).\n\n"
+                    f"✅ Model set for new session.\n{context_note}\n\n"
                     "-# ⏱️ **Per-session** — bot restart returns to CLI default."
                 ),
                 color=COLOR_INFO,

--- a/src/clauded/cogs/session.py
+++ b/src/clauded/cogs/session.py
@@ -37,13 +37,25 @@ async def session_stop(interaction: discord.Interaction) -> None:
         )
         return
 
-    stopped = await bot.session_manager.stop_session(thread_id)
+    # #audit(#4): interrupt any in-flight turn, THEN hold the per-thread lock
+    # across the stop. A bare stop_session → bridge.stop() → client.disconnect()
+    # closes the anyio TaskGroup out from under a concurrent receive_response()
+    # and crashes the turn (the bridge documents this hazard at
+    # claude_bridge.py:794). Defer first because acquiring the lock may wait for
+    # the in-flight turn to end. Mirrors /session clear's locked teardown.
+    await interaction.response.defer(ephemeral=True)
+    bridge = bot.session_manager.get_session(thread_id)
+    if bridge is not None and bridge.is_active:
+        try:
+            await bridge.interrupt()
+        except Exception:
+            log.debug("session_stop: interrupt before stop failed; continuing", exc_info=True)
+    async with bot.session_manager.get_lock(thread_id):
+        stopped = await bot.session_manager.stop_session(thread_id)
     if stopped:
-        await interaction.response.send_message(
-            "Claude session stopped.", ephemeral=True
-        )
+        await interaction.followup.send("Claude session stopped.", ephemeral=True)
     else:
-        await interaction.response.send_message(
+        await interaction.followup.send(
             "No active Claude session in this thread.", ephemeral=True
         )
 
@@ -302,8 +314,13 @@ async def session_compact(interaction: discord.Interaction) -> None:
         return
     await interaction.response.defer()
     try:
-        async for _ in bridge.send_message("/compact"):
-            pass
+        # #audit(#2): hold the per-thread lock so /compact serializes with any
+        # in-flight user turn — otherwise both consume the single shared SDK
+        # receive stream concurrently and silently split messages (lost
+        # ResultMessage / interleaved text). Mirrors /session resume.
+        async with bot.session_manager.get_lock(thread_id):
+            async for _ in bridge.send_message("/compact"):
+                pass
         embed = discord.Embed(
             title="🗜️ Context Compacted",
             description="Session context has been compressed to save tokens.",
@@ -428,8 +445,12 @@ async def session_security_review(interaction: discord.Interaction) -> None:
         return
     await interaction.response.defer()
     try:
-        async for _ in bridge.send_message("/security-review"):
-            pass
+        # #audit(#3): same single-consumer invariant as /session compact —
+        # serialize against any in-flight turn via the per-thread lock so the
+        # two turns never split the shared SDK receive stream.
+        async with bot.session_manager.get_lock(thread_id):
+            async for _ in bridge.send_message("/security-review"):
+                pass
         embed = discord.Embed(
             title="🔒 Security Review",
             description="Security review completed.",

--- a/tests/test_model_cmd.py
+++ b/tests/test_model_cmd.py
@@ -330,13 +330,17 @@ async def test_model_switch_sdk_rejection_shows_error():
 
 
 @pytest.mark.asyncio
-async def test_model_switch_fallback_embed_does_not_claim_preserved():
-    """#273 R2: fallback path (no active session) must NOT say 'Context preserved'."""
+async def test_model_switch_fallback_resumes_stored_session():
+    """#audit(#7): with a stored session, the no-active-session fallback must
+    RESUME it (thread resume_session_id) and honestly say context is preserved,
+    matching every sibling recreate command. Supersedes the #273 R2 test that
+    pinned the old cold-start-drops-context behavior."""
     from clauded.cogs.model import model_switch
     from clauded.bot import ClaudedBot
     bot = MagicMock(spec=ClaudedBot)
     bot.session_manager = MagicMock()
     bot.session_manager.get_session = MagicMock(return_value=None)
+    bot._get_resume_session_id = MagicMock(return_value="sess-abc123")
     bot._recreate_session = AsyncMock(return_value=MagicMock())
     interaction = MagicMock()
     interaction.client = bot
@@ -345,7 +349,34 @@ async def test_model_switch_fallback_embed_does_not_claim_preserved():
     interaction.response.defer = AsyncMock()
     interaction.followup.send = AsyncMock()
     await model_switch.callback(interaction, "opus")
-    embed = interaction.followup.send.await_args.kwargs["embed"]
-    assert "Context preserved" not in embed.description, (
-        f"Fallback path should not claim context preserved: {embed.description!r}"
+    # The stored session id is threaded into the recreate so context survives.
+    assert (
+        bot._recreate_session.await_args.kwargs.get("resume_session_id")
+        == "sess-abc123"
     )
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert "Context preserved" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_model_switch_fallback_no_stored_session_is_honest():
+    """#audit(#7): with NO stored session, the fallback starts genuinely fresh
+    (resume_session_id=None) and says so — no false 'context preserved' claim."""
+    from clauded.cogs.model import model_switch
+    from clauded.bot import ClaudedBot
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=None)
+    bot._get_resume_session_id = MagicMock(return_value=None)
+    bot._recreate_session = AsyncMock(return_value=MagicMock())
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel = MagicMock(spec=discord.Thread)
+    interaction.channel.id = 42
+    interaction.response.defer = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    await model_switch.callback(interaction, "opus")
+    assert bot._recreate_session.await_args.kwargs.get("resume_session_id") is None
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert "Context preserved" not in embed.description
+    assert "No prior context" in embed.description

--- a/tests/test_session_cmd_locks.py
+++ b/tests/test_session_cmd_locks.py
@@ -1,0 +1,109 @@
+"""#audit(#2,#3,#4): session commands that drive the shared SDK receive stream
+(``/session compact``, ``/session security-review``) or tear down the client
+(``/session stop``) MUST hold the per-thread lock. Otherwise they race an
+in-flight user turn: two consumers split the single shared SDK receive stream
+(lost ResultMessage / interleaved text), or a mid-turn disconnect crashes the
+turn's ``receive_response()`` by closing the anyio TaskGroup under it.
+
+Each test records enter/send/exit ordering to prove the stream/teardown op runs
+strictly INSIDE the lock (and, for stop, that we interrupt first).
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+
+from clauded.bot import ClaudedBot
+from clauded.cogs.session import (
+    session_compact,
+    session_security_review,
+    session_stop,
+)
+
+
+class _RecordingLock:
+    """Async context manager that appends enter/exit to a shared list."""
+
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+
+    async def __aenter__(self) -> "_RecordingLock":
+        self._events.append("lock-enter")
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        self._events.append("lock-exit")
+        return False
+
+
+def _interaction(channel_id: int = 42) -> MagicMock:
+    interaction = MagicMock()
+    interaction.channel = MagicMock(spec=discord.Thread)
+    interaction.channel.id = channel_id
+    interaction.channel_id = channel_id
+    interaction.response.defer = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _bot_with_active_bridge(events: list[str]) -> tuple[MagicMock, MagicMock]:
+    bridge = MagicMock()
+    bridge.is_active = True
+
+    async def fake_send(msg):
+        events.append(f"send:{msg}")
+        return
+        yield  # noqa: unreachable — marks fake_send an async generator
+
+    bridge.send_message = fake_send
+    bridge.interrupt = AsyncMock(side_effect=lambda: events.append("interrupt"))
+
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=bridge)
+    bot.session_manager.get_lock = MagicMock(return_value=_RecordingLock(events))
+
+    async def fake_stop(_tid):
+        events.append("stop_session")
+        return True
+
+    bot.session_manager.stop_session = AsyncMock(side_effect=fake_stop)
+    return bot, bridge
+
+
+@pytest.mark.asyncio
+async def test_compact_sends_inside_lock():
+    events: list[str] = []
+    bot, _ = _bot_with_active_bridge(events)
+    interaction = _interaction()
+    interaction.client = bot
+    await session_compact.callback(interaction)
+    assert events == ["lock-enter", "send:/compact", "lock-exit"]
+
+
+@pytest.mark.asyncio
+async def test_security_review_sends_inside_lock(monkeypatch):
+    events: list[str] = []
+    bot, _ = _bot_with_active_bridge(events)
+    # Bypass the Group-A unbound guard so we reach the send path.
+    monkeypatch.setattr(
+        "clauded.cogs.session.reject_if_unbound", AsyncMock(return_value=False)
+    )
+    interaction = _interaction()
+    interaction.client = bot
+    await session_security_review.callback(interaction)
+    assert events == ["lock-enter", "send:/security-review", "lock-exit"]
+
+
+@pytest.mark.asyncio
+async def test_stop_interrupts_then_stops_under_lock():
+    events: list[str] = []
+    bot, _ = _bot_with_active_bridge(events)
+    interaction = _interaction()
+    interaction.client = bot
+    await session_stop.callback(interaction)
+    # Interrupt the in-flight turn first, THEN stop under the lock.
+    assert events == ["interrupt", "lock-enter", "stop_session", "lock-exit"]


### PR DESCRIPTION
Four verified stability-audit findings on **session-command correctness** (single-consumer invariant + memory preservation).

| # | Sev | Command | Bug |
|---|-----|---------|-----|
| **#2** | HIGH | `/session compact` | `send_message()` with **no per-thread lock** → races an in-flight turn; the two consumers split the single shared SDK receive stream (interleaved text, **lost ResultMessage**). |
| **#3** | MED | `/session security-review` | Identical lock-free race. |
| **#4** | MED | `/session stop` | Unlocked `stop_session()` → `client.disconnect()` closes the anyio TaskGroup under a running `receive_response()`, **crashing the turn** (bridge documents this at `claude_bridge.py:794`). |
| **#7** | MED | `/model switch` | Dead-session fallback recreated **without `resume`**, unlike every sibling recreate command → **silent memory fork**. |

## Fix
- `/compact` + `/security-review`: wrap the send loop in `async with session_manager.get_lock(thread_id)` — same lock every human turn holds, so they serialize instead of racing. Mirrors `/session resume`.
- `/stop`: defer → `interrupt()` the in-flight turn → stop **under the lock** (mirrors `/session clear`).
- `/model switch` fallback: thread `resume_session_id=_get_resume_session_id(thread_id)` through `_recreate_session`. Model choice stays ephemeral (#210); the **transcript is resumed**. Message is honest either way.

## Tests
- New `tests/test_session_cmd_locks.py` — records enter/send/exit ordering, proving the stream op / teardown runs **strictly inside** the lock (and `/stop` interrupts first).
- Updated the `#273 R2` model-fallback test (which pinned the old context-dropping behavior) to assert the corrected resume + honest copy.
- All affected files pass **in isolation**; live bot PID unchanged during test runs.

> Note: while verifying I found a pre-existing **cross-file test-order pollution** in `test_model_default`/`test_permission_mode` that makes `test_group_a_unbound` fail when run after them (each passes alone). Not caused by this PR — flagged separately.