### PR TITLE
feat(observability): gateway lifecycle visibility + end-of-turn error footer

### DIFF
--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -397,6 +397,14 @@ class ClaudedBot(commands.Bot):
         # file so the external watchdog grants a longer grace window while a
         # turn is in flight (see _write_heartbeat_state + health-check.sh).
         self._active_turns: int = 0
+        # #audit(#20): gateway lifecycle observability. discord.py's internal
+        # reconnect loop is otherwise entirely silent; these counters +
+        # timestamps (updated by on_disconnect / on_resumed) let /health show
+        # whether the bot is flapping vs steady and give the logs a breadcrumb.
+        self._gw_disconnects: int = 0
+        self._gw_resumes: int = 0
+        self._gw_last_disconnect_at: float | None = None
+        self._gw_last_resumed_at: float | None = None
         # T1-B: live per-agent roster for the workflow/subagent UX, keyed by
         # thread_id → agent_id → {type, tool, started}. Fed by the
         # SubagentStart / PreToolUse / SubagentStop hooks (all of which fire
@@ -804,6 +812,20 @@ class ClaudedBot(commands.Bot):
                 log.exception("Per-guild slash sync failed for %s", guild.id)
         if guilds_synced:
             log.info("Per-guild slash sync done: %s", ", ".join(guilds_synced))
+
+    async def on_disconnect(self) -> None:  # type: ignore[override]
+        # #audit(#20): discord.py auto-reconnects were entirely silent. Record a
+        # counter + timestamp + WARNING so gateway churn is visible in /health
+        # and the logs (the user's "restarts often / gateway drops" symptom).
+        self._gw_disconnects += 1
+        self._gw_last_disconnect_at = time.time()
+        log.warning("Gateway disconnected (#%d this run)", self._gw_disconnects)
+
+    async def on_resumed(self) -> None:  # type: ignore[override]
+        # Session RESUMED (not a full re-identify) — the good recovery path.
+        self._gw_resumes += 1
+        self._gw_last_resumed_at = time.time()
+        log.info("Gateway session resumed (#%d this run)", self._gw_resumes)
 
     async def on_message(self, message: discord.Message) -> None:  # type: ignore[override]
         # Always ignore self.

--- a/src/clauded/cogs/ops.py
+++ b/src/clauded/cogs/ops.py
@@ -140,6 +140,31 @@ async def health_check(interaction: discord.Interaction) -> None:
             inline=False,
         )
 
+    # #audit(#20): gateway health so an operator can tell a steady bot from a
+    # flapping/reconnecting one (the user's "restarts often" symptom). Shown on
+    # the in-thread success path alongside the other health fields.
+    _lat = getattr(bot, "latency", float("nan"))
+    _latency_str = (
+        f"{_lat * 1000:.0f} ms" if isinstance(_lat, float) and _lat == _lat else "—"
+    )
+    try:
+        _gw_state = (
+            "🟢 ready" if bot.is_ready()
+            else ("🔴 closed" if bot.is_closed() else "🟡 connecting")
+        )
+    except Exception:
+        _gw_state = "—"
+    embed.add_field(name="Gateway", value=_gw_state, inline=True)
+    embed.add_field(name="Latency", value=_latency_str, inline=True)
+    embed.add_field(
+        name="Reconnects",
+        value=(
+            f"{getattr(bot, '_gw_disconnects', 0)} drop / "
+            f"{getattr(bot, '_gw_resumes', 0)} resume"
+        ),
+        inline=True,
+    )
+
     await interaction.response.send_message(embed=embed, ephemeral=True)
 
 

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1647,6 +1647,12 @@ class DiscordRenderer:
                         'num_turns': int(getattr(event, 'num_turns', 0) or 0),
                         'model': getattr(event, 'model', '') or '',
                         'stop_reason': _last_stop_reason,
+                        # #audit(#13): end-of-turn error signals that were
+                        # previously dropped, so a rate-limit / max-turns /
+                        # API-error turn looked like a normal stop to the user.
+                        'is_error': bool(getattr(event, 'is_error', False)),
+                        'subtype': getattr(event, 'subtype', None),
+                        'api_error_status': getattr(event, 'api_error_status', None),
                     }
                     # #182 + #220: pull context-window usage and fold
                     # percentage into stats so the footer can render
@@ -2754,6 +2760,15 @@ class DiscordRenderer:
                     footer_text += ctx_seg
                 if _last_stop_reason and _last_stop_reason != "end_turn":
                     footer_text += f" │ ⚠️ {_last_stop_reason}"
+                # #audit(#13): surface a ResultMessage error terminal so the
+                # user learns WHY a turn ended abnormally instead of seeing "it
+                # just stopped" (rate-limit, error_max_turns, API error, …).
+                # Trigger ONLY on is_error or an ``error*`` subtype — a normal
+                # turn's subtype ("result"/"success") must NOT show 🛑.
+                _subtype = stats.get("subtype") or ""
+                if stats.get("is_error") or _subtype.startswith("error"):
+                    _err_seg = stats.get("api_error_status") or _subtype or "error"
+                    footer_text += f" │ 🛑 {_err_seg}"
 
                 # #211: append a second footer line showing the current
                 # effective permission mode — but ONLY when it's not the

--- a/tests/test_error_footer_and_gateway.py
+++ b/tests/test_error_footer_and_gateway.py
@@ -1,0 +1,130 @@
+"""#audit(#13,#20): end-of-turn error surfacing in the cost footer + gateway
+lifecycle observability (on_disconnect/on_resumed counters + /health fields).
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.conftest import FakeBridge, FakeTarget
+
+
+# ---------------------------------------------------------------------------
+# #13 — ResultMessage error terminal surfaces in the footer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_footer_surfaces_result_error_terminal():
+    """A ResultMessage that ends in error adds a 🛑 <status> segment so the
+    user learns WHY the turn stopped instead of seeing a silent end."""
+    from claude_agent_sdk.types import AssistantMessage, TextBlock, ResultMessage
+    from clauded.discord_renderer import DiscordRenderer
+
+    events = [
+        AssistantMessage(
+            content=[TextBlock(text="partial answer")],
+            model="claude-sonnet-4-5",
+            parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="error_max_turns", duration_ms=100, duration_api_ms=80,
+            is_error=True, num_turns=1, session_id="sess-err",
+            total_cost_usd=0.01, usage={"input_tokens": 100, "output_tokens": 50},
+        ),
+    ]
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+    await renderer.render_response(FakeBridge(events), "hi")
+
+    all_content = " ".join(m.content for m in target._sent if m.content)
+    assert "🛑" in all_content, f"expected error segment; got {all_content!r}"
+    assert "error_max_turns" in all_content
+
+
+@pytest.mark.asyncio
+async def test_footer_no_error_segment_on_success():
+    """A normal turn adds NO 🛑 segment. Uses subtype='result' (the value the
+    real SDK / existing e2e tests use for a good turn) to guard against
+    over-triggering on any non-'success' subtype."""
+    from claude_agent_sdk.types import AssistantMessage, TextBlock, ResultMessage
+    from clauded.discord_renderer import DiscordRenderer
+
+    events = [
+        AssistantMessage(
+            content=[TextBlock(text="all good")],
+            model="claude-sonnet-4-5",
+            parent_tool_use_id=None,
+        ),
+        ResultMessage(
+            subtype="result", duration_ms=100, duration_api_ms=80,
+            is_error=False, num_turns=1, session_id="sess-ok",
+            total_cost_usd=0.01, usage={"input_tokens": 100, "output_tokens": 50},
+        ),
+    ]
+    target = FakeTarget()
+    renderer = DiscordRenderer(target)
+    await renderer.render_response(FakeBridge(events), "hi")
+
+    all_content = " ".join(m.content for m in target._sent if m.content)
+    assert "🛑" not in all_content
+
+
+# ---------------------------------------------------------------------------
+# #20 — gateway lifecycle observability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gateway_listeners_update_counters():
+    from clauded.bot import ClaudedBot
+
+    self_ = MagicMock()
+    self_._gw_disconnects = 0
+    self_._gw_resumes = 0
+    self_._gw_last_disconnect_at = None
+    self_._gw_last_resumed_at = None
+
+    await ClaudedBot.on_disconnect(self_)
+    await ClaudedBot.on_disconnect(self_)
+    await ClaudedBot.on_resumed(self_)
+
+    assert self_._gw_disconnects == 2
+    assert self_._gw_resumes == 1
+    assert self_._gw_last_disconnect_at is not None
+    assert self_._gw_last_resumed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_health_embed_shows_gateway_fields():
+    import discord
+    from clauded.cogs.ops import health_check
+    from clauded.bot import ClaudedBot
+
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.list_sessions = MagicMock(return_value={})
+    bot.session_manager.get_session = MagicMock(return_value=None)
+    bot.project_manager = MagicMock()
+    bot.project_manager._projects = {}
+    bot._start_time = 0
+    bot._claude_version = "1.0"
+    bot._gw_disconnects = 3
+    bot._gw_resumes = 2
+    bot.latency = 0.042  # seconds → 42 ms
+    bot.is_ready = MagicMock(return_value=True)
+
+    interaction = MagicMock()
+    interaction.client = bot
+    interaction.channel = MagicMock(spec=discord.Thread)
+    interaction.channel.id = 1
+    interaction.response.send_message = AsyncMock()
+
+    await health_check.callback(interaction)
+
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    fields = {f.name: f.value for f in embed.fields}
+    assert fields.get("Gateway") == "🟢 ready"
+    assert fields.get("Latency") == "42 ms"
+    assert fields.get("Reconnects") == "3 drop / 2 resume"


### PR DESCRIPTION
Two verified stability-audit findings on **diagnosability** (directly serving the "restarts often / gateway drops" symptom).

### #20 — gateway lifecycle observability
discord.py's internal reconnect loop was **entirely silent**; `/health` showed uptime/sessions but not gateway state, so an operator couldn't tell a healthy bot from a degraded/reconnecting one.
- `on_disconnect` / `on_resumed` listeners → WARNING/INFO log + counters + timestamps (a breadcrumb per gateway transition).
- `/health` gains **Gateway** (🟢 ready / 🟡 connecting / 🔴 closed), **Latency** (heartbeat RTT), **Reconnects** (`N drop / M resume`). Mock-safe accessors so the existing health tests stay green.

### #13 — end-of-turn error surfacing
`ResultMessage.is_error` / `subtype` / `api_error_status` were never read — a turn that ended in a rate-limit, `error_max_turns`, or API error looked like a normal stop. Now captured into `stats`; the footer appends a `🛑 <status>` segment.

> **Self-caught bug:** my first condition (`subtype != "success"`) would have shown 🛑 on *every* normal turn, because the real/successful subtype is `"result"`. Corrected to trigger only on `is_error` or an `error*`-prefixed subtype, and pinned with a `subtype="result"` regression test.

### Tests
New `tests/test_error_footer_and_gateway.py` (4): error footer present on `is_error`, **absent** on a normal `result` turn; listeners bump counters; `/health` renders the gateway fields. Existing footer / permission-mode / refuse-path suites still green (46 passed); live bot PID unchanged.