### PR TITLE
feat(mcp): /mcp reconnect + /mcp toggle — in-place MCP control, no session restart

### DIFF
--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -913,6 +913,28 @@ class ClaudeBridge:
             raise RuntimeError("bridge not active")
         await self._client.stop_task(task_id)
 
+    async def reconnect_mcp_server(self, server_name: str) -> None:
+        """Re-dial a single MCP server in place (no session restart).
+
+        #audit(#14): surfaces ``ClaudeSDKClient.reconnect_mcp_server`` so a
+        failed / needs-auth server (visible in ``/mcp list``) can be retried
+        without recreating the bridge — which would lose conversation context.
+        """
+        if self._client is None or not self._active:
+            raise RuntimeError("bridge not active")
+        await self._client.reconnect_mcp_server(server_name)
+
+    async def toggle_mcp_server(self, server_name: str, enabled: bool) -> None:
+        """Enable/disable a single MCP server in place (reversible mute).
+
+        #audit(#14): surfaces ``ClaudeSDKClient.toggle_mcp_server``. Unlike
+        ``/mcp remove`` (which deletes the entry from ``.mcp.json``) this is a
+        reversible runtime toggle that leaves the stored config intact.
+        """
+        if self._client is None or not self._active:
+            raise RuntimeError("bridge not active")
+        await self._client.toggle_mcp_server(server_name, enabled)
+
     async def stop(self) -> None:
         """Stop the bridge, force-dropping after CLAUDED_BRIDGE_STOP_TIMEOUT (default 30s).
 

--- a/src/clauded/cogs/mcp.py
+++ b/src/clauded/cogs/mcp.py
@@ -322,3 +322,133 @@ async def mcp_remove(interaction: discord.Interaction, name: str) -> None:
         await interaction.response.send_message(
             f"\u274c MCP server `{name}` not found.", ephemeral=True
         )
+
+
+# ---------------------------------------------------------------------------
+# #audit(#14): in-place reconnect / toggle of a single MCP server via the SDK
+# control-plane \u2014 no session restart (which would lose conversation context).
+# Both operate on the LIVE bridge, so they require an active session (an active
+# session already implies a bound channel); the "no active session" guard is
+# the meaningful precondition, mirroring /mcp list's Path A.
+# ---------------------------------------------------------------------------
+
+
+async def _mcp_name_autocomplete(
+    interaction: discord.Interaction, current: str
+) -> list[app_commands.Choice[str]]:
+    """Suggest server names from the live session's ``get_mcp_status``."""
+    from ..bot import ClaudedBot
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        return []
+    sid = interaction.channel_id
+    bridge = bot.session_manager.get_session(sid) if sid is not None else None
+    if bridge is None or not getattr(bridge, "is_active", False):
+        return []
+    try:
+        status = await asyncio.wait_for(bridge.get_mcp_status(), timeout=5)
+    except Exception:
+        return []
+    servers = (status or {}).get("mcpServers") or []
+    cur = (current or "").lower()
+    out: list[app_commands.Choice[str]] = []
+    for s in servers:
+        if not isinstance(s, dict):
+            continue
+        nm = str(s.get("name") or "")
+        if nm and cur in nm.lower():
+            out.append(app_commands.Choice(name=nm, value=nm))
+        if len(out) >= 25:
+            break
+    return out
+
+
+def _resolve_live_bridge(interaction: discord.Interaction):
+    """Return the active bridge for this channel, or ``None``."""
+    from ..bot import ClaudedBot
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        return None
+    sid = interaction.channel_id
+    bridge = bot.session_manager.get_session(sid) if sid is not None else None
+    if bridge is None or not getattr(bridge, "is_active", False):
+        return None
+    return bridge
+
+
+@mcp_group.command(
+    name="reconnect",
+    description="Re-dial a failed/needs-auth MCP server without restarting the session",
+)
+@app_commands.describe(name="Server name (see /mcp list)")
+@app_commands.autocomplete(name=_mcp_name_autocomplete)
+async def mcp_reconnect(interaction: discord.Interaction, name: str) -> None:
+    from ..bot import ClaudedBot
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    bridge = _resolve_live_bridge(interaction)
+    if bridge is None:
+        await interaction.response.send_message(
+            "\u274c No active session in this channel \u2014 send a message to start "
+            "one, then the CLI can re-dial the server in place.",
+            ephemeral=True,
+        )
+        return
+    await interaction.response.defer(ephemeral=True)
+    try:
+        await asyncio.wait_for(bridge.reconnect_mcp_server(name), timeout=30)
+    except Exception as exc:
+        log.warning("/mcp reconnect failed for %s: %r", name, exc)
+        await interaction.followup.send(
+            f"\u274c Reconnect failed: `{exc}`", ephemeral=True
+        )
+        return
+    embed = discord.Embed(
+        title=f"\U0001f501 Reconnecting `{name}`",
+        description="Asked the CLI to re-dial this MCP server. "
+        "Run `/mcp list` to confirm its status.",
+        color=COLOR_INFO,
+    )
+    await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+@mcp_group.command(
+    name="toggle",
+    description="Enable or disable an MCP server in place (reversible; keeps .mcp.json)",
+)
+@app_commands.describe(name="Server name", enabled="True to enable, False to disable")
+@app_commands.autocomplete(name=_mcp_name_autocomplete)
+async def mcp_toggle(
+    interaction: discord.Interaction, name: str, enabled: bool
+) -> None:
+    from ..bot import ClaudedBot
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    bridge = _resolve_live_bridge(interaction)
+    if bridge is None:
+        await interaction.response.send_message(
+            "\u274c No active session in this channel \u2014 send a message to start one first.",
+            ephemeral=True,
+        )
+        return
+    await interaction.response.defer(ephemeral=True)
+    try:
+        await asyncio.wait_for(bridge.toggle_mcp_server(name, enabled), timeout=30)
+    except Exception as exc:
+        log.warning("/mcp toggle failed for %s (enabled=%s): %r", name, enabled, exc)
+        await interaction.followup.send(
+            f"\u274c Toggle failed: `{exc}`", ephemeral=True
+        )
+        return
+    state = "enabled" if enabled else "disabled"
+    icon = "\u2705" if enabled else "\u26aa"
+    embed = discord.Embed(
+        title=f"{icon} MCP server `{name}` {state}",
+        description="Reversible \u2014 run `/mcp toggle` again to flip it back.",
+        color=COLOR_INFO,
+    )
+    await interaction.followup.send(embed=embed, ephemeral=True)

--- a/tests/test_mcp_reconnect_toggle.py
+++ b/tests/test_mcp_reconnect_toggle.py
@@ -1,0 +1,112 @@
+"""#audit(#14): /mcp reconnect + /mcp toggle — in-place MCP server control via
+the SDK, no session restart. Covers the ClaudeBridge wrappers and the cog
+commands (live-bridge dispatch + no-session refusal)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from clauded.claude_bridge import ClaudeBridge
+from clauded.config import Config
+from clauded.session_config import SessionConfig
+
+
+def _cfg() -> Config:
+    return Config(
+        discord_bot_token="x",
+        claude_model=None,
+        claude_permission_mode="default",
+        projects_root="/tmp",
+    )
+
+
+def _active_bridge() -> ClaudeBridge:
+    b = ClaudeBridge("/tmp", _cfg(), SessionConfig())
+    b._client = MagicMock()
+    b._client.reconnect_mcp_server = AsyncMock()
+    b._client.toggle_mcp_server = AsyncMock()
+    b._active = True
+    return b
+
+
+# ---- bridge wrappers ----
+
+
+@pytest.mark.asyncio
+async def test_bridge_reconnect_delegates_to_client():
+    b = _active_bridge()
+    await b.reconnect_mcp_server("srv")
+    b._client.reconnect_mcp_server.assert_awaited_once_with("srv")
+
+
+@pytest.mark.asyncio
+async def test_bridge_toggle_delegates_to_client():
+    b = _active_bridge()
+    await b.toggle_mcp_server("srv", False)
+    b._client.toggle_mcp_server.assert_awaited_once_with("srv", False)
+
+
+@pytest.mark.asyncio
+async def test_bridge_mcp_ops_raise_when_inactive():
+    b = ClaudeBridge("/tmp", _cfg(), SessionConfig())  # never started
+    with pytest.raises(RuntimeError):
+        await b.reconnect_mcp_server("srv")
+    with pytest.raises(RuntimeError):
+        await b.toggle_mcp_server("srv", True)
+
+
+# ---- cog commands ----
+
+
+def _interaction(channel_id: int = 42) -> MagicMock:
+    interaction = MagicMock()
+    interaction.channel_id = channel_id
+    interaction.response.defer = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _bot_with_bridge(bridge) -> MagicMock:
+    from clauded.bot import ClaudedBot
+    bot = MagicMock(spec=ClaudedBot)
+    bot.session_manager = MagicMock()
+    bot.session_manager.get_session = MagicMock(return_value=bridge)
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_mcp_reconnect_calls_bridge_on_live_session():
+    from clauded.cogs.mcp import mcp_reconnect
+    bridge = MagicMock()
+    bridge.is_active = True
+    bridge.reconnect_mcp_server = AsyncMock()
+    interaction = _interaction()
+    interaction.client = _bot_with_bridge(bridge)
+    await mcp_reconnect.callback(interaction, "srv")
+    bridge.reconnect_mcp_server.assert_awaited_once_with("srv")
+
+
+@pytest.mark.asyncio
+async def test_mcp_toggle_calls_bridge_on_live_session():
+    from clauded.cogs.mcp import mcp_toggle
+    bridge = MagicMock()
+    bridge.is_active = True
+    bridge.toggle_mcp_server = AsyncMock()
+    interaction = _interaction()
+    interaction.client = _bot_with_bridge(bridge)
+    await mcp_toggle.callback(interaction, "srv", False)
+    bridge.toggle_mcp_server.assert_awaited_once_with("srv", False)
+
+
+@pytest.mark.asyncio
+async def test_mcp_reconnect_refuses_without_session():
+    from clauded.cogs.mcp import mcp_reconnect
+    interaction = _interaction()
+    interaction.client = _bot_with_bridge(None)  # no active session
+    await mcp_reconnect.callback(interaction, "srv")
+    # Refuses via response.send_message, never defers into a control-plane call.
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "No active session" in msg


### PR DESCRIPTION
Verified command-gap finding **#14** — and the **`mcp reload`** you explicitly asked for.

**Before:** when a server showed 🔴 failed / 🔒 needs-auth in `/mcp list`, the only recovery was stop+start a fresh session (**losing conversation context**). And `/mcp remove` was the only way to mute a server — destructively, deleting it from `.mcp.json`.

The SDK already exposes `ClaudeSDKClient.reconnect_mcp_server(name)` and `toggle_mcp_server(name, enabled)`; they were never wrapped.

### Added
- **Bridge wrappers** `reconnect_mcp_server` / `toggle_mcp_server` (mirror `stop_task`; raise if inactive).
- **`/mcp reconnect <name>`** — re-dial a failed/needs-auth server in place, context preserved.
- **`/mcp toggle <name> <enabled>`** — reversible enable/disable that keeps `.mcp.json`.
- Both resolve the live bridge (like `/mcp list` Path A), have **name autocomplete** from `get_mcp_status`, and refuse cleanly when there's no active session.

### Tests
New `tests/test_mcp_reconnect_toggle.py` (6): bridge wrappers delegate to the client and raise when inactive; commands dispatch to the live bridge and refuse without a session. Existing `/mcp` + Group-A suites unchanged; live bot PID unchanged.

> The SDK calls return `None`, so the real effect on a failed/needs-auth server is best confirmed live with `/mcp list` after — noted in the reconnect reply.