### PR TITLE
fix(bridge): raise SDK max_buffer_size to 10MB so a >1MB JSON frame can't kill the turn

### DIFF
--- a/src/clauded/claude_bridge.py
+++ b/src/clauded/claude_bridge.py
@@ -663,6 +663,14 @@ class ClaudeBridge:
             hooks=hooks,
             # Feature #61: partial message streaming for token-level deltas
             include_partial_messages=True,
+            # #audit(live-log): the SDK frames stdout JSON line-by-line with a
+            # 1MB default buffer; a single large frame (a big tool_result or an
+            # aggregated partial-message event) overflows it and the framing
+            # error tears the whole turn down (observed 2026-07-17). Raise to
+            # 10MB (env CLAUDED_MAX_BUFFER_SIZE), matching stream_logger's cap.
+            max_buffer_size=int(
+                os.environ.get("CLAUDED_MAX_BUFFER_SIZE", str(10 * 1024 * 1024))
+            ),
             settings=self._settings,
             # R4 (#117): setting_sources defaults to [] in v1.10 SDK (no
             # auto-load); pass all three explicitly to preserve v1.x

--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -2689,7 +2689,20 @@ class DiscordRenderer:
                     log.debug("C3 partial-delivery notice failed", exc_info=True)
                 # Don't re-raise — caller (_render_with_retry) won't stop_session.
                 return
-            log.exception("Renderer fatal error; tearing down bridge")
+            if "buffer size" in str(exc) or "exceeded maximum buffer" in str(exc):
+                # #audit(live-log): a single SDK stdout JSON frame exceeded
+                # max_buffer_size. The bridge is already torn down by
+                # send_message's except path, so log this distinctly (NOT a
+                # generic "fatal") for diagnosability, then fall through to the
+                # normal retry flow. Raising CLAUDED_MAX_BUFFER_SIZE (now 10MB)
+                # prevents the vast majority of these.
+                log.warning(
+                    "Renderer: SDK buffer overflow on a single JSON frame (%s); "
+                    "turn interrupted — bridge recreates on retry",
+                    type(exc).__name__,
+                )
+            else:
+                log.exception("Renderer fatal error; tearing down bridge")
             # Best-effort: clean up the live cursor. Don't try to surface a
             # plain-text error here — callers (bot.py) wrap render_response
             # in the crash-notification flow which posts a richer embed

--- a/tests/test_claude_bridge.py
+++ b/tests/test_claude_bridge.py
@@ -330,6 +330,35 @@ async def test_setting_sources_includes_user_project_local(monkeypatch, cfg):
     assert captured_kwargs[-1].get("setting_sources") == ["user", "project", "local"]
 
 
+@pytest.mark.asyncio
+async def test_max_buffer_size_is_raised_from_1mb_default(monkeypatch, cfg):
+    """#audit(live-log): the bridge must override the SDK's 1MB default stdout
+    buffer, or a single large JSON frame (big tool_result / aggregated
+    partial-message event) overflows and tears the whole turn down."""
+    captured: list[dict[str, Any]] = []
+
+    class FakeOptions:
+        def __init__(self, **kwargs):
+            captured.append(kwargs)
+            self.__dict__.update(kwargs)
+
+    class FakeClient:
+        def __init__(self, options=None):
+            pass
+
+        async def connect(self, prompt=None):
+            pass
+
+    monkeypatch.setattr("clauded.claude_bridge.ClaudeAgentOptions", FakeOptions)
+    monkeypatch.setattr("clauded.claude_bridge.ClaudeSDKClient", FakeClient)
+
+    bridge = ClaudeBridge(project_path="/tmp/p", config=cfg)
+    await bridge.start()
+
+    assert captured, "ClaudeAgentOptions was not constructed"
+    assert captured[-1].get("max_buffer_size") == 10 * 1024 * 1024
+
+
 # ---------------------------------------------------------------------------
 # Explicit cli_path resolution (#119, R6)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Live-log bug** (CONFIRMED, `clauded.log` 2026-07-17 21:06). The bridge built `ClaudeAgentOptions` without `max_buffer_size`, so the SDK's **1MB default** applied. A single stdout JSON line >1MB (big `tool_result`, or an aggregated partial-message event — `include_partial_messages=True` makes that likely) made the SDK line-framer raise `JSON message exceeded maximum buffer size of 1048576 bytes`; `send_message` tore the bridge down and the turn aborted.

- `claude_bridge.py`: pass `max_buffer_size` (env `CLAUDED_MAX_BUFFER_SIZE`, default **10MB**, matching `stream_logger`'s cap). Prevents the overflow for essentially all real frames.
- `discord_renderer.py`: the bridge is already torn down by `send_message` before the renderer sees the error, so the render loop can't keep it alive — but it now logs the overflow **distinctly** (not a generic "fatal") and still falls through to the existing retry-button flow.

Test: asserts `max_buffer_size` is raised off the 1MB default. Bridge/SDK suites green; live bot PID unchanged.