### PR TITLE
fix(cogs): swallow expired-interaction 10062 via CommandTree error handler + defer /project bind

### DIFF
--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -631,6 +631,10 @@ class ClaudedBot(commands.Bot):
         # #292 S3: /workflow group (list/kill/detail).
         from .cogs.workflow import workflow_group
 
+        # #audit(live-log): register a tree-wide error handler so an expired
+        # interaction (10062) or any command raise is handled gracefully
+        # instead of escalating to a CommandInvokeError traceback in the logs.
+        self.tree.error(self._on_app_command_error)
         self.tree.add_command(project_group)
         self.tree.add_command(session_group)
         self.tree.add_command(cost_group)
@@ -826,6 +830,33 @@ class ClaudedBot(commands.Bot):
         self._gw_resumes += 1
         self._gw_last_resumed_at = time.time()
         log.info("Gateway session resumed (#%d this run)", self._gw_resumes)
+
+    async def _on_app_command_error(
+        self, interaction: discord.Interaction, error: Exception
+    ) -> None:
+        # #audit(live-log): without a tree-wide error handler, any slash command
+        # that raises — most commonly an EXPIRED interaction (discord.NotFound
+        # code 10062, when a busy event loop misses the 3s ACK window) —
+        # escalates to a full CommandInvokeError traceback in the logs (13 seen).
+        # Swallow the expired case at WARNING; surface anything else as a
+        # friendly ephemeral message instead of a stack trace.
+        orig = getattr(error, "original", error)
+        cmd = getattr(getattr(interaction, "command", None), "qualified_name", "?")
+        if isinstance(orig, discord.NotFound) and getattr(orig, "code", None) == 10062:
+            log.warning("Slash interaction expired before response (10062); ignoring: /%s", cmd)
+            return
+        log.error("Slash command /%s failed", cmd, exc_info=error)
+        try:
+            if interaction.response.is_done():
+                await interaction.followup.send(
+                    "❌ Command failed — please try again.", ephemeral=True
+                )
+            else:
+                await interaction.response.send_message(
+                    "❌ Command failed — please try again.", ephemeral=True
+                )
+        except Exception:
+            log.debug("failed to send app-command error notice", exc_info=True)
 
     async def on_message(self, message: discord.Message) -> None:  # type: ignore[override]
         # Always ignore self.

--- a/src/clauded/cogs/project.py
+++ b/src/clauded/cogs/project.py
@@ -39,13 +39,17 @@ async def project_bind(interaction: discord.Interaction, path: str) -> None:
         )
         return
 
+    # #audit(live-log): ACK within the 3s interaction window BEFORE the bind
+    # disk write, so a busy event loop can't let the token expire (10062)
+    # between here and the reply.
+    await interaction.response.defer(ephemeral=True)
     try:
         stored = bot.project_manager.bind(binding_id, path, guild_id=interaction.guild_id)
     except ValueError as exc:
-        await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
+        await interaction.followup.send(f"❌ {exc}", ephemeral=True)
         return
 
-    await interaction.response.send_message(
+    await interaction.followup.send(
         f"✅ Bound this channel to `{stored}`", ephemeral=True
     )
 

--- a/tests/test_tree_error_handler.py
+++ b/tests/test_tree_error_handler.py
@@ -1,0 +1,63 @@
+"""#audit(live-log): the CommandTree error handler must swallow expired
+interactions (discord.NotFound 10062) at WARNING instead of letting them
+escalate to full CommandInvokeError tracebacks, and surface other errors as a
+friendly ephemeral message."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from clauded.bot import ClaudedBot
+
+
+def _interaction(*, is_done: bool, cmd: str = "project bind") -> MagicMock:
+    interaction = MagicMock()
+    interaction.command = MagicMock()
+    interaction.command.qualified_name = cmd
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=is_done)
+    interaction.response.send_message = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _expired_10062() -> discord.NotFound:
+    resp = MagicMock()
+    resp.status = 404
+    resp.reason = "Not Found"
+    err = discord.NotFound(resp, {"code": 10062, "message": "Unknown interaction"})
+    assert err.code == 10062  # sanity: discord parsed the code
+    return err
+
+
+@pytest.mark.asyncio
+async def test_tree_error_swallows_expired_interaction_10062():
+    interaction = _interaction(is_done=True)
+    # Must NOT raise, and must NOT try to send a user-facing message.
+    await ClaudedBot._on_app_command_error(MagicMock(), interaction, _expired_10062())
+    interaction.followup.send.assert_not_awaited()
+    interaction.response.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tree_error_reports_other_errors_friendly():
+    interaction = _interaction(is_done=False, cmd="session info")
+    await ClaudedBot._on_app_command_error(
+        MagicMock(), interaction, RuntimeError("boom")
+    )
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "failed" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_tree_error_uses_followup_when_response_done():
+    interaction = _interaction(is_done=True, cmd="session info")
+    await ClaudedBot._on_app_command_error(
+        MagicMock(), interaction, RuntimeError("boom")
+    )
+    interaction.followup.send.assert_awaited_once()
+    interaction.response.send_message.assert_not_awaited()


### PR DESCRIPTION
**Live-log bug** (CONFIRMED). The bot registered **no tree error handler**, so every slash command that raised — most commonly an **expired interaction** (`discord.NotFound` code **10062**, when a busy event loop missed Discord's 3s ACK window) — escalated to a full `CommandInvokeError` traceback (**13** in the log).

- `bot.py`: register `self.tree.error(self._on_app_command_error)`. Swallows 10062 at WARNING; surfaces any other command error as a friendly ephemeral message (via `followup` if already responded) instead of a stack trace.
- `cogs/project.py`: `/project bind` now **defers (ACKs) before** its disk write, so the token can't expire between the write and the reply under load.

Tests: new `tests/test_tree_error_handler.py` — 10062 swallowed (no user message, no raise); other errors get a friendly reply (response vs followup by `is_done`). Binding suite green; live bot PID unchanged.