### PR TITLE
fix(renderer): stop 274 "ToolResultBlock no-matched" WARNING spam for standalone-rendered tools

### DIFF
--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -2448,13 +2448,23 @@ class DiscordRenderer:
                                     # ("branch forgot to set flag").
                                     matched = True
                                     break
-                                if not matched:
+                                if not matched and tool_id not in tool_msgs:
                                     # #226: rolling-log line for this tool
                                     # was evicted (kept only last 15) or
                                     # the event arrived out of order.
                                     # Logged for #223 / #224 diagnostic
                                     # epic; downstream guards on `is_medium
                                     # = False` make this a safe no-op.
+                                    # #audit(live-log): gate on `tool_id not in
+                                    # tool_msgs`. Tools rendered as their OWN
+                                    # standalone embed (TodoWrite / WebSearch /
+                                    # WebFetch / Grep / Glob / …, tracked in
+                                    # tool_msgs) never append a 🔄 rolling-log
+                                    # line by design, so their result no-matching
+                                    # here is EXPECTED, not a diagnostic — this
+                                    # was ~264/274 of these warnings (pure log
+                                    # spam, no lost data). Only a GENUINE
+                                    # eviction / out-of-order event still warns.
                                     log.warning(
                                         "ToolResultBlock no-matched rolling-log line; "
                                         "tool_id=%s name=%s alias=%r rolling_log_len=%d "

--- a/tests/test_tool_result_no_match_warning.py
+++ b/tests/test_tool_result_no_match_warning.py
@@ -1,0 +1,54 @@
+"""#audit(live-log): the "ToolResultBlock no-matched rolling-log line" warning
+(274 log-spam lines) must be suppressed for tools rendered as their OWN
+standalone embed (tracked in tool_msgs) — those never append a rolling-log line
+by design — while STILL firing for a genuine eviction / out-of-order no-match.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import FakeBridge, FakeTarget
+
+_LOGGER = "clauded.discord_renderer"
+
+
+def _result(session="s"):
+    from claude_agent_sdk.types import ResultMessage
+    return ResultMessage(
+        subtype="result", duration_ms=1, duration_api_ms=1, is_error=False,
+        num_turns=1, session_id=session, total_cost_usd=0.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_standalone_tool_result_no_warning(caplog):
+    """A standalone-rendered tool (TodoWrite → tool_msgs) whose result has no
+    rolling-log line must NOT log the no-match warning (was ~264/274 of them)."""
+    from claude_agent_sdk.types import AssistantMessage, ToolUseBlock, ToolResultBlock
+    from clauded.discord_renderer import DiscordRenderer
+
+    events = [
+        AssistantMessage(
+            content=[ToolUseBlock(
+                id="todo-1", name="TodoWrite",
+                input={"todos": [{"content": "do x", "status": "pending"}]},
+            )],
+            model="m", parent_tool_use_id=None,
+        ),
+        AssistantMessage(
+            content=[ToolResultBlock(tool_use_id="todo-1", content="ok", is_error=False)],
+            model="m", parent_tool_use_id=None,
+        ),
+        _result(),
+    ]
+    renderer = DiscordRenderer(FakeTarget())
+    with caplog.at_level("WARNING", logger=_LOGGER):
+        await renderer.render_response(FakeBridge(events), "todo")
+    assert "no-matched rolling-log line" not in caplog.text
+
+
+# Note: the complementary "a GENUINE eviction still warns" property is
+# preserved by construction — the fix only ADDS `and tool_id not in tool_msgs`
+# to the warning guard, so it can never suppress a warning for a rolling-log
+# tool (Bash/Write/… which are never in tool_msgs). Reproducing a real eviction
+# needs >15 tool lines, which isn't worth the test weight here.


### PR DESCRIPTION
**Live-log finding** — 274 `ToolResultBlock no-matched rolling-log line` WARNINGs (largest non-network signal).

The workflow's verifier **corrected the finding's root cause**: ~264/274 are not eviction/parallelism — they're tools rendered as their **own standalone embed** (TodoWrite 186, Grep, WebFetch, WebSearch, Glob, …) that by design never append a `🔄 <name>` rolling-log line, so their result always fails the reverse-scan and warns. **No data lost** (the standalone embed already shows the tool) — pure log spam.

### Surgical fix
Gate the warning on `tool_id not in tool_msgs`. `tool_msgs` is populated **only** by standalone-rendered tools, so this suppresses the by-design noise while **still** warning for a genuine eviction/out-of-order event (rolling-log tools like Bash/Write are never in `tool_msgs`). One condition added — **no change to any rendering/numbering path**.

> Deliberately **not** the proposed `tool_id`→line-index correlation rewrite: that touches the giant render state-machine + the #187 numbering invariant for a cosmetic, no-data-loss issue — not worth the regression risk.

### Test
New `tests/test_tool_result_no_match_warning.py` drives a real TodoWrite render and asserts (caplog) the warning is suppressed. All 4 render suites (82 tests) green; live bot PID unchanged.