### PR TITLE
feat(bot): gateway-connectivity watchdog — freeze heartbeat once off-gateway past a reconnect budget (#9)

### DIFF
--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -6,6 +6,14 @@ RESTART_COUNTER="$HOME/Library/Caches/clauded/restart-count"
 ALERTS_LOG="$HOME/Library/Logs/clauded/alerts.log"
 HEALTHCHECK_LOG="$HOME/Library/Logs/clauded/healthcheck.log"
 STALE_THRESHOLD_SECS=120
+# NOTE(#9): the bot ALSO freezes this heartbeat (stops refreshing mtime) when it
+# has been continuously off the Discord gateway longer than
+# CLAUDED_GATEWAY_BUDGET_SECS (default 600s) with no turn in flight — a wedged
+# reconnect loop keeps the event loop alive (so mtime would otherwise stay
+# fresh) but is functionally dead. That case reaches the stale branch below and
+# kickstarts, same as a wedged loop / OOM. Active-turn leniency
+# (ACTIVE_TURN_THRESHOLD_SECS) still applies because the bot keeps writing while
+# a turn is in flight.
 # T2-D: longer grace window while a turn is in flight. The bot writes the
 # in-flight-turn count as the heartbeat file CONTENT; a transient event-loop
 # stall UNDER a turn (memory-pressure thrash) then gets this bigger budget

--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -192,6 +192,23 @@ AUTO_CRASH_COOLDOWN_S = 300
 _HEARTBEAT_PATH = _CACHE_DIR / "heartbeat"
 
 
+def _gateway_budget_secs() -> float:
+    """#audit(#9): how long the gateway may stay CONTINUOUSLY down before the
+    heartbeat is allowed to go stale so the external watchdog restarts us.
+
+    Must exceed discord.py's ExponentialBackoff single-sleep for common
+    reconnect storms (observed up to ~384s; theoretical 2^10=1024s) so brief
+    storms that self-heal are NOT killed, while a permanently-wedged reconnect
+    IS. 600s is a conservative middle; overridable for tuning/tests.
+    """
+    raw = os.environ.get("CLAUDED_GATEWAY_BUDGET_SECS", "600")
+    try:
+        v = float(raw)
+        return v if v > 0 else 600.0
+    except ValueError:
+        return 600.0
+
+
 def _touch_heartbeat() -> None:
     """Refresh ``_HEARTBEAT_PATH`` mtime so the external healthcheck sees us alive.
 
@@ -405,6 +422,12 @@ class ClaudedBot(commands.Bot):
         self._gw_resumes: int = 0
         self._gw_last_disconnect_at: float | None = None
         self._gw_last_resumed_at: float | None = None
+        # #audit(#9): wall time of the FIRST disconnect not yet followed by a
+        # resume/ready; None means "gateway believed up". _heartbeat_task stops
+        # refreshing the heartbeat once we've been off-gateway longer than
+        # _gateway_budget_secs() so a reconnect-storm wedge (a false-alive to
+        # the event-loop-only heartbeat) finally gets restarted.
+        self._gw_down_since: float | None = None
         # T1-B: live per-agent roster for the workflow/subagent UX, keyed by
         # thread_id → agent_id → {type, tool, started}. Fed by the
         # SubagentStart / PreToolUse / SubagentStop hooks (all of which fire
@@ -767,7 +790,32 @@ class ClaudedBot(commands.Bot):
         # goes stale, and the watchdog kickstarts (a self-inflicted restart).
         # _write_heartbeat_state already swallows OSError; guard anything else.
         try:
-            _write_heartbeat_state(self._active_turns)
+            # #audit(#9): FREEZE the heartbeat (return without writing → mtime
+            # ages past health-check.sh's STALE_THRESHOLD → watchdog restarts)
+            # ONLY when the gateway has been continuously down past the reconnect
+            # budget AND no turn is in flight. Pre-login (_gw_down_since is None)
+            # and brief blips (within budget) refresh exactly as before, so the
+            # pre-login window and healthy RESUMEs are never false-killed.
+            # Scope: catches a reconnect-STORM wedge (where on_disconnect fired),
+            # NOT a silent poll_event hang (no disconnect → _gw_down_since None).
+            # While a turn is in flight we keep writing (T2-D resume-bug safety),
+            # so a dead-gateway + stuck-turn defers restart until _active_turns
+            # returns to 0 — an accepted trade-off.
+            off = self._gw_down_since
+            budget = _gateway_budget_secs()
+            if (
+                off is not None
+                and (time.time() - off) > budget
+                and self._active_turns <= 0
+            ):
+                log.warning(
+                    "gateway down %.0fs > budget %.0fs and no active turn; "
+                    "freezing heartbeat so the watchdog restarts (disc=%d resume=%d)",
+                    time.time() - off, budget,
+                    self._gw_disconnects, self._gw_resumes,
+                )
+            else:
+                _write_heartbeat_state(self._active_turns)
         except Exception:
             log.exception("heartbeat write failed (loop kept alive)")
 
@@ -795,6 +843,13 @@ class ClaudedBot(commands.Bot):
     async def on_ready(self) -> None:  # type: ignore[override]
         user = self.user
         log.info("Bot online as %s (id=%s)", user, getattr(user, "id", "?"))
+        # #audit(#9): on_ready fires after a fresh IDENTIFY (session invalidated
+        # → reconnect — the observed recovery path for the 2026-07-19 DNS storm,
+        # NOT on_resumed). Without clearing the gate here, a re-identify recovery
+        # would look like a permanent outage and self-kill. Record recovery
+        # FIRST — before the per-guild slash-sync loop below, which can raise.
+        self._gw_last_resumed_at = time.time()
+        self._gw_down_since = None
         # #185: sync slash commands per-guild on first on_ready. Guarded
         # idempotency (``self._slash_synced``) so reconnect-driven
         # re-fires don't waste Discord rate-limit budget. Global sync
@@ -823,12 +878,19 @@ class ClaudedBot(commands.Bot):
         # and the logs (the user's "restarts often / gateway drops" symptom).
         self._gw_disconnects += 1
         self._gw_last_disconnect_at = time.time()
+        # #audit(#9): anchor to the FIRST unrecovered disconnect. on_disconnect
+        # fires on EVERY failed reconnect iteration, so the `is None` guard is
+        # load-bearing — without it each backoff step resets the clock and the
+        # budget never elapses.
+        if self._gw_down_since is None:
+            self._gw_down_since = self._gw_last_disconnect_at
         log.warning("Gateway disconnected (#%d this run)", self._gw_disconnects)
 
     async def on_resumed(self) -> None:  # type: ignore[override]
         # Session RESUMED (not a full re-identify) — the good recovery path.
         self._gw_resumes += 1
         self._gw_last_resumed_at = time.time()
+        self._gw_down_since = None  # #audit(#9): recovered via RESUME
         log.info("Gateway session resumed (#%d this run)", self._gw_resumes)
 
     async def _on_app_command_error(

--- a/tests/test_error_footer_and_gateway.py
+++ b/tests/test_error_footer_and_gateway.py
@@ -128,3 +128,47 @@ async def test_health_embed_shows_gateway_fields():
     assert fields.get("Gateway") == "🟢 ready"
     assert fields.get("Latency") == "42 ms"
     assert fields.get("Reconnects") == "3 drop / 2 resume"
+
+
+# ---------------------------------------------------------------------------
+# #9 — _gw_down_since wiring (the gateway-connectivity watchdog gate)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gw_down_since_anchors_first_disconnect_then_clears_on_resume():
+    from clauded.bot import ClaudedBot
+
+    self_ = MagicMock()
+    self_._gw_disconnects = 0
+    self_._gw_resumes = 0
+    self_._gw_last_disconnect_at = None
+    self_._gw_last_resumed_at = None
+    self_._gw_down_since = None
+
+    await ClaudedBot.on_disconnect(self_)
+    first = self_._gw_down_since
+    assert first is not None
+    # A 2nd disconnect (reconnect-storm iteration) must NOT re-anchor the clock —
+    # else the budget never elapses.
+    await ClaudedBot.on_disconnect(self_)
+    assert self_._gw_down_since == first
+    # RESUME clears the gate.
+    await ClaudedBot.on_resumed(self_)
+    assert self_._gw_down_since is None
+
+
+@pytest.mark.asyncio
+async def test_on_ready_clears_gw_down_since_fresh_identify_recovery():
+    from clauded.bot import ClaudedBot
+
+    self_ = MagicMock()
+    self_._gw_down_since = 123.0
+    self_._gw_last_resumed_at = None
+    self_.guilds = []          # empty → per-guild slash-sync loop no-ops
+    self_._slash_synced = set()
+    self_.user = MagicMock()
+
+    await ClaudedBot.on_ready(self_)
+    assert self_._gw_down_since is None
+    assert self_._gw_last_resumed_at is not None

--- a/tests/test_heartbeat_gateway_gate.py
+++ b/tests/test_heartbeat_gateway_gate.py
@@ -1,0 +1,70 @@
+"""#audit(#9): the heartbeat freezes (stops refreshing mtime) once the gateway
+has been continuously down past the reconnect budget with no turn in flight, so
+the external watchdog restarts a reconnect-storm-wedged bot — while brief blips,
+the pre-login window, and active turns keep refreshing (no false kills).
+
+Drives the loop body directly via ClaudedBot._heartbeat_task.coro(mock_self) and
+patches _write_heartbeat_state, so nothing touches the real heartbeat file or a
+live gateway.
+"""
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from clauded.bot import ClaudedBot
+
+
+def _self(*, down_since, active_turns):
+    s = MagicMock()
+    s._gw_down_since = down_since
+    s._active_turns = active_turns
+    s._gw_disconnects = 1
+    s._gw_resumes = 0
+    return s
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_freezes_past_budget_no_active_turn(monkeypatch):
+    monkeypatch.setenv("CLAUDED_GATEWAY_BUDGET_SECS", "600")
+    s = _self(down_since=time.time() - 601, active_turns=0)
+    with patch("clauded.bot._write_heartbeat_state") as w:
+        await ClaudedBot._heartbeat_task.coro(s)
+        w.assert_not_called()  # frozen → mtime ages → watchdog restarts
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_writes_within_budget(monkeypatch):
+    monkeypatch.setenv("CLAUDED_GATEWAY_BUDGET_SECS", "600")
+    s = _self(down_since=time.time() - 100, active_turns=0)  # brief blip
+    with patch("clauded.bot._write_heartbeat_state") as w:
+        await ClaudedBot._heartbeat_task.coro(s)
+        w.assert_called_once()  # within budget → refresh normally
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_writes_past_budget_when_active_turn(monkeypatch):
+    monkeypatch.setenv("CLAUDED_GATEWAY_BUDGET_SECS", "600")
+    s = _self(down_since=time.time() - 601, active_turns=1)
+    with patch("clauded.bot._write_heartbeat_state") as w:
+        await ClaudedBot._heartbeat_task.coro(s)
+        w.assert_called_once_with(1)  # active turn keeps writing (T2-D safety)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_writes_pre_login_down_since_none():
+    s = _self(down_since=None, active_turns=0)  # pre-login / healthy
+    with patch("clauded.bot._write_heartbeat_state") as w:
+        await ClaudedBot._heartbeat_task.coro(s)
+        w.assert_called_once()  # gate open → always refresh
+
+
+@pytest.mark.asyncio
+async def test_budget_env_override_respected(monkeypatch):
+    monkeypatch.setenv("CLAUDED_GATEWAY_BUDGET_SECS", "60")
+    s = _self(down_since=time.time() - 90, active_turns=0)  # >60s budget
+    with patch("clauded.bot._write_heartbeat_state") as w:
+        await ClaudedBot._heartbeat_task.coro(s)
+        w.assert_not_called()  # env-lowered budget → frozen


### PR DESCRIPTION
**Finding #9** (user-selected). The heartbeat proved only that the asyncio loop ticks, not that the bot is on the Discord gateway. discord.py's reconnect loop runs on the same loop, so during a wedged/looping reconnect the heartbeat stayed fresh and the watchdog **never restarted an off-gateway bot** — the silent complement of "restarts often" (live log 2026-07-19: a ~10-min DNS storm, backoff to 384s, recovered only by luck).

### Approach
Track `_gw_down_since` (first disconnect not yet followed by recovery). When the gateway has been continuously down past `CLAUDED_GATEWAY_BUDGET_SECS` (default **600s**) **and no turn is in flight**, `_heartbeat_task` returns **without writing** → mtime ages past the existing 120s `STALE_THRESHOLD` → the **unchanged** `health-check.sh` kickstarts. Reuses the whole existing watchdog; health-check gets a comment only.

### Regression-safe by construction
- **Pre-login window** preserved (`_gw_down_since` starts `None` → gate open).
- **Brief blips / healthy RESUMEs** preserved (budget 600s > observed 384s max backoff; `on_resumed` **and** `on_ready` clear the gate — `on_ready` is the observed fresh-IDENTIFY recovery path; RESUME-only would self-kill).
- **Active turns keep writing** (T2-D resume-bug safety).
- `on_disconnect` anchors to the **first** unrecovered disconnect (the `is None` guard is load-bearing — it fires every backoff iteration).

### Scope honesty (per adversarial critique)
Catches a reconnect-**storm** wedge where `on_disconnect` fired, **not** a silent `poll_event` hang; and a dead-gateway + stuck active-turn defers restart until `_active_turns` returns to 0.

### Tests
New `test_heartbeat_gateway_gate.py` drives `_heartbeat_task.coro` across the matrix (frozen past budget / writes within budget / writes with active turn / writes pre-login / env override); `test_error_footer_and_gateway.py` pins the `_gw_down_since` wiring. Nothing touches the real heartbeat file or launchctl; live bot PID unchanged.