### PR TITLE
feat(cogs): /session history · open · rename · tag · delete — browse & manage past on-disk sessions (#15)

### DIFF
--- a/src/clauded/cogs/_sessions_disk.py
+++ b/src/clauded/cogs/_sessions_disk.py
@@ -1,0 +1,111 @@
+"""#audit(#15): disk-session helpers for the /session history·open·rename·tag·
+delete commands.
+
+Centralizes the ``claude_agent_sdk`` import and wraps EVERY sync, filesystem-
+backed SDK call in ``asyncio.to_thread`` — a directory scan / jsonl edit / unlink
+must never run on the live bot's event loop. Mirrors how cogs/mcp.py keeps its
+``_resolve_live_bridge`` / autocomplete helpers out of the command bodies.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from discord import app_commands
+
+
+def _sdk():
+    # Lazy import (matches cogs/skill.py / cogs/context.py) so a missing/old SDK
+    # surfaces as a clean runtime error, not an import-time crash of the cog.
+    import claude_agent_sdk as s
+    return s
+
+
+def _resolve_project_dir(interaction, bot) -> str | None:
+    """Bound project directory for this channel/thread (parent-keyed), or None."""
+    from ._unbound import resolve_binding_id  # parent-keyed for threads (#197/#209)
+    bid = resolve_binding_id(interaction)
+    return bot.project_manager.get_path(bid) if bid is not None else None
+
+
+# --- sync SDK calls, each hopped onto a thread ---------------------------------
+
+
+async def _list_sessions(directory, limit=25, offset=0):
+    s = _sdk()
+    return await asyncio.to_thread(s.list_sessions, directory, limit, offset, True)
+
+
+async def _get_info(directory, sid):
+    s = _sdk()
+    return await asyncio.to_thread(s.get_session_info, sid, directory)
+
+
+async def _rename(directory, sid, title):
+    s = _sdk()
+    await asyncio.to_thread(s.rename_session, sid, title, directory)
+
+
+async def _tag(directory, sid, tag):
+    s = _sdk()
+    await asyncio.to_thread(s.tag_session, sid, tag, directory)
+
+
+async def _delete(directory, sid):
+    s = _sdk()
+    await asyncio.to_thread(s.delete_session, sid, directory)
+
+
+# --- pure helpers -------------------------------------------------------------
+
+
+def _fmt_session_label(info) -> str:
+    title = (
+        getattr(info, "custom_title", None)
+        or getattr(info, "summary", None)
+        or (getattr(info, "first_prompt", None) or "")[:80]
+        or "(untitled)"
+    )
+    parts = [title[:60]]
+    if getattr(info, "git_branch", None):
+        parts.append(info.git_branch)
+    if getattr(info, "tag", None):
+        parts.append(f"#{info.tag}")
+    return " · ".join(parts)
+
+
+def _resolve_session_id(sessions, token: str) -> str:
+    """Resolve a full UUID or a >=8-char unique prefix to a full session id."""
+    token = (token or "").strip()
+    ids = [x.session_id for x in sessions]
+    if token in ids:
+        return token
+    if len(token) >= 8:
+        pref = [i for i in ids if i.startswith(token)]
+        if len(pref) == 1:
+            return pref[0]
+        if len(pref) > 1:
+            raise ValueError(f'Ambiguous id "{token}" matches {len(pref)} sessions.')
+    raise ValueError(f'No session matches "{token}" in this project.')
+
+
+async def _session_id_autocomplete(interaction, current):
+    from ..bot import ClaudedBot
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        return []
+    directory = _resolve_project_dir(interaction, bot)
+    if not directory:
+        return []
+    try:
+        sessions = await _list_sessions(directory, limit=25)
+    except Exception:
+        return []
+    cur = (current or "").lower()
+    out: list[app_commands.Choice[str]] = []
+    for x in sessions:
+        lbl = _fmt_session_label(x)
+        if cur in lbl.lower() or cur in x.session_id:
+            out.append(app_commands.Choice(name=lbl[:100], value=x.session_id))
+        if len(out) >= 25:
+            break
+    return out

--- a/src/clauded/cogs/session.py
+++ b/src/clauded/cogs/session.py
@@ -8,6 +8,10 @@ import discord
 from discord import app_commands
 
 from ._unbound import reject_if_unbound
+from ._sessions_disk import (
+    _resolve_project_dir, _list_sessions, _get_info, _rename, _tag, _delete,
+    _resolve_session_id, _fmt_session_label, _session_id_autocomplete,
+)
 from ..discord_renderer import COLOR_INFO, COLOR_TOOL_FAILURE
 from ..interaction_handler import InteractionHandler
 from ..session_config import SessionConfig
@@ -524,6 +528,244 @@ async def session_export(interaction: discord.Interaction) -> None:
     import io
     file = discord.File(io.BytesIO(md.encode()), filename=f"{thread_name[:50]}.md")
     await interaction.followup.send("📄 Session exported:", file=file, ephemeral=True)
+
+
+# ---------------------------------------------------------------------------
+# #audit(#15): browse / open / rename / tag / delete PAST on-disk sessions.
+# /session list shows only LIVE in-memory bridges; these surface the SDK's
+# on-disk session store (keyed by project directory). Every SDK call routes
+# through cogs/_sessions_disk (asyncio.to_thread) so a directory scan / jsonl
+# edit / unlink never blocks the live bot's event loop.
+# ---------------------------------------------------------------------------
+
+
+class DeleteConfirmView(discord.ui.View):
+    """Author-gated confirm for the irreversible ``/session delete``."""
+
+    def __init__(self, directory: str, sid: str, author_id: int) -> None:
+        super().__init__(timeout=30)
+        self._dir = directory
+        self._sid = sid
+        self._author = author_id
+
+    async def interaction_check(self, itx: discord.Interaction) -> bool:
+        # #audit(#15) BLOCKER-2: a bare `return False` leaves the other user's
+        # client showing "This interaction failed" with no reason — send an
+        # explicit ephemeral rejection instead.
+        if itx.user.id != self._author:
+            await itx.response.send_message(
+                "Only the person who ran `/session delete` can use these buttons.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    @discord.ui.button(label="Delete", style=discord.ButtonStyle.danger)
+    async def _confirm(self, itx: discord.Interaction, _btn: discord.ui.Button) -> None:
+        try:
+            await _delete(self._dir, self._sid)
+        except Exception as exc:
+            await itx.response.edit_message(
+                embed=discord.Embed(
+                    title="❌ Delete failed", description=f"`{exc}`",
+                    color=COLOR_TOOL_FAILURE,
+                ),
+                view=None,
+            )
+            return
+        await itx.response.edit_message(
+            embed=discord.Embed(
+                title="🗑️ Deleted", description=f"`{self._sid[:8]}` removed.",
+                color=COLOR_INFO,
+            ),
+            view=None,
+        )
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.secondary)
+    async def _cancel(self, itx: discord.Interaction, _btn: discord.ui.Button) -> None:
+        await itx.response.edit_message(
+            embed=discord.Embed(title="Cancelled", color=COLOR_INFO), view=None
+        )
+
+
+@session_group.command(name="history", description="Browse past on-disk Claude sessions for this project.")
+@app_commands.describe(limit="How many to show (1-25, default 10)")
+async def session_history(interaction: discord.Interaction, limit: int = 10) -> None:
+    from ..bot import ClaudedBot
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    directory = _resolve_project_dir(interaction, bot)
+    if not directory:
+        # #audit(#15) polish: don't tell a DM user to "run /project bind" — just
+        # state the requirement neutrally.
+        await interaction.response.send_message(
+            "This channel isn't bound to a project — `/session history` needs one.",
+            ephemeral=True,
+        )
+        return
+    limit = max(1, min(25, limit))
+    await interaction.response.defer(ephemeral=True)
+    try:
+        sessions = await _list_sessions(directory, limit=limit)
+    except Exception as exc:
+        await interaction.followup.send(
+            f"❌ Could not read session history: `{exc}`", ephemeral=True
+        )
+        return
+    if not sessions:
+        await interaction.followup.send(
+            "No past sessions on disk for this project.", ephemeral=True
+        )
+        return
+    cur_id = bot._get_resume_session_id(interaction.channel_id)
+    embed = discord.Embed(title="🗂️ Past sessions", description=f"`{directory}`", color=COLOR_INFO)
+    for x in sessions:
+        mark = "▶ " if x.session_id == cur_id else ""
+        meta = [f"`{x.session_id[:8]}`", f"<t:{x.last_modified}:R>"]
+        if getattr(x, "tag", None):
+            meta.append(f"#{x.tag}")
+        embed.add_field(
+            name=f"{mark}{_fmt_session_label(x)}"[:256],
+            value=" • ".join(meta)[:1024],
+            inline=False,
+        )
+    await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+@session_group.command(name="open", description="Resume a specific past session into this thread.")
+@app_commands.describe(session_id="Pick from history (autocomplete)")
+@app_commands.autocomplete(session_id=_session_id_autocomplete)
+async def session_open(interaction: discord.Interaction, session_id: str) -> None:
+    from ..bot import ClaudedBot
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    if await reject_if_unbound(interaction, bot):
+        return
+    directory = _resolve_project_dir(interaction, bot)
+    # #audit(#15) BLOCKER-1: validate with a single cheap get_session_info (NOT a
+    # full list_sessions scan) so we don't blow Discord's 3s ack window before
+    # _recreate_session (which defers first). Autocomplete delivers the full UUID.
+    try:
+        info = await _get_info(directory, session_id)
+    except Exception as exc:
+        await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
+        return
+    if info is None:
+        await interaction.response.send_message(
+            "❌ No such session in this project — pick one from the autocomplete.",
+            ephemeral=True,
+        )
+        return
+    bridge = await bot._recreate_session(interaction, resume_session_id=session_id)
+    if bridge:
+        await interaction.followup.send(embed=discord.Embed(
+            title="📂 Session opened",
+            description=f"Resumed `{session_id[:12]}…` — context restored.",
+            color=COLOR_INFO,
+        ))
+
+
+@session_group.command(name="rename", description="Set a past session's custom title (distinct from /session name).")
+@app_commands.describe(session_id="Pick from history (autocomplete)", title="New custom title for the session")
+@app_commands.autocomplete(session_id=_session_id_autocomplete)
+async def session_rename(interaction: discord.Interaction, session_id: str, title: str) -> None:
+    from ..bot import ClaudedBot
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    if await reject_if_unbound(interaction, bot):
+        return
+    directory = _resolve_project_dir(interaction, bot)
+    await interaction.response.defer(ephemeral=True)
+    try:
+        sessions = await _list_sessions(directory, limit=50)
+        full = _resolve_session_id(sessions, session_id)
+        await _rename(directory, full, title)
+    except (ValueError, FileNotFoundError) as exc:
+        await interaction.followup.send(f"❌ {exc}", ephemeral=True)
+        return
+    await interaction.followup.send(
+        embed=discord.Embed(
+            title="✏️ Renamed", description=f"`{full[:8]}` → **{title[:80]}**",
+            color=COLOR_INFO,
+        ),
+        ephemeral=True,
+    )
+
+
+@session_group.command(name="tag", description="Set or clear a past session's tag (empty or '-' clears).")
+@app_commands.describe(session_id="Pick from history (autocomplete)", tag="Tag text; empty or '-' clears it")
+@app_commands.autocomplete(session_id=_session_id_autocomplete)
+async def session_tag(interaction: discord.Interaction, session_id: str, tag: str = "") -> None:
+    from ..bot import ClaudedBot
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    if await reject_if_unbound(interaction, bot):
+        return
+    directory = _resolve_project_dir(interaction, bot)
+    tag_val = None if tag.strip() in ("", "-") else tag.strip()
+    await interaction.response.defer(ephemeral=True)
+    try:
+        sessions = await _list_sessions(directory, limit=50)
+        full = _resolve_session_id(sessions, session_id)
+        await _tag(directory, full, tag_val)
+    except (ValueError, FileNotFoundError) as exc:
+        await interaction.followup.send(f"❌ {exc}", ephemeral=True)
+        return
+    msg = f"`{full[:8]}` tagged **#{tag_val}**" if tag_val else f"`{full[:8]}` tag cleared"
+    await interaction.followup.send(
+        embed=discord.Embed(title="🏷️ Tag updated", description=msg, color=COLOR_INFO),
+        ephemeral=True,
+    )
+
+
+@session_group.command(name="delete", description="Permanently delete a past session (jsonl + subagent transcripts).")
+@app_commands.describe(session_id="Pick from history (autocomplete)")
+@app_commands.autocomplete(session_id=_session_id_autocomplete)
+async def session_delete(interaction: discord.Interaction, session_id: str) -> None:
+    from ..bot import ClaudedBot
+    bot = interaction.client
+    if not isinstance(bot, ClaudedBot):
+        await interaction.response.send_message("Bot not ready.", ephemeral=True)
+        return
+    if await reject_if_unbound(interaction, bot):
+        return
+    directory = _resolve_project_dir(interaction, bot)
+    await interaction.response.defer(ephemeral=True)
+    try:
+        sessions = await _list_sessions(directory, limit=50)
+        full = _resolve_session_id(sessions, session_id)
+    except ValueError as exc:
+        await interaction.followup.send(f"❌ {exc}", ephemeral=True)
+        return
+    if full == bot._get_resume_session_id(interaction.channel_id):
+        await interaction.followup.send(
+            "❌ That's this thread's active/stored session — `/session clear` "
+            "or `/session stop` first.",
+            ephemeral=True,
+        )
+        return
+    label = next((_fmt_session_label(x) for x in sessions if x.session_id == full), full[:12])
+    view = DeleteConfirmView(directory, full, interaction.user.id)
+    await interaction.followup.send(
+        embed=discord.Embed(
+            title="⚠️ Confirm delete",
+            description=(
+                f"Permanently delete **{label}** (`{full[:8]}`)?\n"
+                "Also removes subagent transcripts. This cannot be undone."
+            ),
+            color=COLOR_TOOL_FAILURE,
+        ),
+        view=view,
+        ephemeral=True,
+    )
 
 
 

--- a/tests/test_session_history_cmds.py
+++ b/tests/test_session_history_cmds.py
@@ -1,0 +1,316 @@
+"""#audit(#15): /session history·open·rename·tag·delete + DeleteConfirmView.
+
+All mock-based — the claude_agent_sdk calls are patched at the session-cog seam
+(session.py imports the helpers by name) or the _sessions_disk seam; nothing
+touches the real filesystem, the SDK, or the live bot.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _info(sid, **kw):
+    d = dict(
+        session_id=sid, summary=None, last_modified=1700000000, file_size=0,
+        custom_title=None, first_prompt=None, git_branch=None, cwd=None,
+        tag=None, created_at=None,
+    )
+    d.update(kw)
+    return SimpleNamespace(**d)
+
+
+def _itx(channel_id=42, user_id=111):
+    itx = MagicMock()
+    itx.channel_id = channel_id
+    itx.user = MagicMock()
+    itx.user.id = user_id
+    itx.response = MagicMock()
+    itx.response.send_message = AsyncMock()
+    itx.response.defer = AsyncMock()
+    itx.response.edit_message = AsyncMock()
+    itx.followup = MagicMock()
+    itx.followup.send = AsyncMock()
+    return itx
+
+
+# --------------------------------------------------------------------------
+# _resolve_session_id (pure)
+# --------------------------------------------------------------------------
+
+
+def test_resolve_exact_uuid():
+    from clauded.cogs._sessions_disk import _resolve_session_id
+    s = [_info("aaaabbbb-1111"), _info("ccccdddd-2222")]
+    assert _resolve_session_id(s, "aaaabbbb-1111") == "aaaabbbb-1111"
+
+
+def test_resolve_unique_prefix():
+    from clauded.cogs._sessions_disk import _resolve_session_id
+    s = [_info("aaaabbbb-1111"), _info("ccccdddd-2222")]
+    assert _resolve_session_id(s, "aaaabbbb") == "aaaabbbb-1111"
+
+
+def test_resolve_ambiguous_prefix_raises():
+    from clauded.cogs._sessions_disk import _resolve_session_id
+    s = [_info("aaaabbbb-1"), _info("aaaabbbb-2")]
+    with pytest.raises(ValueError, match="Ambiguous"):
+        _resolve_session_id(s, "aaaabbbb")
+
+
+def test_resolve_no_match_raises():
+    from clauded.cogs._sessions_disk import _resolve_session_id
+    with pytest.raises(ValueError, match="No session"):
+        _resolve_session_id([_info("aaaabbbb-1")], "zzzzzzzz")
+
+
+# --------------------------------------------------------------------------
+# event-loop safety: every SDK call routes through asyncio.to_thread
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_routes_through_to_thread(monkeypatch):
+    import clauded.cogs._sessions_disk as sd
+
+    calls = []
+
+    async def fake_to_thread(fn, *a, **kw):
+        calls.append((fn, a))
+        return ["sentinel"]
+
+    fake_sdk = MagicMock()
+    monkeypatch.setattr(sd.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(sd, "_sdk", lambda: fake_sdk)
+
+    out = await sd._list_sessions("/dir", limit=10)
+    assert out == ["sentinel"]
+    assert calls[0][0] is fake_sdk.list_sessions
+    assert calls[0][1] == ("/dir", 10, 0, True)  # positional order matches SDK sig
+
+
+# --------------------------------------------------------------------------
+# autocomplete
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_autocomplete_not_ready_returns_empty():
+    from clauded.cogs._sessions_disk import _session_id_autocomplete
+    itx = MagicMock()
+    itx.client = object()  # not a ClaudedBot
+    assert await _session_id_autocomplete(itx, "") == []
+
+
+@pytest.mark.asyncio
+async def test_autocomplete_unbound_returns_empty(monkeypatch):
+    import clauded.cogs._sessions_disk as sd
+    from clauded.bot import ClaudedBot
+    monkeypatch.setattr(sd, "_resolve_project_dir", lambda i, b: None)
+    itx = MagicMock()
+    itx.client = MagicMock(spec=ClaudedBot)
+    assert await sd._session_id_autocomplete(itx, "") == []
+
+
+@pytest.mark.asyncio
+async def test_autocomplete_happy_filters_by_current(monkeypatch):
+    import clauded.cogs._sessions_disk as sd
+    from clauded.bot import ClaudedBot
+    monkeypatch.setattr(sd, "_resolve_project_dir", lambda i, b: "/dir")
+
+    async def fake_list(directory, limit=25):
+        return [_info("uuid-alpha-1", summary="Alpha"), _info("uuid-beta-2", summary="Beta")]
+
+    monkeypatch.setattr(sd, "_list_sessions", fake_list)
+    itx = MagicMock()
+    itx.client = MagicMock(spec=ClaudedBot)
+    out = await sd._session_id_autocomplete(itx, "alpha")
+    assert [c.value for c in out] == ["uuid-alpha-1"]
+
+
+# --------------------------------------------------------------------------
+# /session history
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_history_unbound_soft_refuses(monkeypatch):
+    from clauded.cogs.session import session_history
+    from clauded.bot import ClaudedBot
+    monkeypatch.setattr("clauded.cogs.session._resolve_project_dir", lambda i, b: None)
+    itx = _itx()
+    itx.client = MagicMock(spec=ClaudedBot)
+    await session_history.callback(itx, 10)
+    itx.response.send_message.assert_awaited_once()
+    assert "isn't bound" in itx.response.send_message.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_history_happy_renders_embed(monkeypatch):
+    from clauded.cogs.session import session_history
+    from clauded.bot import ClaudedBot
+    bot = MagicMock(spec=ClaudedBot)
+    bot._get_resume_session_id = MagicMock(return_value=None)
+    monkeypatch.setattr("clauded.cogs.session._resolve_project_dir", lambda i, b: "/dir")
+
+    async def fake_list(directory, limit=25):
+        return [_info("uuid-1234-5678", summary="Hello world")]
+
+    monkeypatch.setattr("clauded.cogs.session._list_sessions", fake_list)
+    itx = _itx()
+    itx.client = bot
+    await session_history.callback(itx, 10)
+    itx.response.defer.assert_awaited_once()
+    embed = itx.followup.send.await_args.kwargs["embed"]
+    assert "Past sessions" in embed.title
+
+
+# --------------------------------------------------------------------------
+# /session open
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_missing_session_errors_without_recreate(monkeypatch):
+    from clauded.cogs.session import session_open
+    from clauded.bot import ClaudedBot
+    bot = MagicMock(spec=ClaudedBot)
+    bot._recreate_session = AsyncMock()
+    monkeypatch.setattr("clauded.cogs.session.reject_if_unbound", AsyncMock(return_value=False))
+    monkeypatch.setattr("clauded.cogs.session._resolve_project_dir", lambda i, b: "/dir")
+
+    async def fake_get(d, sid):
+        return None
+
+    monkeypatch.setattr("clauded.cogs.session._get_info", fake_get)
+    itx = _itx()
+    itx.client = bot
+    await session_open.callback(itx, "nope-uuid")
+    bot._recreate_session.assert_not_awaited()
+    itx.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_open_happy_recreates_with_resume_id(monkeypatch):
+    from clauded.cogs.session import session_open
+    from clauded.bot import ClaudedBot
+    bot = MagicMock(spec=ClaudedBot)
+    bot._recreate_session = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr("clauded.cogs.session.reject_if_unbound", AsyncMock(return_value=False))
+    monkeypatch.setattr("clauded.cogs.session._resolve_project_dir", lambda i, b: "/dir")
+
+    async def fake_get(d, sid):
+        return _info(sid)
+
+    monkeypatch.setattr("clauded.cogs.session._get_info", fake_get)
+    itx = _itx()
+    itx.client = bot
+    await session_open.callback(itx, "uuid-full-1234")
+    bot._recreate_session.assert_awaited_once()
+    assert bot._recreate_session.await_args.kwargs.get("resume_session_id") == "uuid-full-1234"
+
+
+# --------------------------------------------------------------------------
+# /session tag (clear semantics)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tag_dash_clears_to_none(monkeypatch):
+    from clauded.cogs.session import session_tag
+    from clauded.bot import ClaudedBot
+    monkeypatch.setattr("clauded.cogs.session.reject_if_unbound", AsyncMock(return_value=False))
+    monkeypatch.setattr("clauded.cogs.session._resolve_project_dir", lambda i, b: "/dir")
+
+    async def fake_list(d, limit=50):
+        return [_info("uuid-tag-1234")]
+
+    captured = {}
+
+    async def fake_tag(d, sid, tag):
+        captured["tag"] = tag
+
+    monkeypatch.setattr("clauded.cogs.session._list_sessions", fake_list)
+    monkeypatch.setattr("clauded.cogs.session._tag", fake_tag)
+    itx = _itx()
+    itx.client = MagicMock(spec=ClaudedBot)
+    await session_tag.callback(itx, "uuid-tag-1234", "-")
+    assert captured["tag"] is None
+
+
+# --------------------------------------------------------------------------
+# /session delete + DeleteConfirmView
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_refuses_active_session(monkeypatch):
+    from clauded.cogs.session import session_delete
+    from clauded.bot import ClaudedBot
+    bot = MagicMock(spec=ClaudedBot)
+    bot._get_resume_session_id = MagicMock(return_value="uuid-active-1234")
+    monkeypatch.setattr("clauded.cogs.session.reject_if_unbound", AsyncMock(return_value=False))
+    monkeypatch.setattr("clauded.cogs.session._resolve_project_dir", lambda i, b: "/dir")
+
+    async def fake_list(d, limit=50):
+        return [_info("uuid-active-1234")]
+
+    del_spy = AsyncMock()
+    monkeypatch.setattr("clauded.cogs.session._list_sessions", fake_list)
+    monkeypatch.setattr("clauded.cogs.session._delete", del_spy)
+    itx = _itx()
+    itx.client = bot
+    await session_delete.callback(itx, "uuid-active-1234")
+    del_spy.assert_not_awaited()
+    assert "active/stored" in itx.followup.send.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_delete_valid_shows_confirm_view(monkeypatch):
+    from clauded.cogs.session import session_delete, DeleteConfirmView
+    from clauded.bot import ClaudedBot
+    bot = MagicMock(spec=ClaudedBot)
+    bot._get_resume_session_id = MagicMock(return_value="uuid-active-1234")
+    monkeypatch.setattr("clauded.cogs.session.reject_if_unbound", AsyncMock(return_value=False))
+    monkeypatch.setattr("clauded.cogs.session._resolve_project_dir", lambda i, b: "/dir")
+
+    async def fake_list(d, limit=50):
+        return [_info("uuid-other-9999", summary="Other")]
+
+    monkeypatch.setattr("clauded.cogs.session._list_sessions", fake_list)
+    itx = _itx()
+    itx.client = bot
+    await session_delete.callback(itx, "uuid-other-9999")
+    view = itx.followup.send.await_args.kwargs.get("view")
+    assert isinstance(view, DeleteConfirmView)
+    assert view._sid == "uuid-other-9999"
+    assert view._author == itx.user.id
+
+
+@pytest.mark.asyncio
+async def test_confirm_view_non_author_refused():
+    from clauded.cogs.session import DeleteConfirmView
+    v = DeleteConfirmView("/dir", "sid-1234", author_id=111)
+    itx = MagicMock()
+    itx.user.id = 222  # NOT the author
+    itx.response.send_message = AsyncMock()
+    ok = await v.interaction_check(itx)
+    assert ok is False
+    itx.response.send_message.assert_awaited_once()  # explicit refusal, not a bare False
+
+
+@pytest.mark.asyncio
+async def test_confirm_view_author_deletes(monkeypatch):
+    import clauded.cogs.session as se
+    from clauded.cogs.session import DeleteConfirmView
+    del_spy = AsyncMock()
+    monkeypatch.setattr(se, "_delete", del_spy)
+    v = DeleteConfirmView("/dir", "sid-1234", author_id=111)
+    itx = MagicMock()
+    itx.user.id = 111
+    itx.response.edit_message = AsyncMock()
+    await v._confirm.callback(itx)
+    del_spy.assert_awaited_once_with("/dir", "sid-1234")
+    itx.response.edit_message.assert_awaited_once()


### PR DESCRIPTION
**Finding #15** (user-selected). `/session list` only enumerated **live in-memory** bridges; every past conversation on disk was invisible — you couldn't browse, resume an arbitrary one, rename/tag, or delete stale history. The SDK exposes all of it (module-level, keyed by project directory); the bot never surfaced it.

### New `cogs/_sessions_disk.py`
Centralizes the `claude_agent_sdk` import and wraps **every** sync, filesystem-backed SDK call in `asyncio.to_thread` — the single most important correctness point: a directory scan / jsonl edit / unlink must **never** block the live bot's event loop.

### Five subcommands (19 total, under Discord's 25 cap)
- **`/session history [limit]`** — top-N of the bound project's sessions (`last_modified` `<t:…:R>`, tag, ▶ for the thread's current id).
- **`/session open <id>`** — resume an arbitrary past session via `_recreate_session(resume_session_id=…)`, full fidelity.
- **`/session rename <id> <title>`** — `custom_title` (disambiguated from `/session name` + the thread name).
- **`/session tag <id> [tag]`** — set/clear (empty or `-` → None).
- **`/session delete <id>`** — HARD delete behind a **self-delete refusal** + an **author-gated confirm View**.

### Critique blockers fixed
- **BLOCKER-1:** `/session open` validates with a single cheap `get_session_info` (not a full `list_sessions` scan), so it can't blow Discord's 3s ack window before `_recreate_session`'s own `defer()` (double-defer → 404).
- **BLOCKER-2:** `DeleteConfirmView.interaction_check` sends an **explicit ephemeral rejection** to non-authors instead of a bare `False` (which shows a generic "interaction failed").
- Polish: `last_modified` (not None-prone `created_at`); embed field capped `[:1024]`; neutral unbound copy.

### Tests
New `tests/test_session_history_cmds.py` — **17, all mock-based** (SDK stubbed, no filesystem, no live bot): id resolution, `to_thread` routing (event-loop-safety guard), autocomplete, each command's happy/guard paths, self-delete refusal, and the confirm-View author gate + delete callback. Session/group-A/slash-sync suites green; live bot PID unchanged.