### PR TITLE
fix(renderer): stop background-subagent content leaking into the main conversation

### DIFF
--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -1630,6 +1630,25 @@ class DiscordRenderer:
                 if await self._dispatch_task_event(event, subagent_renderers):
                     continue
 
+                # #audit(subagent-leak): a subagent-attributed event
+                # (parent_tool_use_id set) that reaches HERE has NO registered
+                # sub-thread — the `ptid in subagent_renderers` branch above
+                # already `continue`d the ones that do. Background/parallel
+                # subagents dispatched via the Task* control-plane never emit a
+                # Task/Agent ToolUseBlock in the parent stream, so their
+                # sub-thread is never created and their raw step chatter
+                # (AssistantMessage / StreamEvent) would otherwise fall through
+                # to the MAIN rendering below — the observed leak (61 content
+                # events in one turn, per stream-debug). Drop it from MAIN; the
+                # compact Task* status embeds + terminal summary still render.
+                if ptid:
+                    log.debug(
+                        "subagent-leak guard: dropped %s (parent_tool_use_id=%s) "
+                        "with no sub-thread from the main channel",
+                        type(event).__name__, ptid,
+                    )
+                    continue
+
                 if isinstance(event, ResultMessage):
                     # Capture stats from the result.
                     # #v1.18-footer: ``total_cost_usd`` on ResultMessage is

--- a/tests/test_subagent_leak_guard.py
+++ b/tests/test_subagent_leak_guard.py
@@ -1,0 +1,74 @@
+"""#audit(subagent-leak): subagent-attributed content (parent_tool_use_id set)
+that has no registered sub-thread must be dropped from the MAIN channel — this
+is how background/parallel subagents (dispatched via the Task* control-plane,
+which never emits a Task/Agent ToolUseBlock in the parent stream) leaked their
+raw step chatter into the main conversation. Main-agent content (ptid=None)
+must still render.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import FakeBridge, FakeTarget
+
+
+def _all_text(target) -> str:
+    parts = []
+    for m in target._sent:
+        if getattr(m, "content", None):
+            parts.append(m.content)
+        for e in getattr(m, "embeds", None) or []:
+            parts.append(str(getattr(e, "title", "") or ""))
+            parts.append(str(getattr(e, "description", "") or ""))
+    return " ".join(parts)
+
+
+def _result():
+    from claude_agent_sdk.types import ResultMessage
+    return ResultMessage(
+        subtype="result", duration_ms=1, duration_api_ms=1, is_error=False,
+        num_turns=1, session_id="s", total_cost_usd=0.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_subagent_content_without_thread_dropped_from_main():
+    from claude_agent_sdk.types import AssistantMessage, TextBlock, ToolUseBlock
+    from clauded.discord_renderer import DiscordRenderer
+
+    events = [
+        # Background subagent content: parent_tool_use_id set, but NO preceding
+        # Task/Agent ToolUseBlock ever created a sub-thread for it.
+        AssistantMessage(
+            content=[TextBlock(text="SECRET_SUBAGENT_STEP_should_not_leak")],
+            model="m", parent_tool_use_id="toolu-bg-agent-1",
+        ),
+        AssistantMessage(
+            content=[ToolUseBlock(id="x1", name="Bash", input={"command": "cat /secret"})],
+            model="m", parent_tool_use_id="toolu-bg-agent-1",
+        ),
+        _result(),
+    ]
+    target = FakeTarget()
+    await DiscordRenderer(target).render_response(FakeBridge(events), "hi")
+    text = _all_text(target)
+    assert "SECRET_SUBAGENT_STEP" not in text
+    assert "cat /secret" not in text
+
+
+@pytest.mark.asyncio
+async def test_main_agent_content_still_renders():
+    """Guard must only drop subagent content — main-agent text (ptid=None) stays."""
+    from claude_agent_sdk.types import AssistantMessage, TextBlock
+    from clauded.discord_renderer import DiscordRenderer
+
+    events = [
+        AssistantMessage(
+            content=[TextBlock(text="MAIN_AGENT_VISIBLE_TEXT")],
+            model="m", parent_tool_use_id=None,
+        ),
+        _result(),
+    ]
+    target = FakeTarget()
+    await DiscordRenderer(target).render_response(FakeBridge(events), "hi")
+    assert "MAIN_AGENT_VISIBLE_TEXT" in _all_text(target)

--- a/tests/test_subagent_threads.py
+++ b/tests/test_subagent_threads.py
@@ -935,10 +935,17 @@ class _NotifyBot:
         from clauded.bot import ClaudedBot as _CB
 
         self._pending_subagents: dict[int, dict[str, str]] = {}
+        # #319 T1-B: the real subagent stop callback prunes the live roster via
+        # self._roster_clear (bot.py:1733). Bind it + its backing dict so this
+        # stub matches the production surface (stale-mock fix — the callback
+        # gained _roster_clear after this stub was written).
+        self._agent_roster: dict[int, dict[str, str]] = {}
         self._chan: dict[int, _NotifyChannel] = {}
         self._make_subagent_start_cb = _CB._make_subagent_start_cb.__get__(self)
         self._make_subagent_stop_cb = _CB._make_subagent_stop_cb.__get__(self)
         self._warn_pending_subagents = _CB._warn_pending_subagents.__get__(self)
+        self._roster_note_start = _CB._roster_note_start.__get__(self)
+        self._roster_clear = _CB._roster_clear.__get__(self)
         # _read_subagent_result is a @staticmethod — bind it as a plain
         # callable attribute so ``self._read_subagent_result(...)`` works.
         self._read_subagent_result = _CB._read_subagent_result


### PR DESCRIPTION
**User report, confirmed with live `stream-debug.jsonl` data.** Subagent output was showing up in the Discord **MAIN** conversation instead of a per-subagent sub-thread.

### Root cause (evidence-backed)
The renderer creates a sub-thread + registers `subagent_renderers[tool_id]` **only** when it sees a synchronous `Task`/`Agent` ToolUseBlock in the parent stream (`discord_renderer.py:1910`). But **background / parallel** subagents are dispatched via the SDK **Task\*** control-plane (`task_type=local_agent`) and emit **no such block** in the parent stream — so their sub-thread is never created, `subagent_renderers` stays empty for their `parent_tool_use_id`, and their streamed content (`AssistantMessage`/`StreamEvent` carrying `parent_tool_use_id`) fell through the `ptid in subagent_renderers` guard at `:1446` into **MAIN** rendering.

> One turn showed **61 leaked content events** across 2 background agents that had no matching ToolUseBlock at all — the investigator correlated every subagent `parent_tool_use_id` against every logged `Task`/`Agent` ToolUseBlock.

### Fix (minimal, in the highest-risk render state-machine)
After the Task\* dispatch and the registered-sub-thread branch, if the event still carries a `parent_tool_use_id` it has no home → **drop it from MAIN** (a single `if ptid: continue`) instead of falling through. The compact Task\* status embeds + terminal summary still render; only the raw subagent step chatter is suppressed. Foreground subagents (real sub-thread) `continue` in the branch above and never reach the guard.

Also fixes a **pre-existing stale test mock**: `_NotifyBot` lacked `_roster_note_start`/`_roster_clear` (+ `_agent_roster`) that the real callbacks gained in the #319 roster work — 2 tests were AttributeError-ing on the clean base regardless of this change.

### Tests
New `tests/test_subagent_leak_guard.py` — subagent content (ptid set, no thread) dropped from main; main-agent content (ptid=None) still renders. Full subagent/subtask/workflow render suites now green (**56 tests**). Live bot PID unchanged.

> Chose **suppression** (the "content in main" complaint). If you'd rather **see** background-subagent work, a follow-up can lazily create a sub-thread per `local_agent` in `_handle_task_started` (heavier; risks many threads on large fan-outs).