### PR TITLE
feat(renderer): headline a clear one-line description in the subtask/task panel

### DIFF
--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -240,6 +240,9 @@ class _TaskState:
     last_usage: dict[str, Any] | None = None
     thread_id: int | None = None
     last_tool_name: str | None = None
+    # #panel: the specific agent kind (Explore / general-purpose / …) when the
+    # SDK surfaces it, so progress/terminal panels can say WHICH agent ran.
+    subagent_type: str | None = None
 
 # ---------------------------------------------------------------------------
 # Color scheme for embeds
@@ -888,19 +891,28 @@ class DiscordRenderer:
         task_id = getattr(event, "task_id", None)
         if not task_id:
             return
-        description = (getattr(event, "description", "") or "")[:60] or "Task"
+        data = getattr(event, "data", None) or {}
+        # #panel: the one-line "what is this doing" — draw from the richest
+        # source (the Task* description = the Agent tool's short summary), then
+        # data.description / data.prompt. Keep it a real sentence, not [:60].
+        description = (
+            (getattr(event, "description", "") or "")
+            or data.get("description") or data.get("prompt") or ""
+        ).strip()[:220] or "(no description provided)"
         task_type = getattr(event, "task_type", None)
         tool_use_id = getattr(event, "tool_use_id", None)
+        # #panel: the specific agent kind (Explore / general-purpose / …), so the
+        # card says WHICH agent, not just "task".
+        subagent_type = data.get("subagent_type") or data.get("agent_type")
 
         # #321: label by real task_type instead of always "Dynamic Workflow".
         label = self._task_type_label(task_type)
+        kind = subagent_type or task_type or "task"
         embed = discord.Embed(
-            title=f"{label} Started",
+            title=f"{label} · {kind}",
             description=(
-                "━━━━━━━━━━━━━━━━━━━━━━━\n"
-                f"🔮 Task: {description[:60]}\n"
-                f"🤖 Type: {task_type or 'workflow'}\n"
-                f"📋 ID: `{task_id[:8]}`"
+                f"🔮 **{description}**\n"
+                f"-# 📋 `{task_id[:8]}` · {task_type or 'task'}"
             ),
             color=COLOR_WORKFLOW,
         )
@@ -914,6 +926,7 @@ class DiscordRenderer:
         msg = await target_renderer._safe_send(embed=embed)
         state = _TaskState(
             description=description,
+            subagent_type=subagent_type,
             task_type=task_type,
             tool_use_id=tool_use_id,
             message=msg,
@@ -998,9 +1011,8 @@ class DiscordRenderer:
             except Exception:
                 roster = {}
             lines = [
-                "━━━━━━━━━━━━━━━━━━━━━━━",
-                f"🔮 Task: {state.description[:60]}",
-                f"⏱️ {elapsed}s elapsed",
+                f"🔮 **{state.description[:200]}**",
+                f"-# {state.subagent_type or state.task_type or 'task'} · ⏱️ {elapsed}s elapsed",
             ]
             agent_lines = self._format_roster_lines(roster)
             if agent_lines:
@@ -1191,8 +1203,16 @@ class DiscordRenderer:
             title = f"ℹ️ Task ({status or 'unknown'})"
             color = COLOR_INFO
 
-        embed = discord.Embed(title=title, description=description, color=color)
         state = self._task_states.get(task_id)
+        # #panel: prepend the task's one-line description so the terminal card
+        # says WHAT finished, not only its result summary.
+        _task_desc = getattr(state, "description", None) if state else None
+        if _task_desc and _task_desc != "(no description provided)":
+            description = (
+                f"🔮 **{_task_desc}**\n\n{description}" if description
+                else f"🔮 **{_task_desc}**"
+            )
+        embed = discord.Embed(title=title, description=description, color=color)
         # T1-D: fold total wall-clock duration into the terminal footer so the
         # completed/failed/stopped card summarizes how long the workflow ran,
         # alongside the SDK usage (tokens/tool-uses/SDK-time).

--- a/tests/test_task_panel_description.py
+++ b/tests/test_task_panel_description.py
@@ -1,0 +1,65 @@
+"""#panel: the Task*/subagent panel must headline a clear one-line description
+of what each subagent/task is doing (started + terminal), not a truncated
+"🔮 Task: …" buried under type/id.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tests.conftest import FakeTarget
+
+
+@pytest.mark.asyncio
+async def test_task_started_panel_headlines_description_and_kind():
+    from clauded.discord_renderer import DiscordRenderer
+
+    target = FakeTarget()
+    r = DiscordRenderer(target)
+    event = SimpleNamespace(
+        task_id="tid1234567890",
+        description="Trace the subagent leak precisely",
+        task_type="local_agent",
+        tool_use_id="tu1",
+        data={"subagent_type": "Explore"},
+    )
+    await r._handle_task_started(event, {})
+
+    embed = target._sent[0].embeds[0]
+    blob = f"{embed.title} {embed.description}"
+    assert "Trace the subagent leak precisely" in blob  # description headlined
+    assert "Explore" in blob  # which agent
+
+
+@pytest.mark.asyncio
+async def test_task_started_description_not_truncated_at_60():
+    from clauded.discord_renderer import DiscordRenderer
+
+    long_desc = "Investigate the reconnect storm and correlate it with the DNS failures across every session"
+    target = FakeTarget()
+    r = DiscordRenderer(target)
+    event = SimpleNamespace(
+        task_id="tidX", description=long_desc, task_type="local_agent",
+        tool_use_id="tu", data={},
+    )
+    await r._handle_task_started(event, {})
+    embed = target._sent[0].embeds[0]
+    # The full sentence (>60 chars) survives — old code cut it at [:60].
+    assert long_desc in embed.description
+
+
+@pytest.mark.asyncio
+async def test_task_terminal_prepends_task_description():
+    from clauded.discord_renderer import DiscordRenderer, _TaskState
+
+    target = FakeTarget()
+    r = DiscordRenderer(target)
+    r._task_states["tid1"] = _TaskState(
+        description="Research X thoroughly", subagent_type="general-purpose",
+    )
+    await r._render_terminal_task("tid1", "completed", "Found 3 issues.", None)
+
+    embed = target._sent[-1].embeds[0]
+    assert "Research X thoroughly" in embed.description  # WHAT finished
+    assert "Found 3 issues" in embed.description  # its result


### PR DESCRIPTION
Follow-up to #337. **Hybrid direction** (user pick): keep raw subagent content suppressed from main (#337 already does — it only drops `parent_tool_use_id` chatter, leaving the compact Task\* panels), **but make the panel say WHAT each subagent/task is doing.**

**Before:** `🔮 Task: {description[:60]}` — truncated at 60, buried under `🤖 Type: local_agent` / `📋 ID`. A background agent's card read like "Background Agent Started / local_agent" with no sense of purpose.

**Now** (started / progress / terminal):
- Description is the **bold headline** (`🔮 **…**`), from the richest source (Task\* `description`, then `data.description`/`data.prompt`), **not cut at 60**.
- Title names the **specific agent** (`{label} · {subagent_type}`, e.g. "🤖 Background Agent · Explore") when the SDK surfaces it; persisted on `_TaskState` for progress + terminal.
- Terminal card **prepends the task description** before the result summary.

Presentation-only, defensive `getattr`/`.get` fallbacks (→ "(no description provided)" if the SDK omits it).

Tests: new `tests/test_task_panel_description.py` — headline + agent kind, >60-char survival, terminal prepend. Task/workflow render suites (47) green; live bot PID unchanged.

> If the SDK doesn't populate `description`/`subagent_type` for some task types, those cards show "(no description provided)" — I'll confirm the real fields once the bot restarts on this code and can adjust the source list.