### PR TITLE
fix(bot): defer gateway-wedge restart while background subagents are in flight

### DIFF
--- a/src/clauded/bot.py
+++ b/src/clauded/bot.py
@@ -209,6 +209,27 @@ def _gateway_budget_secs() -> float:
         return 600.0
 
 
+def _gateway_hard_ceiling_secs() -> float:
+    """#audit(#9) fail-safe: the ABSOLUTE cap on how long the wedge-restart may
+    be DEFERRED by in-flight work.
+
+    Past ``_gateway_budget_secs()`` we normally keep writing the heartbeat while
+    a turn OR a background subagent is still running (so a reconnect wedge does
+    not kill work that runs in the CLI child and can still post via REST). But a
+    dropped SubagentStop can orphan the in-flight counter, and a genuinely dead
+    gateway makes the bot useless — so once we've been off-gateway longer than
+    THIS ceiling we freeze regardless of in-flight count. Must be >= budget;
+    default 1800s (= 3x the 600s budget, well past the observed ~384s backoff).
+    Overridable for tuning/tests.
+    """
+    raw = os.environ.get("CLAUDED_GATEWAY_HARD_CEILING_SECS", "1800")
+    try:
+        v = float(raw)
+        return v if v > 0 else 1800.0
+    except ValueError:
+        return 1800.0
+
+
 def _touch_heartbeat() -> None:
     """Refresh ``_HEARTBEAT_PATH`` mtime so the external healthcheck sees us alive.
 
@@ -410,6 +431,16 @@ class ClaudedBot(commands.Bot):
         # warning at all (graceful degradation; still strictly better than
         # the old guaranteed false positive).
         self._pending_subagents: dict[int, dict[str, str]] = {}
+        # #audit(#9): live count of in-flight BACKGROUND subagents across all
+        # threads. Separate from _pending_subagents (a per-thread notification
+        # dict) on purpose: this is a single self-cleaning integer the heartbeat
+        # gate reads so a reconnect-wedge restart is DEFERRED while background
+        # work is running (the CLI child keeps working + can still post via
+        # REST). Kept in lockstep with _pending_subagents inc/dec + the same
+        # reaper / fresh-bridge resets, so a dropped SubagentStop self-heals on
+        # the next idle-reap instead of latching the watchdog off forever. A
+        # hard ceiling (_gateway_hard_ceiling_secs) is the ultimate backstop.
+        self._inflight_bg: int = 0
         # T2-D: number of turns currently rendering. Written into the heartbeat
         # file so the external watchdog grants a longer grace window while a
         # turn is in flight (see _write_heartbeat_state + health-check.sh).
@@ -740,7 +771,12 @@ class ClaudedBot(commands.Bot):
                     # #324 (review fix): the background reader is cancelled inside
                     # bridge.stop() (invoked by stop_session below), so no explicit
                     # cancel is needed here.
-                    self._pending_subagents.pop(tid, None)
+                    # #audit(#9): this is the GC point for orphaned in-flight bg
+                    # entries (dropped SubagentStop) — subtract whatever we reap so
+                    # the heartbeat gate's counter self-heals here.
+                    _reaped = self._pending_subagents.pop(tid, None)
+                    if _reaped:
+                        self._inflight_bg = max(0, self._inflight_bg - len(_reaped))
                     self._agent_roster.pop(tid, None)
                     # #audit(#6): sweep this thread's workflow-task entries from
                     # the long-lived bot registry. They're removed on terminal
@@ -793,29 +829,41 @@ class ClaudedBot(commands.Bot):
             # #audit(#9): FREEZE the heartbeat (return without writing → mtime
             # ages past health-check.sh's STALE_THRESHOLD → watchdog restarts)
             # ONLY when the gateway has been continuously down past the reconnect
-            # budget AND no turn is in flight. Pre-login (_gw_down_since is None)
+            # budget AND nothing is in flight. Pre-login (_gw_down_since is None)
             # and brief blips (within budget) refresh exactly as before, so the
             # pre-login window and healthy RESUMEs are never false-killed.
             # Scope: catches a reconnect-STORM wedge (where on_disconnect fired),
             # NOT a silent poll_event hang (no disconnect → _gw_down_since None).
-            # While a turn is in flight we keep writing (T2-D resume-bug safety),
-            # so a dead-gateway + stuck-turn defers restart until _active_turns
-            # returns to 0 — an accepted trade-off.
+            #
+            # "In flight" = foreground turns (_active_turns) OR background
+            # subagents (_inflight_bg). Both keep writing so a wedge does NOT
+            # kill work that runs in the CLI child and can still post via REST —
+            # the restart would be pure loss (see 2026-07-24 R5 workflow). The
+            # hard ceiling is the backstop: past it we freeze regardless, so a
+            # dropped-SubagentStop orphan or a truly dead gateway can't defer
+            # recovery forever.
             off = self._gw_down_since
             budget = _gateway_budget_secs()
+            # clamp so a mis-set ceiling can never fire before the budget.
+            hard_ceiling = max(_gateway_hard_ceiling_secs(), budget)
+            down_for = (time.time() - off) if off is not None else 0.0
+            inflight = self._active_turns + max(0, self._inflight_bg)
+            past_ceiling = off is not None and down_for > hard_ceiling
             if (
                 off is not None
-                and (time.time() - off) > budget
-                and self._active_turns <= 0
+                and down_for > budget
+                and (inflight <= 0 or past_ceiling)
             ):
                 log.warning(
-                    "gateway down %.0fs > budget %.0fs and no active turn; "
-                    "freezing heartbeat so the watchdog restarts (disc=%d resume=%d)",
-                    time.time() - off, budget,
+                    "gateway down %.0fs > budget %.0fs; freezing heartbeat so the "
+                    "watchdog restarts (inflight=%d turns=%d bg=%d past_ceiling=%s "
+                    "disc=%d resume=%d)",
+                    down_for, budget, inflight, self._active_turns,
+                    self._inflight_bg, past_ceiling,
                     self._gw_disconnects, self._gw_resumes,
                 )
             else:
-                _write_heartbeat_state(self._active_turns)
+                _write_heartbeat_state(inflight)
         except Exception:
             log.exception("heartbeat write failed (loop kept alive)")
 
@@ -1584,7 +1632,11 @@ class ClaudedBot(commands.Bot):
         # orphaned entry (SubagentStart fired, session killed before
         # SubagentStop) would produce a stale "N subagent(s) still running"
         # warning on a later turn's stop.
-        self._pending_subagents.pop(thread_id, None)
+        # #audit(#9): also decrement the in-flight bg counter for these orphans
+        # so a fresh session heals the heartbeat gate's count too.
+        _orphaned = self._pending_subagents.pop(thread_id, None)
+        if _orphaned:
+            self._inflight_bg = max(0, self._inflight_bg - len(_orphaned))
         # #323 (review fix): mirror the reset for _agent_roster. It is otherwise
         # cleared ONLY by the SubagentStop hook, so a single dropped SubagentStop
         # would orphan an entry that makes the idle-reaper's #323 guard veto
@@ -1851,9 +1903,13 @@ class ClaudedBot(commands.Bot):
             agent_type = input_data.get("agent_type")
             if not agent_id:
                 return
-            self._pending_subagents.setdefault(thread_id, {})[agent_id] = (
-                agent_type or "subagent"
-            )
+            bucket = self._pending_subagents.setdefault(thread_id, {})
+            # #audit(#9): count each distinct agent_id once so the heartbeat gate
+            # defers the wedge-restart while this bg work runs. Guard on newness
+            # so a duplicate SubagentStart can't double-count.
+            if agent_id not in bucket:
+                self._inflight_bg += 1
+            bucket[agent_id] = agent_type or "subagent"
             # T1-B: seed the live roster so the workflow embed can show this
             # agent (type + current tool + elapsed) even without workflowProgress.
             self._roster_note_start(thread_id, agent_id, agent_type)
@@ -1887,7 +1943,11 @@ class ClaudedBot(commands.Bot):
             # thread bucket and the id — SubagentStart may not have fired).
             bucket = self._pending_subagents.get(thread_id)
             if bucket is not None:
-                bucket.pop(agent_id, None)
+                # #audit(#9): decrement the in-flight bg counter only when a
+                # tracked entry is actually removed (mirrors the newness guard
+                # in _on_subagent_start).
+                if bucket.pop(agent_id, None) is not None:
+                    self._inflight_bg = max(0, self._inflight_bg - 1)
                 if not bucket:
                     self._pending_subagents.pop(thread_id, None)
             # T1-B: drop from the live roster too.

--- a/tests/test_heartbeat_gateway_gate.py
+++ b/tests/test_heartbeat_gateway_gate.py
@@ -17,10 +17,11 @@ import pytest
 from clauded.bot import ClaudedBot
 
 
-def _self(*, down_since, active_turns):
+def _self(*, down_since, active_turns, inflight_bg=0):
     s = MagicMock()
     s._gw_down_since = down_since
     s._active_turns = active_turns
+    s._inflight_bg = inflight_bg
     s._gw_disconnects = 1
     s._gw_resumes = 0
     return s
@@ -68,3 +69,63 @@ async def test_budget_env_override_respected(monkeypatch):
     with patch("clauded.bot._write_heartbeat_state") as w:
         await ClaudedBot._heartbeat_task.coro(s)
         w.assert_not_called()  # env-lowered budget → frozen
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_writes_past_budget_when_inflight_bg(monkeypatch):
+    """#audit(#9): a background subagent in flight defers the wedge-restart the
+    same way a foreground turn does — keep writing (with content = the count)."""
+    monkeypatch.setenv("CLAUDED_GATEWAY_BUDGET_SECS", "600")
+    s = _self(down_since=time.time() - 601, active_turns=0, inflight_bg=1)
+    with patch("clauded.bot._write_heartbeat_state") as w:
+        await ClaudedBot._heartbeat_task.coro(s)
+        w.assert_called_once_with(1)  # bg work keeps the heartbeat alive
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_content_sums_turns_and_bg(monkeypatch):
+    """Heartbeat content is _active_turns + _inflight_bg so the external
+    watchdog's longer active grace applies to background work too."""
+    monkeypatch.setenv("CLAUDED_GATEWAY_BUDGET_SECS", "600")
+    s = _self(down_since=time.time() - 601, active_turns=1, inflight_bg=2)
+    with patch("clauded.bot._write_heartbeat_state") as w:
+        await ClaudedBot._heartbeat_task.coro(s)
+        w.assert_called_once_with(3)
+
+
+@pytest.mark.asyncio
+async def test_hard_ceiling_freezes_even_with_inflight_bg(monkeypatch):
+    """The fail-safe: past the hard ceiling we freeze regardless of in-flight
+    background work, so a dropped SubagentStop / truly dead gateway can't defer
+    recovery forever."""
+    monkeypatch.setenv("CLAUDED_GATEWAY_BUDGET_SECS", "600")
+    monkeypatch.setenv("CLAUDED_GATEWAY_HARD_CEILING_SECS", "1000")
+    s = _self(down_since=time.time() - 1001, active_turns=0, inflight_bg=1)
+    with patch("clauded.bot._write_heartbeat_state") as w:
+        await ClaudedBot._heartbeat_task.coro(s)
+        w.assert_not_called()  # past ceiling → frozen despite bg work
+
+
+@pytest.mark.asyncio
+async def test_hard_ceiling_env_override_respected(monkeypatch):
+    """Below the (default 1800s) ceiling, in-flight bg still defers; a lowered
+    ceiling brings the fail-safe forward."""
+    monkeypatch.setenv("CLAUDED_GATEWAY_BUDGET_SECS", "600")
+    monkeypatch.setenv("CLAUDED_GATEWAY_HARD_CEILING_SECS", "700")
+    # 650s: past budget (600) but under ceiling (700) → bg work still defers.
+    s = _self(down_since=time.time() - 650, active_turns=0, inflight_bg=1)
+    with patch("clauded.bot._write_heartbeat_state") as w:
+        await ClaudedBot._heartbeat_task.coro(s)
+        w.assert_called_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_hard_ceiling_clamped_to_budget(monkeypatch):
+    """A mis-set ceiling below the budget must NOT fire before the budget — it
+    is clamped up to the budget, so within-budget blips still refresh."""
+    monkeypatch.setenv("CLAUDED_GATEWAY_BUDGET_SECS", "600")
+    monkeypatch.setenv("CLAUDED_GATEWAY_HARD_CEILING_SECS", "60")  # < budget
+    s = _self(down_since=time.time() - 100, active_turns=0, inflight_bg=0)
+    with patch("clauded.bot._write_heartbeat_state") as w:
+        await ClaudedBot._heartbeat_task.coro(s)
+        w.assert_called_once()  # within budget → refresh (ceiling clamp holds)

--- a/tests/test_subagent_threads.py
+++ b/tests/test_subagent_threads.py
@@ -935,6 +935,10 @@ class _NotifyBot:
         from clauded.bot import ClaudedBot as _CB
 
         self._pending_subagents: dict[int, dict[str, str]] = {}
+        # #audit(#9): the start/stop callbacks now keep an in-flight bg counter
+        # in lockstep with _pending_subagents (heartbeat wedge-defer signal), so
+        # the stub must carry it too (same stale-mock class as _roster_clear).
+        self._inflight_bg: int = 0
         # #319 T1-B: the real subagent stop callback prunes the live roster via
         # self._roster_clear (bot.py:1733). Bind it + its backing dict so this
         # stub matches the production surface (stale-mock fix — the callback
@@ -972,10 +976,17 @@ async def test_subagent_routing_survives_first_stop():
     await start({"agent_id": "s1", "agent_type": "general-purpose"})
     await start({"agent_id": "s2", "agent_type": "Explore"})
     assert len(bot._pending_subagents[thread_id]) == 2
+    # #audit(#9): the in-flight bg counter (heartbeat wedge-defer signal) tracks
+    # in lockstep with the pending map.
+    assert bot._inflight_bg == 2
+    # A duplicate start must NOT double-count.
+    await start({"agent_id": "s1", "agent_type": "general-purpose"})
+    assert bot._inflight_bg == 2
 
     await stop({"agent_id": "s1", "agent_type": "general-purpose"})
     # Routing/count for s2 is intact — this is the core of the old bug.
     assert list(bot._pending_subagents[thread_id]) == ["s2"]
+    assert bot._inflight_bg == 1
     # And a warning at this point reports exactly the 1 remaining subagent.
     await bot._warn_pending_subagents(thread_id)
     warn_embeds = [e for e in ch.embeds if "still running" in (e.description or "")]
@@ -986,7 +997,11 @@ async def test_subagent_routing_survives_first_stop():
     n_before = len(ch.embeds)
     await stop({"agent_id": "s2", "agent_type": "Explore"})
     assert bot._pending_subagents.get(thread_id, {}) == {}
+    assert bot._inflight_bg == 0
     assert len(ch.embeds) == n_before + 1  # the s2 completion embed
+    # A stop with no prior start must not drive the counter negative.
+    await stop({"agent_id": "ghost", "agent_type": "x"})
+    assert bot._inflight_bg == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The gateway-connectivity watchdog (`#audit(#9)`) freezes the heartbeat once the gateway has been down past the reconnect budget (600s), so the external `health-check.sh` restarts a reconnect-storm-wedged bot. Its "is anything in flight?" gate only counted `_active_turns` (foreground turns) — background workflow subagents were invisible to it.

So a session whose foreground turn had **ended** but which was still running background subagents looked idle (`_active_turns == 0`), and the last-resort restart **killed that in-flight work**.

### Observed 2026-07-24
An R5 im-redesign workflow (3 parallel reshoot agents on `cloudplayplus_chat`) was killed at **13:33** when the gateway wedged (`gateway-us-east1-c.discord.gg` unreachable, 29 disc / 2 resume). The foreground turn had ended at 12:22 → `_active_turns == 0` → watchdog froze the heartbeat → `launchctl kickstart -k`. The work runs in the **CLI child** (independent of the Discord gateway) and can still post results via **REST** during a gateway wedge, so the restart was pure loss.

## Fix

- Add a self-cleaning `_inflight_bg` counter kept in lockstep with `_pending_subagents`:
  - `+1` on a new `SubagentStart` (guarded so a duplicate can't double-count), `-1` on `SubagentStop` (only when an entry is actually removed).
  - **Mirrored on both resets** (idle-reaper + fresh-bridge) so a dropped `SubagentStop` self-heals on the next idle-reap instead of latching the watchdog off forever.
- The freeze gate now defers while `inflight = _active_turns + _inflight_bg > 0`, and writes that sum to the heartbeat so the external watchdog's longer active-grace (300s) applies to background work too.
- New `CLAUDED_GATEWAY_HARD_CEILING_SECS` (default **1800s**, clamped `>= budget`) is the backstop: past it we freeze regardless of in-flight work, so an orphaned counter or a genuinely dead gateway can **never defer recovery forever**.

**discord.py's own auto-reconnect is unchanged** — this only changes when the last-resort *process restart* is allowed to fire.

## Behaviour

| gateway state | in-flight | before | after |
|---|---|---|---|
| within budget (blip) | any | write | write (unchanged) |
| past budget | nothing | **freeze→restart** | freeze→restart (unchanged) |
| past budget | bg subagents | **freeze→restart (kills work)** | **write→defer, keep reconnecting** |
| past hard ceiling (30min) | bg subagents | — | freeze→restart (fail-safe) |

## Tests

- `test_heartbeat_gateway_gate.py`: +bg-defer, +content-sum(turns+bg), +hard-ceiling freeze / env-override / budget-clamp cases (10 pass).
- `test_subagent_threads.py`: pin `_inflight_bg` lockstep — inc/dec, no-double-count on duplicate start, no-underflow on stop-without-start (21 pass). Stub updated for the new attribute (same stale-mock class as the existing `_roster_clear` note).
- `health-check.sh` unchanged (confirmed: it reads content as an opaque int and already grants 300s for any value > 0).

Validated per-file in isolation vs git-stash base. Two unrelated files (`test_review_subagent_notify.py`, `test_model_stored_readside.py`) have pre-existing failures identical on base — untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)