### PR TITLE
fix(renderer): slow workflow progress-card edit cadence to avoid Discord 429s

### DIFF
--- a/src/clauded/discord_renderer.py
+++ b/src/clauded/discord_renderer.py
@@ -284,6 +284,16 @@ FAST_PATH_SECONDS = 3.0
 # Discord rate-limits edits aggressively; ~1.2s keeps us well under the cap.
 EDIT_INTERVAL_SECONDS = 1.2
 
+# Minimum delay between successive edits of a workflow/task PROGRESS CARD.
+# The card is a status embed, not a typewriter — it doesn't need 1.2s
+# smoothness, and a single card edited continuously through a long multi-agent
+# workflow hits Discord's per-message edit ceiling at 1.2s (2026-07-24: 29x 429
+# on one progress card). A slower cadence stays comfortably under the limit and
+# is imperceptible for a status panel. Env-overridable for tuning.
+TASK_PROGRESS_EDIT_INTERVAL_SECONDS = float(
+    os.environ.get("CLAUDED_TASK_PROGRESS_EDIT_INTERVAL", "4.0")
+)
+
 # Up to 5 retries with 0.5/1/2/4/8s backoff covers ~15s of transient HTTP badness.
 MAX_HTTP_RETRIES = 5
 _BACKOFF = (0.5, 1.0, 2.0, 4.0, 8.0)  # seconds, indexed by attempt
@@ -975,7 +985,7 @@ class DiscordRenderer:
             state.last_tool_name = last_tool
 
         now = time.time()
-        if now - state.last_edit_at < EDIT_INTERVAL_SECONDS:
+        if now - state.last_edit_at < TASK_PROGRESS_EDIT_INTERVAL_SECONDS:
             return
         if state.message is None:
             return
@@ -1031,7 +1041,10 @@ class DiscordRenderer:
 
         ok = await self._safe_edit(state.message, embed=embed)
         if ok:
-            state.last_edit_at = now
+            # Measure the next interval from when this edit actually COMPLETED
+            # (not the pre-edit `now`), so a slow / 429-retried edit can't be
+            # immediately followed by a burst that re-triggers the rate limit.
+            state.last_edit_at = time.time()
 
     def _build_workflow_progress_embed(
         self,

--- a/tests/test_workflow_render.py
+++ b/tests/test_workflow_render.py
@@ -6,6 +6,7 @@ in isolation (no full render_response loop required).
 """
 from __future__ import annotations
 
+import asyncio
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -22,6 +23,7 @@ from clauded.discord_renderer import (
     COLOR_TOOL_SUCCESS,
     COLOR_WORKFLOW,
     EDIT_INTERVAL_SECONDS,
+    TASK_PROGRESS_EDIT_INTERVAL_SECONDS,
     DiscordRenderer,
 )
 
@@ -180,6 +182,59 @@ async def test_task_progress_throttle():
 
     # But last_usage in state SHOULD have been updated (always stored)
     assert renderer._task_states["t1"].last_usage["total_tokens"] == 999
+
+
+def test_task_progress_interval_decoupled_and_larger():
+    """The progress card has its OWN interval, larger than the typewriter's, so
+    lowering the card's edit frequency doesn't make streaming text laggy."""
+    assert TASK_PROGRESS_EDIT_INTERVAL_SECONDS > EDIT_INTERVAL_SECONDS
+    assert TASK_PROGRESS_EDIT_INTERVAL_SECONDS >= 3.0
+
+
+@pytest.mark.asyncio
+async def test_task_progress_gate_reads_card_interval(monkeypatch):
+    """The card throttle uses TASK_PROGRESS_EDIT_INTERVAL_SECONDS (not the 1.2s
+    typewriter constant): lowering it to 0 lets back-to-back events both edit."""
+    import clauded.discord_renderer as dr
+
+    monkeypatch.setattr(dr, "TASK_PROGRESS_EDIT_INTERVAL_SECONDS", 0.0)
+    renderer, target = _make_renderer()
+    await renderer._handle_task_started(_started_event(), subagent_renderers={})
+
+    renderer._task_states["t1"].last_edit_at = 0.0
+    await renderer._handle_task_progress(
+        _progress_event(usage={"total_tokens": 1, "tool_uses": 1, "duration_ms": 1})
+    )
+    desc_after_first = target._sent[0].embeds[0].description
+
+    # Second, immediate — with a 0s interval it must NOT be throttled.
+    await renderer._handle_task_progress(
+        _progress_event(usage={"total_tokens": 777, "tool_uses": 9, "duration_ms": 9})
+    )
+    desc_after_second = target._sent[0].embeds[0].description
+    assert desc_after_first != desc_after_second
+    assert "777" in desc_after_second
+
+
+@pytest.mark.asyncio
+async def test_task_progress_last_edit_at_from_completion(monkeypatch):
+    """last_edit_at is stamped AFTER the edit completes, not from the pre-edit
+    timestamp — so a slow/429-retried edit can't be followed by an immediate
+    burst. Simulated with a _safe_edit that takes measurable wall time."""
+    renderer, target = _make_renderer()
+    await renderer._handle_task_started(_started_event(), subagent_renderers={})
+    state = renderer._task_states["t1"]
+    state.last_edit_at = 0.0
+
+    async def _slow_edit(*_a, **_k):
+        await asyncio.sleep(0.05)
+        return True
+
+    monkeypatch.setattr(renderer, "_safe_edit", _slow_edit)
+    t_before = time.time()
+    await renderer._handle_task_progress(_progress_event())
+    # Stamped from completion: at least the edit's duration after we started.
+    assert state.last_edit_at >= t_before + 0.05
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The task/workflow **progress card** shared the 1.2s typewriter edit interval (`EDIT_INTERVAL_SECONDS`). A single card edited continuously through a long multi-agent workflow sits right at Discord's per-message edit ceiling at 1.2s (~5 edits/6s) and 429s under load.

**Observed 2026-07-24:** 29 consecutive 429s on one R5-workflow progress card (`PATCH .../messages/1530067551344660533`, 13:30–13:33), each backing off ~5s → the card froze on-screen (the surface-level "1:30 卡住" symptom, alongside the gateway wedge fixed in #339).

## Fix (`discord_renderer.py`, 3 spots)

- **Dedicated interval** `TASK_PROGRESS_EDIT_INTERVAL_SECONDS` (env `CLAUDED_TASK_PROGRESS_EDIT_INTERVAL`, default **4.0s**) for the progress card — ~3.3× fewer edits, comfortably under the limit, imperceptible for a status embed. The **1.2s typewriter cadence for streaming text is untouched** (different message, needs the smoothness).
- **Stamp `last_edit_at` after the edit completes** (was the pre-edit timestamp), so a slow / 429-retried edit can't be immediately followed by a burst that re-triggers the rate limit.

| | before | after |
|---|---|---|
| progress card edit interval | 1.2s (shared) | 4.0s (own, env-tunable) |
| interval measured from | pre-edit time | edit completion |
| streaming typewriter | 1.2s | 1.2s (unchanged) |

## Tests (`test_workflow_render.py`)

- card interval is decoupled from + larger than the typewriter's;
- the card gate reads the new (monkeypatchable) constant — lowering it to 0 lets back-to-back events both edit;
- `last_edit_at` is stamped from edit completion (simulated slow `_safe_edit`).

Existing throttle/gate tests unchanged (17 pass in `test_workflow_render.py`, 4 in `test_task_type_gate.py`), validated per-file in isolation.

## Not in scope (future, optional)
- A per-channel global edit pacer (serialize all `.edit()` on a channel — typewriter + card + tool embeds). Bigger change; the single-card slowdown already resolves the observed 429s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)